### PR TITLE
fix(deps): pin uuid to 14.0.0 via resolutions to fix GHSA-w5hq-g745-h8pq

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
   },
   "resolutions": {
     "lodash": "4.18.1",
-    "@typescript-eslint/utils": "^8.58.0"
+    "@typescript-eslint/utils": "^8.58.0",
+    "uuid": "14.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8641,20 +8641,10 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
-uuid@14.0.0:
+uuid@14.0.0, uuid@^8.3.2, uuid@^9.0.1:
   version "14.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
   integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
-
-uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
-
-uuid@^9.0.1:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
-  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 v8-to-istanbul@^9.0.1:
   version "9.3.0"


### PR DESCRIPTION
Transitive dependencies node-notifier and @newrelic/security-agent pulled in uuid <14.0.0, which has a missing buffer bounds check in v3/v5/v6 (moderate). Adding a resolutions entry forces both transitive paths to the patched version.