### PR TITLE
plan(licensee-form-wizard): Licensee form wizard plan

### DIFF
--- a/.plans/README.md
+++ b/.plans/README.md
@@ -24,6 +24,7 @@ Git-native Markdown plans for multi-step work.
 |---|------|--------|--------|-------------|
 | 1 | [JS → TypeScript](./js-to-ts/overview.md) | `js-to-ts/` | not-started | Incremental migration of all source files (backend + client) to TypeScript using `allowJs: true` throughout |
 | 2 | [Remove PDV](./remove-pdv/overview.md) | `remove-pdv/` | not-started | Delete cart, payment (PagarMe), and order integration (Pedidos10) domain — strip PDV fields from Licensee and Contact |
+| 3 | [Licensee Form Wizard](./licensee-form-wizard/overview.md) | `licensee-form-wizard/` | not-started | Split the licensee form into Bootstrap 5 Nav Tabs with panels shown/hidden based on whatsappDefault and chatbotDefault choices |
 
 ---
 

--- a/.plans/licensee-form-wizard/overview.md
+++ b/.plans/licensee-form-wizard/overview.md
@@ -2,7 +2,7 @@
 
 **Status**: not-started
 **Created**: 2026-05-06
-**Last Updated**: 2026-05-06
+**Last Updated**: 2026-05-07
 **Estimated Demo Date**: —
 **Assigned Dev**: Alan Costa Facchini
 **Assigned QA**: unassigned
@@ -10,42 +10,78 @@
 
 ## Objective
 
-Split the large licensee form (~960 lines) into contextual tab panels that show or hide based on the user's chosen messenger and chatbot type, replacing the current single long form with scattered `display:none` visibility logic.
+Split the large licensee form (~960 lines) into contextual tab panels. The main tab collects identity data and 6 yes/no questions ("Integração com X?"). Each question, when checked, reveals a dedicated tab with the relevant configuration fields.
 
 ## Scope
 
 ### In Scope
-- Extract field groups from `Form/index.js` into dedicated panel components (pure presentational)
-- Bootstrap 5 Nav Tab shell in `Form/index.js` with `activeTab` state controlling which tab is active
-- Tab visibility driven by form values (`whatsappDefault`, `chatbotDefault`) — tabs shown/hidden via CSS, panels always mounted so Formik captures all values on submit
-- Update existing Vitest tests to account for the new component structure
+- Extract field groups from `Form/index.js` into panel components under `panels/`
+- **Main tab**: identity fields, read-only tokens/webhook URLs, 6 integration questions
+- **Chat tab** (Q1): chatDefault combo + chat fields; visible when Q1 = true
+- **ChatBot tab** (Q2): chatbotDefault combo + chatbot fields; visible when Q2 (`useChatbot`) = true
+- **WhatsApp tab** (Q3): whatsappDefault combo + WA fields; visible when Q3 = true
+- **Carrinho de Compras tab** (Q4): cartDefault combo + cart fields; visible when Q4 = true
+- **PagarMe tab** (Q5): financial/bank fields + Pagar.Me button; visible when Q5 = true
+- **Pedidos10 tab** (Q6): integrator/data fields + webhook button; visible only when `currentUser.isPedidos10` = true
+- Q1/Q3/Q4/Q5 are local React state in `Form/index.js`, initialized from existing field values; no new model fields
+- Q2 uses the existing `useChatbot` model field
+- Q6 is controlled by `currentUser.isPedidos10` — no extra checkbox in main tab
+- Bootstrap 5 Nav Tabs with always-mounted panes (CSS-driven visibility)
+- Update existing tests
 
 ### Out of Scope
-- Multi-step wizard with Next/Back navigation (tabs are sufficient; wizard UX is a follow-up if requested)
-- Server-side validation changes — no backend changes
-- New form fields — layout refactor only
-- Accessibility audit — out of scope for this iteration
+- AWS fields (`awsId`, `awsSecret`, `bucketName`) — not listed in wizard spec; keep in main tab as-is pending removal by remove-pdv plan
+- New backend model fields — UI state only
+- Multi-step wizard with Next/Back navigation
+- Accessibility audit
 
 ## Kill Criteria
 - If Formik is replaced with another form library before this plan executes
+
+## Tab Layout
+
+| Tab | Visible When | Key Fields |
+|-----|-------------|------------|
+| Principal | Always | name, active, kind, document, email, licenseKind, phone, apiToken (RO), 4 webhook URLs (RO), 6 questions |
+| Chat | Q1 = true | chatDefault, chatUrl, useSenderName, chatIdentifier*, chatKey* |
+| ChatBot | Q2 = true (`useChatbot`) | chatbotDefault, chatbotUrl, chatbotAuthorizationToken, chatbotApiToken, messageOnResetChatbot, messageOnCloseChat |
+| WhatsApp | Q3 = true | whatsappDefault, whatsappToken†, whatsappUrl†, useFileIDYcloud‡, buttons |
+| Carrinho | Q4 = true | cartDefault, useCartGallabox, unidadeId, statusId, productFractionals |
+| PagarMe | Q5 = true | taxa, holder fields, bank fields, Integrar button |
+| Pedidos10 | `currentUser.isPedidos10` | pedidos10_integrator, pedidos10_integration, Assinar webhook button |
+
+\* Only when `chatDefault` is `crisp` or `chatwoot`
+† Hidden when `whatsappDefault === 'baileys'`
+‡ Only when `whatsappDefault === 'ycloud'`
+
+## Question State Strategy
+
+| Question | State | Initialization | Reset on false |
+|----------|-------|----------------|----------------|
+| Q1 useChat | local useState | `initialValues.chatDefault !== ''` | setFieldValue('chatDefault', '') |
+| Q2 useChatbot | Formik field (existing) | from initialValues | setFieldValue('useChatbot', false) |
+| Q3 useWhatsapp | local useState | `initialValues.whatsappDefault !== ''` | setFieldValue('whatsappDefault', '') |
+| Q4 useCart | local useState | `initialValues.cartDefault !== ''` | setFieldValue('cartDefault', '') |
+| Q5 usePagarMe | local useState | `initialValues.holder_name !== '' \|\| initialValues.financial_player_fee !== '0.00'` | no reset (financial data preserved) |
+| Q6 | `currentUser.isPedidos10` | N/A | N/A — not a checkbox |
 
 ## Phases
 
 | Phase | Name | Tasks | Dependencies | Description |
 |-------|------|-------|--------------|-------------|
 | 1 | Extract Panels | task-01, task-02, task-03 | None | Extract field groups into panel components; no behavior change |
-| 2 | Tab Shell | task-04 | Phase 1 | Add Bootstrap Nav Tabs to Form/index.js, wiring panels |
-| 3 | Tests | task-05 | Phase 2 | Update Vitest tests for new structure |
+| 2 | Tab Shell | task-04 | Phase 1 | Add Bootstrap Nav Tabs, questions, tab visibility logic |
+| 3 | Tests | task-05 | Phase 2 | Update existing tests for new structure |
 
 ## Task Summary
 
 | Task Path | Title | Phase | Status | Depends On |
 |-----------|-------|-------|--------|------------|
-| phase-1/task-01-panel-general | GeneralPanel + ChatbotPanel | 1 | not-started | — |
-| phase-1/task-02-panel-comms | ChatPanel + WhatsAppPanel | 1 | not-started | — |
-| phase-1/task-03-panel-infra | AwsPanel + CartPanel + FinancialPanel + OthersPanel | 1 | not-started | — |
+| phase-1/task-01-panel-general | MainPanel | 1 | not-started | — |
+| phase-1/task-02-panel-comms | ChatPanel + ChatbotPanel | 1 | not-started | — |
+| phase-1/task-03-panel-infra | WhatsAppPanel + CartPanel + PagarMePanel + Pedidos10Panel | 1 | not-started | — |
 | phase-2/task-04-tab-shell | Tab Shell in Form/index.js | 2 | not-started | phase-1/* |
-| phase-3/task-05-tests | Vitest — update licensee form tests | 3 | not-started | phase-2/task-04-tab-shell |
+| phase-3/task-05-tests | Update Licensee Form Tests | 3 | not-started | phase-2/task-04-tab-shell |
 
 ## Branch Convention
 
@@ -61,28 +97,27 @@ Base branch: `main`
 
 | File/Directory | Relevance |
 |----------------|-----------|
-| `client/src/pages/Licensees/scenes/Form/index.js` | Source of all field groups; owns all panel extraction |
-| `client/src/pages/Licensees/scenes/Form/panels/` | NEW directory — one file per panel component |
-| `client/src/pages/Licensees/scenes/Edit/index.js` | Hosts `<Form>`; no changes needed |
-| `client/src/services/licensee.js` | getBaileysQr service; consumed by WhatsAppPanel |
-| `client/package.json` | Bootstrap 5.3 already available — no new deps |
+| `client/src/pages/Licensees/scenes/Form/index.js` | Source — ~960 lines; all panels extracted from here |
+| `client/src/pages/Licensees/scenes/Form/panels/` | NEW directory — one file per panel |
+| `client/src/services/licensee.js` | Service calls used by WhatsAppPanel and others |
+| `client/package.json` | Bootstrap 5.3 and qrcode.react already available |
 
 ## Risks
 
-- Panel components receive large props surface (all Formik props + helpers); keep props explicit, do not spread `...props` blindly
-- Always-mounted panels: all tabs must render even when not active — avoid conditional rendering with `&&`; use CSS `d-none` or tab `show/active` classes instead
-- Formik `setFieldValue` must be threaded into panels that need it (e.g. WhatsAppPanel for QR state)
+- Q1/Q3/Q4 local state initialised from field values: editing an existing licensee that has chatDefault set will correctly show Chat tab; a new licensee starts with all questions unchecked
+- Always-mounted panes: do NOT use `&&` for panels — use CSS `show active` classes or `d-none` on panes
+- Tab nav buttons must have `type="button"` to prevent form submission
 
 ## Success Criteria
 
-- [ ] All field groups extracted into panel components under `client/src/pages/Licensees/scenes/Form/panels/`
-- [ ] Form/index.js renders Bootstrap Nav Tabs; active tab controlled by `activeTab` useState
-- [ ] Correct tabs are visible/active based on `whatsappDefault` and `chatbotDefault` values
-- [ ] All panes always mounted — submit captures all field values regardless of active tab
-- [ ] QR code generation still works correctly when Baileys is selected
-- [ ] Existing Vitest tests pass with updated selectors
-- [ ] `npx eslint .` passes clean
-- [ ] No regressions in create/edit licensee flow
+- [ ] All panel components created under `panels/`
+- [ ] Main tab shows identity fields + 6 questions; all questions work as checkboxes
+- [ ] Each integration tab appears/disappears based on its question
+- [ ] All panes always mounted — submit captures all field values
+- [ ] Existing conditional logic inside tabs preserved (e.g. chatIdentifier only for crisp/chatwoot)
+- [ ] Baileys QR generation still works on WhatsApp tab
+- [ ] All existing tests pass; new tab-switch tests added
+- [ ] `npx eslint .` passes
 
 ## Defects
 
@@ -90,4 +125,5 @@ None
 
 ## References
 
-- **Related Plans**: `baileys-plugin` (complete) — WhatsApp panel includes QR generation from that work
+- **Related Plans**: `baileys-plugin` (complete) — QR code generation in WhatsApp tab
+- **Related Plans**: `remove-pdv` (not-started) — may remove Cart/PagarMe tabs; run before or after

--- a/.plans/licensee-form-wizard/overview.md
+++ b/.plans/licensee-form-wizard/overview.md
@@ -1,0 +1,93 @@
+# Plan: Licensee Form Wizard
+
+**Status**: not-started
+**Created**: 2026-05-06
+**Last Updated**: 2026-05-06
+**Estimated Demo Date**: —
+**Assigned Dev**: Alan Costa Facchini
+**Assigned QA**: unassigned
+**Master Plan**: None
+
+## Objective
+
+Split the large licensee form (~960 lines) into contextual tab panels that show or hide based on the user's chosen messenger and chatbot type, replacing the current single long form with scattered `display:none` visibility logic.
+
+## Scope
+
+### In Scope
+- Extract field groups from `Form/index.js` into dedicated panel components (pure presentational)
+- Bootstrap 5 Nav Tab shell in `Form/index.js` with `activeTab` state controlling which tab is active
+- Tab visibility driven by form values (`whatsappDefault`, `chatbotDefault`) — tabs shown/hidden via CSS, panels always mounted so Formik captures all values on submit
+- Update existing Vitest tests to account for the new component structure
+
+### Out of Scope
+- Multi-step wizard with Next/Back navigation (tabs are sufficient; wizard UX is a follow-up if requested)
+- Server-side validation changes — no backend changes
+- New form fields — layout refactor only
+- Accessibility audit — out of scope for this iteration
+
+## Kill Criteria
+- If Formik is replaced with another form library before this plan executes
+
+## Phases
+
+| Phase | Name | Tasks | Dependencies | Description |
+|-------|------|-------|--------------|-------------|
+| 1 | Extract Panels | task-01, task-02, task-03 | None | Extract field groups into panel components; no behavior change |
+| 2 | Tab Shell | task-04 | Phase 1 | Add Bootstrap Nav Tabs to Form/index.js, wiring panels |
+| 3 | Tests | task-05 | Phase 2 | Update Vitest tests for new structure |
+
+## Task Summary
+
+| Task Path | Title | Phase | Status | Depends On |
+|-----------|-------|-------|--------|------------|
+| phase-1/task-01-panel-general | GeneralPanel + ChatbotPanel | 1 | not-started | — |
+| phase-1/task-02-panel-comms | ChatPanel + WhatsAppPanel | 1 | not-started | — |
+| phase-1/task-03-panel-infra | AwsPanel + CartPanel + FinancialPanel + OthersPanel | 1 | not-started | — |
+| phase-2/task-04-tab-shell | Tab Shell in Form/index.js | 2 | not-started | phase-1/* |
+| phase-3/task-05-tests | Vitest — update licensee form tests | 3 | not-started | phase-2/task-04-tab-shell |
+
+## Branch Convention
+
+Pattern: `plan/licensee-form-wizard/{task-path}`
+
+Example branches:
+- `plan/licensee-form-wizard/phase-1/task-01-panel-general`
+- `plan/licensee-form-wizard/phase-2/task-04-tab-shell`
+
+Base branch: `main`
+
+## Key Files
+
+| File/Directory | Relevance |
+|----------------|-----------|
+| `client/src/pages/Licensees/scenes/Form/index.js` | Source of all field groups; owns all panel extraction |
+| `client/src/pages/Licensees/scenes/Form/panels/` | NEW directory — one file per panel component |
+| `client/src/pages/Licensees/scenes/Edit/index.js` | Hosts `<Form>`; no changes needed |
+| `client/src/services/licensee.js` | getBaileysQr service; consumed by WhatsAppPanel |
+| `client/package.json` | Bootstrap 5.3 already available — no new deps |
+
+## Risks
+
+- Panel components receive large props surface (all Formik props + helpers); keep props explicit, do not spread `...props` blindly
+- Always-mounted panels: all tabs must render even when not active — avoid conditional rendering with `&&`; use CSS `d-none` or tab `show/active` classes instead
+- Formik `setFieldValue` must be threaded into panels that need it (e.g. WhatsAppPanel for QR state)
+
+## Success Criteria
+
+- [ ] All field groups extracted into panel components under `client/src/pages/Licensees/scenes/Form/panels/`
+- [ ] Form/index.js renders Bootstrap Nav Tabs; active tab controlled by `activeTab` useState
+- [ ] Correct tabs are visible/active based on `whatsappDefault` and `chatbotDefault` values
+- [ ] All panes always mounted — submit captures all field values regardless of active tab
+- [ ] QR code generation still works correctly when Baileys is selected
+- [ ] Existing Vitest tests pass with updated selectors
+- [ ] `npx eslint .` passes clean
+- [ ] No regressions in create/edit licensee flow
+
+## Defects
+
+None
+
+## References
+
+- **Related Plans**: `baileys-plugin` (complete) — WhatsApp panel includes QR generation from that work

--- a/.plans/licensee-form-wizard/overview.md
+++ b/.plans/licensee-form-wizard/overview.md
@@ -30,8 +30,7 @@ Split the large licensee form (~960 lines) into contextual tab panels. The main 
 - Update existing tests
 
 ### Out of Scope
-- AWS fields (`awsId`, `awsSecret`, `bucketName`) — not listed in wizard spec; keep in main tab as-is pending removal by remove-pdv plan
-- New backend model fields — UI state only
+- New backend model fields — UI state only for questions
 - Multi-step wizard with Next/Back navigation
 - Accessibility audit
 
@@ -80,6 +79,7 @@ Split the large licensee form (~960 lines) into contextual tab panels. The main 
 | phase-1/task-01-panel-general | MainPanel | 1 | not-started | — |
 | phase-1/task-02-panel-comms | ChatPanel + ChatbotPanel | 1 | not-started | — |
 | phase-1/task-03-panel-infra | WhatsAppPanel + CartPanel + PagarMePanel + Pedidos10Panel | 1 | not-started | — |
+| phase-1/task-06-remove-aws | Remove AWS Fields — Use Env Vars | 1 | not-started | — |
 | phase-2/task-04-tab-shell | Tab Shell in Form/index.js | 2 | not-started | phase-1/* |
 | phase-3/task-05-tests | Update Licensee Form Tests | 3 | not-started | phase-2/task-04-tab-shell |
 

--- a/.plans/licensee-form-wizard/phase-1/task-01-panel-general/status.md
+++ b/.plans/licensee-form-wizard/phase-1/task-01-panel-general/status.md
@@ -1,0 +1,25 @@
+# Status: GeneralPanel + ChatbotPanel
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-06
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-06 | not-started | — | Plan created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/licensee-form-wizard/phase-1/task-01-panel-general/task.md
+++ b/.plans/licensee-form-wizard/phase-1/task-01-panel-general/task.md
@@ -1,4 +1,4 @@
-# Task: GeneralPanel + ChatbotPanel
+# Task: MainPanel
 
 **Plan**: Licensee Form Wizard
 **Task ID**: task-01
@@ -8,40 +8,64 @@
 
 ## Before You Start
 
-- [ ] Read `client/src/pages/Licensees/scenes/Form/index.js` in full to identify the exact field groups
-- [ ] Note all Formik props and helpers used by the general/chatbot sections
+- [ ] Read `client/src/pages/Licensees/scenes/Form/index.js` in full
 - [ ] Confirm `client/src/pages/Licensees/scenes/Form/panels/` does not yet exist
 
 ## Context
 
-`Form/index.js` is ~960 lines with all fields inlined. This task extracts the **general licensee fields** and **chatbot configuration fields** into two presentational components. No behavior change — pure extraction.
+Extract the **main tab fields** from `Form/index.js` into a `MainPanel` component. This panel contains identity data, read-only tokens/webhook URLs, and the 6 integration questions.
 
-**GeneralPanel** fields (from top of form):
-- name, phone, email, active, licenseKind, contractStartedAt, contractEndedAt, whatsappDefault
+The 6 questions are **not** implemented here — they will be `props` passed in from `Form/index.js` (just checkboxes rendered via props). MainPanel is purely presentational; the question state lives in the parent.
 
-**ChatbotPanel** fields:
-- chatbotDefault, chatbotApiToken, chatbotUrl, messageOnInactive, messageOnInactiveAlt, noteOnInactive
+### Fields to extract (lines 88–223 + 866–926 of current Form/index.js)
+
+**Identity fields**:
+- name (text)
+- active (checkbox)
+- kind (select: Jurídica / Física)
+- document (text)
+- email (text)
+- licenseKind (select: Demonstração / Grátis / Pago)
+- phone (text)
+- apiToken (`disabled` — read-only, auto-generated)
+
+**Read-only webhook URLs** (`disabled`):
+- urlChatWebhook
+- urlChatbotWebhook
+- urlChatbotTransfer
+- urlWhatsappWebhook
+
+**AWS fields** (no conditional logic — always shown; keep in this panel pending remove-pdv):
+- awsId, awsSecret, bucketName
+
+**6 integration questions** — rendered as checkboxes, values/handlers passed as props:
+```
+useChat        — "Integração com Plataforma de Chat?"
+useChatbot     — "Integração com Plataforma de ChatBot?" (Formik field via props.values.useChatbot)
+useWhatsapp    — "Integração com Plataforma de WhatsApp?"
+useCart        — "Integração com Carrinho de Compras?"
+usePagarMe     — "Integração com PagarMe?"
+(Q6 Pedidos10) — rendered only when currentUser.isPedidos10, value = currentUser.isPedidos10 (read-only indicator)
+```
+
+> Note: Q1, Q3, Q4, Q5 are local state managed by `Form/index.js`; Q2 (`useChatbot`) is a Formik field. MainPanel receives all of them as props and just renders checkboxes.
 
 ## File Ownership
 
 | File | Action | Notes |
 |------|--------|-------|
-| `client/src/pages/Licensees/scenes/Form/panels/GeneralPanel.js` | create | New panel component |
-| `client/src/pages/Licensees/scenes/Form/panels/ChatbotPanel.js` | create | New panel component |
-| `client/src/pages/Licensees/scenes/Form/index.js` | modify | Replace inlined JSX with `<GeneralPanel>` and `<ChatbotPanel>` |
+| `client/src/pages/Licensees/scenes/Form/panels/MainPanel.js` | create | New panel component |
+| `client/src/pages/Licensees/scenes/Form/index.js` | modify | Replace extracted JSX with `<MainPanel>` |
 
 ### Do NOT Modify
 
-- `client/src/pages/Licensees/scenes/Form/panels/ChatPanel.js` (task-02)
-- `client/src/pages/Licensees/scenes/Form/panels/WhatsAppPanel.js` (task-02)
-- `client/src/pages/Licensees/scenes/Form/panels/AwsPanel.js` (task-03)
-- Any other panel files (task-03)
+- Any other `panels/*.js` files (tasks 02 and 03)
 
 ## Conflict Avoidance Notes
 
-task-01, task-02, task-03 all modify `Form/index.js`. Run them sequentially (01 → 02 → 03) on chained branches, or coordinate file sections carefully if truly parallel.
-
-**Recommended approach**: chain branches — task-02 branches from task-01, task-03 branches from task-02.
+Tasks 01, 02, 03 all modify `Form/index.js`. Run sequentially on chained branches:
+- task-02 branches from task-01's branch
+- task-03 branches from task-02's branch
 
 ## Implementation Steps
 
@@ -50,35 +74,52 @@ task-01, task-02, task-03 all modify `Form/index.js`. Run them sequentially (01 
 mkdir -p client/src/pages/Licensees/scenes/Form/panels
 ```
 
-### Step 2: Create GeneralPanel.js
-Extract fields: name, phone, email, active, licenseKind, contractStartedAt, contractEndedAt, whatsappDefault.
+### Step 2: Create MainPanel.js
 
-Props: `{ values, errors, touched, handleChange, handleBlur, setFieldValue }`
+Props interface:
+```js
+function MainPanel({
+  values,          // Formik values
+  errors,
+  touched,
+  handleChange,
+  handleBlur,
+  currentUser,     // for Q6 Pedidos10 visibility
+  // Question state (local state from Form/index.js)
+  useChat, setUseChat,
+  useWhatsapp, setUseWhatsapp,
+  useCart, setUseCart,
+  usePagarMe, setUsePagarMe,
+  setFieldValue,   // to reset chatDefault/whatsappDefault/cartDefault on uncheck
+})
+```
 
-### Step 3: Create ChatbotPanel.js
-Extract fields: chatbotDefault, chatbotApiToken, chatbotUrl, messageOnInactive, messageOnInactiveAlt, noteOnInactive.
+Question checkbox behaviour on uncheck:
+- `useChat` off → `setFieldValue('chatDefault', '')`
+- `useWhatsapp` off → `setFieldValue('whatsappDefault', '')`
+- `useCart` off → `setFieldValue('cartDefault', '')`
+- `usePagarMe` off → no field reset (preserve financial data)
 
-Visibility logic: show chatbotApiToken and chatbotUrl only when `values.chatbotDefault !== 'none'` (carry forward existing conditional).
+### Step 3: Update Form/index.js
 
-Props: `{ values, errors, touched, handleChange, handleBlur }`
-
-### Step 4: Replace inlined JSX in Form/index.js
-Import and render `<GeneralPanel>` and `<ChatbotPanel>` in place of the extracted JSX. Pass all required props explicitly.
+Replace the extracted JSX blocks with `<MainPanel {...questionProps} {...formikProps} currentUser={currentUser} />`.
+Do NOT yet add tab structure — that is task-04.
 
 ## Testing
 
-- [ ] Run `npx jest --testPathPattern=Licensees` and confirm no test failures
-- [ ] Manual: open the Create Licensee form and verify general and chatbot fields are visible and functional
-- [ ] No visual change expected — this is a pure extraction
+- [ ] Run `npx jest --testPathPattern=Licensees` — no failures
+- [ ] Manual: verify all identity fields still render and save correctly
+- [ ] Manual: verify read-only fields (apiToken, webhook URLs) are disabled
+- [ ] No visual change expected
 
 ## Documentation / KB Updates
 
-No KB/doc updates required — this is a presentational refactor with no behavior change.
+No KB/doc updates required — pure extraction.
 
 ## Completion Criteria
 
-- [ ] `GeneralPanel.js` and `ChatbotPanel.js` created under `panels/`
-- [ ] `Form/index.js` imports and renders both panels
-- [ ] No field is lost or duplicated
+- [ ] `MainPanel.js` created under `panels/`
+- [ ] `Form/index.js` imports and renders `<MainPanel>`
+- [ ] No field lost or duplicated
 - [ ] All tests pass
 - [ ] `npx eslint .` passes

--- a/.plans/licensee-form-wizard/phase-1/task-01-panel-general/task.md
+++ b/.plans/licensee-form-wizard/phase-1/task-01-panel-general/task.md
@@ -1,0 +1,84 @@
+# Task: GeneralPanel + ChatbotPanel
+
+**Plan**: Licensee Form Wizard
+**Task ID**: task-01
+**Task Path**: phase-1/task-01-panel-general
+**Depends On**: None
+**JIRA**: N/A
+
+## Before You Start
+
+- [ ] Read `client/src/pages/Licensees/scenes/Form/index.js` in full to identify the exact field groups
+- [ ] Note all Formik props and helpers used by the general/chatbot sections
+- [ ] Confirm `client/src/pages/Licensees/scenes/Form/panels/` does not yet exist
+
+## Context
+
+`Form/index.js` is ~960 lines with all fields inlined. This task extracts the **general licensee fields** and **chatbot configuration fields** into two presentational components. No behavior change — pure extraction.
+
+**GeneralPanel** fields (from top of form):
+- name, phone, email, active, licenseKind, contractStartedAt, contractEndedAt, whatsappDefault
+
+**ChatbotPanel** fields:
+- chatbotDefault, chatbotApiToken, chatbotUrl, messageOnInactive, messageOnInactiveAlt, noteOnInactive
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `client/src/pages/Licensees/scenes/Form/panels/GeneralPanel.js` | create | New panel component |
+| `client/src/pages/Licensees/scenes/Form/panels/ChatbotPanel.js` | create | New panel component |
+| `client/src/pages/Licensees/scenes/Form/index.js` | modify | Replace inlined JSX with `<GeneralPanel>` and `<ChatbotPanel>` |
+
+### Do NOT Modify
+
+- `client/src/pages/Licensees/scenes/Form/panels/ChatPanel.js` (task-02)
+- `client/src/pages/Licensees/scenes/Form/panels/WhatsAppPanel.js` (task-02)
+- `client/src/pages/Licensees/scenes/Form/panels/AwsPanel.js` (task-03)
+- Any other panel files (task-03)
+
+## Conflict Avoidance Notes
+
+task-01, task-02, task-03 all modify `Form/index.js`. Run them sequentially (01 → 02 → 03) on chained branches, or coordinate file sections carefully if truly parallel.
+
+**Recommended approach**: chain branches — task-02 branches from task-01, task-03 branches from task-02.
+
+## Implementation Steps
+
+### Step 1: Create panels directory
+```bash
+mkdir -p client/src/pages/Licensees/scenes/Form/panels
+```
+
+### Step 2: Create GeneralPanel.js
+Extract fields: name, phone, email, active, licenseKind, contractStartedAt, contractEndedAt, whatsappDefault.
+
+Props: `{ values, errors, touched, handleChange, handleBlur, setFieldValue }`
+
+### Step 3: Create ChatbotPanel.js
+Extract fields: chatbotDefault, chatbotApiToken, chatbotUrl, messageOnInactive, messageOnInactiveAlt, noteOnInactive.
+
+Visibility logic: show chatbotApiToken and chatbotUrl only when `values.chatbotDefault !== 'none'` (carry forward existing conditional).
+
+Props: `{ values, errors, touched, handleChange, handleBlur }`
+
+### Step 4: Replace inlined JSX in Form/index.js
+Import and render `<GeneralPanel>` and `<ChatbotPanel>` in place of the extracted JSX. Pass all required props explicitly.
+
+## Testing
+
+- [ ] Run `npx jest --testPathPattern=Licensees` and confirm no test failures
+- [ ] Manual: open the Create Licensee form and verify general and chatbot fields are visible and functional
+- [ ] No visual change expected — this is a pure extraction
+
+## Documentation / KB Updates
+
+No KB/doc updates required — this is a presentational refactor with no behavior change.
+
+## Completion Criteria
+
+- [ ] `GeneralPanel.js` and `ChatbotPanel.js` created under `panels/`
+- [ ] `Form/index.js` imports and renders both panels
+- [ ] No field is lost or duplicated
+- [ ] All tests pass
+- [ ] `npx eslint .` passes

--- a/.plans/licensee-form-wizard/phase-1/task-01-panel-general/task.md
+++ b/.plans/licensee-form-wizard/phase-1/task-01-panel-general/task.md
@@ -10,6 +10,7 @@
 
 - [ ] Read `client/src/pages/Licensees/scenes/Form/index.js` in full
 - [ ] Confirm `client/src/pages/Licensees/scenes/Form/panels/` does not yet exist
+- [ ] Confirm task-06-remove-aws is complete (AWS fields removed from model) — or coordinate so MainPanel simply doesn't render them
 
 ## Context
 
@@ -35,9 +36,6 @@ The 6 questions are **not** implemented here — they will be `props` passed in 
 - urlChatbotTransfer
 - urlWhatsappWebhook
 
-**AWS fields** (no conditional logic — always shown; keep in this panel pending remove-pdv):
-- awsId, awsSecret, bucketName
-
 **6 integration questions** — rendered as checkboxes, values/handlers passed as props:
 ```
 useChat        — "Integração com Plataforma de Chat?"
@@ -55,7 +53,7 @@ usePagarMe     — "Integração com PagarMe?"
 | File | Action | Notes |
 |------|--------|-------|
 | `client/src/pages/Licensees/scenes/Form/panels/MainPanel.js` | create | New panel component |
-| `client/src/pages/Licensees/scenes/Form/index.js` | modify | Replace extracted JSX with `<MainPanel>` |
+| `client/src/pages/Licensees/scenes/Form/index.js` | modify | Replace extracted JSX with `<MainPanel>`; remove awsId/awsSecret/bucketName from `licenseeInitialValues` and field JSX |
 
 ### Do NOT Modify
 

--- a/.plans/licensee-form-wizard/phase-1/task-02-panel-comms/status.md
+++ b/.plans/licensee-form-wizard/phase-1/task-02-panel-comms/status.md
@@ -1,0 +1,25 @@
+# Status: ChatPanel + WhatsAppPanel
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-06
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-06 | not-started | — | Plan created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/licensee-form-wizard/phase-1/task-02-panel-comms/task.md
+++ b/.plans/licensee-form-wizard/phase-1/task-02-panel-comms/task.md
@@ -1,4 +1,4 @@
-# Task: ChatPanel + WhatsAppPanel
+# Task: ChatPanel + ChatbotPanel
 
 **Plan**: Licensee Form Wizard
 **Task ID**: task-02
@@ -8,74 +8,96 @@
 
 ## Before You Start
 
-- [ ] Read `client/src/pages/Licensees/scenes/Form/index.js` (after task-01 changes) to identify remaining field groups
-- [ ] Identify all Formik props and helpers used by chat/whatsapp sections
-- [ ] Identify baileysQr state and getBaileysQr service usage — these must be threaded as props to WhatsAppPanel
+- [ ] Confirm task-01 branch exists and is complete
+- [ ] Branch from task-01: `git switch plan/licensee-form-wizard/phase-1/task-01-panel-general && git switch -c plan/licensee-form-wizard/phase-1/task-02-panel-comms`
+- [ ] Read `Form/index.js` (post task-01) to confirm which JSX remains
 
 ## Context
 
-Extraction of the **chat/operator configuration** and **WhatsApp/messenger configuration** fields. The WhatsAppPanel is the most complex: it contains the Baileys QR code generation UI (introduced in the baileys-plugin plan), conditional rendering for token/URL vs. QR display, and local `baileysQr` state.
+Extract **Chat** and **ChatBot** configuration fields into two panel components.
 
-**ChatPanel** fields:
-- attendant fields (attendantDefault?), productFractional, productRandomSorting, sendInactiveMessage, inactiveMessage
+### ChatPanel fields (Form/index.js lines ~316–399)
 
-**WhatsAppPanel** fields:
-- whatsappDefault (combobox — already in GeneralPanel; WhatsAppPanel shows conditional fields based on its value)
-- whatsappToken, whatsappUrl (hidden when whatsappDefault === 'baileys')
-- Gerar QR Code button + QRCodeSVG display (shown when whatsappDefault === 'baileys')
-- baileysQr local state + getBaileysQr call
+The **chatDefault combo is the tab trigger** — it moves inside this panel (not in the main tab questions area, as it was before). The question checkbox `useChat` controls tab visibility; `chatDefault` is the provider selector inside the tab.
+
+Fields:
+- chatDefault (select: Rocketchat / Crisp / CuboUp / Chatwoot)
+- chatUrl (text)
+- useSenderName (checkbox — "Usa o remetente no nome do chat?")
+- chatIdentifier (text — only when `chatDefault` is `crisp` or `chatwoot`)
+- chatKey (text — only when `chatDefault` is `crisp` or `chatwoot`)
+
+Preserve existing conditional: `{['crisp', 'chatwoot'].includes(values.chatDefault) && (...)}`
+
+The outer `<fieldset disabled={chatDefault === ''}>` is replaced by the tab visibility rule (panel not shown when `useChat` is false). Inside the panel, no extra disabled wrapper needed.
+
+### ChatbotPanel fields (Form/index.js lines ~224–314)
+
+Fields:
+- chatbotDefault (select: Landbot)
+- chatbotUrl (text)
+- chatbotAuthorizationToken (text — "Token do chatbot")
+- chatbotApiToken (text — "Token de acesso via API do chatbot")
+- messageOnResetChatbot (textarea — "Mensagem de encerramento de chatbot abandonado")
+- messageOnCloseChat (textarea — "Mensagem de encerramento de chat")
+
+The outer `<fieldset disabled={!useChatbot}>` is replaced by tab visibility. No disabled wrapper inside the panel.
 
 ## File Ownership
 
 | File | Action | Notes |
 |------|--------|-------|
 | `client/src/pages/Licensees/scenes/Form/panels/ChatPanel.js` | create | New panel component |
-| `client/src/pages/Licensees/scenes/Form/panels/WhatsAppPanel.js` | create | New panel component; receives baileysQr/setBaileysQr as props OR manages its own local state |
-| `client/src/pages/Licensees/scenes/Form/index.js` | modify | Replace inlined JSX with `<ChatPanel>` and `<WhatsAppPanel>` |
+| `client/src/pages/Licensees/scenes/Form/panels/ChatbotPanel.js` | create | New panel component |
+| `client/src/pages/Licensees/scenes/Form/index.js` | modify | Replace extracted JSX with panel imports |
 
 ### Do NOT Modify
 
-- `client/src/pages/Licensees/scenes/Form/panels/GeneralPanel.js` (task-01)
-- `client/src/pages/Licensees/scenes/Form/panels/ChatbotPanel.js` (task-01)
-- `client/src/pages/Licensees/scenes/Form/panels/AwsPanel.js` (task-03)
-- Any other panel files (task-03)
+- `client/src/pages/Licensees/scenes/Form/panels/MainPanel.js` (task-01)
+- Any infra panels (task-03)
 
 ## Conflict Avoidance Notes
 
-Branch from task-01's branch (chained): `git switch plan/licensee-form-wizard/phase-1/task-01-panel-general && git switch -c plan/licensee-form-wizard/phase-1/task-02-panel-comms`
+Chain from task-01's branch (see Before You Start above).
 
 ## Implementation Steps
 
 ### Step 1: Create ChatPanel.js
-Extract chat-related fields. Props: `{ values, errors, touched, handleChange, handleBlur }`
 
-### Step 2: Create WhatsAppPanel.js
-Extract WhatsApp fields including:
-- Conditional display of whatsappToken/whatsappUrl (hidden when `values.whatsappDefault === 'baileys'`)
-- Gerar QR Code button (visible when `values.whatsappDefault === 'baileys'`)
-- QRCodeSVG component for QR display
+```js
+function ChatPanel({ values, errors, touched, handleChange, handleBlur }) { ... }
+```
 
-**State decision**: WhatsAppPanel manages its own `baileysQr` and `baileysQrStatus` local state (avoids lifting state to Form/index.js). It receives `licenseeId` as a prop for the API call.
+Include the `crisp`/`chatwoot` conditional for chatIdentifier and chatKey.
 
-Props: `{ values, errors, touched, handleChange, handleBlur, licenseeId }`
+### Step 2: Create ChatbotPanel.js
+
+```js
+function ChatbotPanel({ values, errors, touched, handleChange, handleBlur }) { ... }
+```
 
 ### Step 3: Update Form/index.js
-Import and render `<ChatPanel>` and `<WhatsAppPanel>`. Remove now-extracted JSX. Pass `licenseeId` (available from the `licensee` prop or URL param) to WhatsAppPanel.
+
+Replace the two extracted JSX blocks with `<ChatPanel>` and `<ChatbotPanel>`.
+Remove the `useChatbot` `<fieldset disabled>` wrapper — tab visibility handles that.
+Remove the `chatDefault === ''` `<fieldset disabled>` wrapper.
 
 ## Testing
 
-- [ ] Run `npx jest --testPathPattern=Licensees` and confirm no failures
-- [ ] Manual: switch whatsappDefault to 'baileys' — verify QR button appears, token/URL hide
-- [ ] Manual: click Gerar QR Code — verify QR code displays (requires running backend)
+- [ ] Run `npx jest --testPathPattern=Licensees` — no failures
+- [ ] Manual: verify Chat fields still render (chatUrl, useSenderName, chatIdentifier/Key for crisp)
+- [ ] Manual: verify ChatBot fields still render
+- [ ] No visual change expected — extraction only
 
 ## Documentation / KB Updates
 
-No KB/doc updates required — presentational extraction only.
+No KB/doc updates required.
 
 ## Completion Criteria
 
-- [ ] `ChatPanel.js` and `WhatsAppPanel.js` created under `panels/`
+- [ ] `ChatPanel.js` and `ChatbotPanel.js` created under `panels/`
 - [ ] `Form/index.js` imports and renders both panels
-- [ ] Baileys QR generation still works end-to-end
+- [ ] Conditional logic for chatIdentifier/chatKey preserved
+- [ ] `<fieldset disabled>` wrappers removed for these sections
 - [ ] All tests pass
 - [ ] `npx eslint .` passes

--- a/.plans/licensee-form-wizard/phase-1/task-02-panel-comms/task.md
+++ b/.plans/licensee-form-wizard/phase-1/task-02-panel-comms/task.md
@@ -1,0 +1,81 @@
+# Task: ChatPanel + WhatsAppPanel
+
+**Plan**: Licensee Form Wizard
+**Task ID**: task-02
+**Task Path**: phase-1/task-02-panel-comms
+**Depends On**: phase-1/task-01-panel-general
+**JIRA**: N/A
+
+## Before You Start
+
+- [ ] Read `client/src/pages/Licensees/scenes/Form/index.js` (after task-01 changes) to identify remaining field groups
+- [ ] Identify all Formik props and helpers used by chat/whatsapp sections
+- [ ] Identify baileysQr state and getBaileysQr service usage — these must be threaded as props to WhatsAppPanel
+
+## Context
+
+Extraction of the **chat/operator configuration** and **WhatsApp/messenger configuration** fields. The WhatsAppPanel is the most complex: it contains the Baileys QR code generation UI (introduced in the baileys-plugin plan), conditional rendering for token/URL vs. QR display, and local `baileysQr` state.
+
+**ChatPanel** fields:
+- attendant fields (attendantDefault?), productFractional, productRandomSorting, sendInactiveMessage, inactiveMessage
+
+**WhatsAppPanel** fields:
+- whatsappDefault (combobox — already in GeneralPanel; WhatsAppPanel shows conditional fields based on its value)
+- whatsappToken, whatsappUrl (hidden when whatsappDefault === 'baileys')
+- Gerar QR Code button + QRCodeSVG display (shown when whatsappDefault === 'baileys')
+- baileysQr local state + getBaileysQr call
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `client/src/pages/Licensees/scenes/Form/panels/ChatPanel.js` | create | New panel component |
+| `client/src/pages/Licensees/scenes/Form/panels/WhatsAppPanel.js` | create | New panel component; receives baileysQr/setBaileysQr as props OR manages its own local state |
+| `client/src/pages/Licensees/scenes/Form/index.js` | modify | Replace inlined JSX with `<ChatPanel>` and `<WhatsAppPanel>` |
+
+### Do NOT Modify
+
+- `client/src/pages/Licensees/scenes/Form/panels/GeneralPanel.js` (task-01)
+- `client/src/pages/Licensees/scenes/Form/panels/ChatbotPanel.js` (task-01)
+- `client/src/pages/Licensees/scenes/Form/panels/AwsPanel.js` (task-03)
+- Any other panel files (task-03)
+
+## Conflict Avoidance Notes
+
+Branch from task-01's branch (chained): `git switch plan/licensee-form-wizard/phase-1/task-01-panel-general && git switch -c plan/licensee-form-wizard/phase-1/task-02-panel-comms`
+
+## Implementation Steps
+
+### Step 1: Create ChatPanel.js
+Extract chat-related fields. Props: `{ values, errors, touched, handleChange, handleBlur }`
+
+### Step 2: Create WhatsAppPanel.js
+Extract WhatsApp fields including:
+- Conditional display of whatsappToken/whatsappUrl (hidden when `values.whatsappDefault === 'baileys'`)
+- Gerar QR Code button (visible when `values.whatsappDefault === 'baileys'`)
+- QRCodeSVG component for QR display
+
+**State decision**: WhatsAppPanel manages its own `baileysQr` and `baileysQrStatus` local state (avoids lifting state to Form/index.js). It receives `licenseeId` as a prop for the API call.
+
+Props: `{ values, errors, touched, handleChange, handleBlur, licenseeId }`
+
+### Step 3: Update Form/index.js
+Import and render `<ChatPanel>` and `<WhatsAppPanel>`. Remove now-extracted JSX. Pass `licenseeId` (available from the `licensee` prop or URL param) to WhatsAppPanel.
+
+## Testing
+
+- [ ] Run `npx jest --testPathPattern=Licensees` and confirm no failures
+- [ ] Manual: switch whatsappDefault to 'baileys' — verify QR button appears, token/URL hide
+- [ ] Manual: click Gerar QR Code — verify QR code displays (requires running backend)
+
+## Documentation / KB Updates
+
+No KB/doc updates required — presentational extraction only.
+
+## Completion Criteria
+
+- [ ] `ChatPanel.js` and `WhatsAppPanel.js` created under `panels/`
+- [ ] `Form/index.js` imports and renders both panels
+- [ ] Baileys QR generation still works end-to-end
+- [ ] All tests pass
+- [ ] `npx eslint .` passes

--- a/.plans/licensee-form-wizard/phase-1/task-03-panel-infra/status.md
+++ b/.plans/licensee-form-wizard/phase-1/task-03-panel-infra/status.md
@@ -1,0 +1,25 @@
+# Status: AwsPanel + CartPanel + FinancialPanel + OthersPanel
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-06
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-06 | not-started | — | Plan created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/licensee-form-wizard/phase-1/task-03-panel-infra/task.md
+++ b/.plans/licensee-form-wizard/phase-1/task-03-panel-infra/task.md
@@ -1,4 +1,4 @@
-# Task: AwsPanel + CartPanel + FinancialPanel + OthersPanel
+# Task: WhatsAppPanel + CartPanel + PagarMePanel + Pedidos10Panel
 
 **Plan**: Licensee Form Wizard
 **Task ID**: task-03
@@ -8,61 +8,132 @@
 
 ## Before You Start
 
-- [ ] Read `client/src/pages/Licensees/scenes/Form/index.js` (after task-01 + task-02 changes) to identify remaining field groups
-- [ ] List all props needed by each panel
+- [ ] Confirm task-02 branch exists and is complete
+- [ ] Branch from task-02: `git switch plan/licensee-form-wizard/phase-1/task-02-panel-comms && git switch -c plan/licensee-form-wizard/phase-1/task-03-panel-infra`
+- [ ] Read `Form/index.js` (post task-02) to see remaining JSX
 
 ## Context
 
-Extract the remaining field groups: AWS S3 configuration, cart/store settings, financial/payment settings, and miscellaneous (Pedidos10, webhooks, etc.).
+Extract the 4 remaining fieldset groups into panel components.
 
-**AwsPanel** fields: awsDefaultRegion, awsBucketNameFiles, awsBucketNameAudios, awsAccessKeyId, awsSecretAccessKey
+### WhatsAppPanel fields (Form/index.js lines ~401–535)
 
-**CartPanel** fields: productFractional, productRandomSorting, cartDefault, and any cart-related fields
+- whatsappDefault (select: Utalk / Dialog360 / YCloud / Pabbly / Baileys)
+- whatsappToken (text — hidden when `whatsappDefault === 'baileys'`)
+- whatsappUrl (text — hidden when `whatsappDefault === 'baileys'`)
+- useFileIDYcloud (checkbox — only when `whatsappDefault === 'ycloud'`)
+- "Configurar Webhook no provedor" button — only when `whatsappDefault` is `dialog` or `ycloud` AND `values.apiToken` is set
+- "Importar templates" button — same condition as above
+- "Gerar QR Code" button + QRCodeSVG display — only when `whatsappDefault === 'baileys'`
 
-**FinancialPanel** fields: pagarmeApiKey, billingType, and any payment-related fields
+The `baileysQr` and `baileysStatus` state currently lives in `Form/index.js`. Move it into `WhatsAppPanel` (self-contained). Receives `values.apiToken` and `values` as props for the service call and condition checks.
 
-**OthersPanel** fields: pedidos10Token, webhookUrl, sendInactiveMessage, inactiveMessage, and any remaining fields not covered by other panels
+Props: `{ values, errors, touched, handleChange, handleBlur }`
 
-> Note: exact field grouping should be confirmed by reading the current Form/index.js. Adjust panel names/groupings as makes sense for the actual fields present.
+Imports needed inside WhatsAppPanel:
+```js
+import { useState } from 'react'
+import { QRCodeSVG } from 'qrcode.react'
+import { setLicenseeWebhook, getBaileysQr, importLicenseeTemplate } from '../../../../../services/licensee'
+```
+
+Remove `baileysQr`/`baileysStatus` state from `Form/index.js` once extracted.
+
+### CartPanel fields (Form/index.js lines ~581–662)
+
+- cartDefault (select: Alloy / Go2Go / Go2Go v2)
+- useCartGallabox (checkbox)
+- unidadeId (text)
+- statusId (text)
+- productFractionals (textarea, 10 rows)
+
+Props: `{ values, errors, touched, handleChange, handleBlur }`
+
+### PagarMePanel fields (Form/index.js lines ~664–814)
+
+- financial_player_fee (number — "% Taxa")
+- holder_name (text)
+- holder_kind (select: Jurídica / Física)
+- holder_document (text)
+- bank, branch_number, branch_check_digit, account_number, account_check_digit (text)
+- account_type (select: Corrente / Poupança)
+- "Integrar com a Pagar.Me" button
+
+Imports inside PagarMePanel:
+```js
+import { sendLicenseePagarMe } from '../../../../../services/licensee'
+```
+
+Props: `{ values, errors, touched, handleChange, handleBlur }`
+
+### Pedidos10Panel fields (Form/index.js lines ~816–864)
+
+- pedidos10_integrator (select — currently empty options; keep as-is)
+- pedidos10_integration (textarea, 10 rows)
+- "Assinar Webhook P10" button
+
+Imports inside Pedidos10Panel:
+```js
+import { signOrderWebhook } from '../../../../../services/licensee'
+```
+
+Props: `{ values, errors, touched, handleChange, handleBlur }`
+
+The `currentUser.isPedidos10` guard is NOT in this panel — it is handled by the tab shell in task-04.
 
 ## File Ownership
 
 | File | Action | Notes |
 |------|--------|-------|
-| `client/src/pages/Licensees/scenes/Form/panels/AwsPanel.js` | create | New panel component |
-| `client/src/pages/Licensees/scenes/Form/panels/CartPanel.js` | create | New panel component (if cart fields exist) |
-| `client/src/pages/Licensees/scenes/Form/panels/FinancialPanel.js` | create | New panel component (if financial fields exist) |
-| `client/src/pages/Licensees/scenes/Form/panels/OthersPanel.js` | create | Remaining fields not in other panels |
-| `client/src/pages/Licensees/scenes/Form/index.js` | modify | Replace remaining inlined JSX with panel components |
+| `client/src/pages/Licensees/scenes/Form/panels/WhatsAppPanel.js` | create | Manages its own baileysQr/baileysStatus state |
+| `client/src/pages/Licensees/scenes/Form/panels/CartPanel.js` | create | |
+| `client/src/pages/Licensees/scenes/Form/panels/PagarMePanel.js` | create | |
+| `client/src/pages/Licensees/scenes/Form/panels/Pedidos10Panel.js` | create | |
+| `client/src/pages/Licensees/scenes/Form/index.js` | modify | Replace remaining JSX; remove baileysQr state; remove service imports now in panels |
 
 ### Do NOT Modify
 
-- `client/src/pages/Licensees/scenes/Form/panels/GeneralPanel.js` (task-01)
-- `client/src/pages/Licensees/scenes/Form/panels/ChatbotPanel.js` (task-01)
-- `client/src/pages/Licensees/scenes/Form/panels/ChatPanel.js` (task-02)
-- `client/src/pages/Licensees/scenes/Form/panels/WhatsAppPanel.js` (task-02)
+- `panels/MainPanel.js` (task-01)
+- `panels/ChatPanel.js` / `panels/ChatbotPanel.js` (task-02)
 
 ## Conflict Avoidance Notes
 
-Branch from task-02's branch (chained): `git switch plan/licensee-form-wizard/phase-1/task-02-panel-comms && git switch -c plan/licensee-form-wizard/phase-1/task-03-panel-infra`
+Chain from task-02's branch (see Before You Start).
 
 ## Implementation Steps
 
-### Step 1: Identify remaining fields
-Read Form/index.js after task-01 and task-02 changes. List all JSX sections not yet extracted.
+### Step 1: Create WhatsAppPanel.js
 
-### Step 2: Create panel components
-Create one file per logical group. Each component is purely presentational.
-Props: `{ values, errors, touched, handleChange, handleBlur, setFieldValue }` (pass only what's needed).
+- Move `baileysQr`/`baileysStatus` useState here
+- Preserve all conditional rendering logic exactly as it is today
+- Import `setLicenseeWebhook`, `getBaileysQr`, `importLicenseeTemplate` from services
 
-### Step 3: Update Form/index.js
-Replace remaining inlined JSX with the new panel imports. After this task, Form/index.js should render only panel components (no inlined field JSX).
+### Step 2: Create CartPanel.js
+
+Straightforward extraction — no conditionals inside.
+
+### Step 3: Create PagarMePanel.js
+
+Import and use `sendLicenseePagarMe`.
+
+### Step 4: Create Pedidos10Panel.js
+
+Import and use `signOrderWebhook`.
+
+### Step 5: Update Form/index.js
+
+- Replace the 4 extracted JSX blocks with panel imports
+- Remove `baileysQr`, `baileysStatus` state declarations (moved to WhatsAppPanel)
+- Remove service imports that are now owned by panels (`setLicenseeWebhook`, `getBaileysQr`, `importLicenseeTemplate`, `sendLicenseePagarMe`, `signOrderWebhook`)
+- Keep `QRCodeSVG` import removal as well (now in WhatsAppPanel)
+
+After this task, `Form/index.js` renders only: `<MainPanel>`, `<ChatPanel>`, `<ChatbotPanel>`, `<WhatsAppPanel>`, `<CartPanel>`, `<PagarMePanel>`, `<Pedidos10Panel>`.
 
 ## Testing
 
-- [ ] Run `npx jest --testPathPattern=Licensees` — all tests pass
-- [ ] Manual: verify all form fields are still visible and editable
-- [ ] Manual: verify save/update still works
+- [ ] Run `npx jest --testPathPattern=Licensees` — no failures
+- [ ] Manual: verify WhatsApp fields and QR button still work (requires running backend for QR)
+- [ ] Manual: verify Cart, PagarMe, Pedidos10 fields all render and save
 
 ## Documentation / KB Updates
 
@@ -70,7 +141,8 @@ No KB/doc updates required.
 
 ## Completion Criteria
 
-- [ ] All remaining field groups extracted into panel components
-- [ ] `Form/index.js` contains no inlined field JSX — only panel imports and layout
+- [ ] All 4 panel files created under `panels/`
+- [ ] `Form/index.js` renders only panel components (no inline field JSX)
+- [ ] baileysQr/baileysStatus state lives in WhatsAppPanel
 - [ ] All tests pass
 - [ ] `npx eslint .` passes

--- a/.plans/licensee-form-wizard/phase-1/task-03-panel-infra/task.md
+++ b/.plans/licensee-form-wizard/phase-1/task-03-panel-infra/task.md
@@ -1,0 +1,76 @@
+# Task: AwsPanel + CartPanel + FinancialPanel + OthersPanel
+
+**Plan**: Licensee Form Wizard
+**Task ID**: task-03
+**Task Path**: phase-1/task-03-panel-infra
+**Depends On**: phase-1/task-02-panel-comms
+**JIRA**: N/A
+
+## Before You Start
+
+- [ ] Read `client/src/pages/Licensees/scenes/Form/index.js` (after task-01 + task-02 changes) to identify remaining field groups
+- [ ] List all props needed by each panel
+
+## Context
+
+Extract the remaining field groups: AWS S3 configuration, cart/store settings, financial/payment settings, and miscellaneous (Pedidos10, webhooks, etc.).
+
+**AwsPanel** fields: awsDefaultRegion, awsBucketNameFiles, awsBucketNameAudios, awsAccessKeyId, awsSecretAccessKey
+
+**CartPanel** fields: productFractional, productRandomSorting, cartDefault, and any cart-related fields
+
+**FinancialPanel** fields: pagarmeApiKey, billingType, and any payment-related fields
+
+**OthersPanel** fields: pedidos10Token, webhookUrl, sendInactiveMessage, inactiveMessage, and any remaining fields not covered by other panels
+
+> Note: exact field grouping should be confirmed by reading the current Form/index.js. Adjust panel names/groupings as makes sense for the actual fields present.
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `client/src/pages/Licensees/scenes/Form/panels/AwsPanel.js` | create | New panel component |
+| `client/src/pages/Licensees/scenes/Form/panels/CartPanel.js` | create | New panel component (if cart fields exist) |
+| `client/src/pages/Licensees/scenes/Form/panels/FinancialPanel.js` | create | New panel component (if financial fields exist) |
+| `client/src/pages/Licensees/scenes/Form/panels/OthersPanel.js` | create | Remaining fields not in other panels |
+| `client/src/pages/Licensees/scenes/Form/index.js` | modify | Replace remaining inlined JSX with panel components |
+
+### Do NOT Modify
+
+- `client/src/pages/Licensees/scenes/Form/panels/GeneralPanel.js` (task-01)
+- `client/src/pages/Licensees/scenes/Form/panels/ChatbotPanel.js` (task-01)
+- `client/src/pages/Licensees/scenes/Form/panels/ChatPanel.js` (task-02)
+- `client/src/pages/Licensees/scenes/Form/panels/WhatsAppPanel.js` (task-02)
+
+## Conflict Avoidance Notes
+
+Branch from task-02's branch (chained): `git switch plan/licensee-form-wizard/phase-1/task-02-panel-comms && git switch -c plan/licensee-form-wizard/phase-1/task-03-panel-infra`
+
+## Implementation Steps
+
+### Step 1: Identify remaining fields
+Read Form/index.js after task-01 and task-02 changes. List all JSX sections not yet extracted.
+
+### Step 2: Create panel components
+Create one file per logical group. Each component is purely presentational.
+Props: `{ values, errors, touched, handleChange, handleBlur, setFieldValue }` (pass only what's needed).
+
+### Step 3: Update Form/index.js
+Replace remaining inlined JSX with the new panel imports. After this task, Form/index.js should render only panel components (no inlined field JSX).
+
+## Testing
+
+- [ ] Run `npx jest --testPathPattern=Licensees` — all tests pass
+- [ ] Manual: verify all form fields are still visible and editable
+- [ ] Manual: verify save/update still works
+
+## Documentation / KB Updates
+
+No KB/doc updates required.
+
+## Completion Criteria
+
+- [ ] All remaining field groups extracted into panel components
+- [ ] `Form/index.js` contains no inlined field JSX — only panel imports and layout
+- [ ] All tests pass
+- [ ] `npx eslint .` passes

--- a/.plans/licensee-form-wizard/phase-1/task-06-remove-aws/status.md
+++ b/.plans/licensee-form-wizard/phase-1/task-06-remove-aws/status.md
@@ -1,0 +1,25 @@
+# Status: Remove AWS Fields from Licensee — Use Env Vars
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-07
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-07 | not-started | — | Task added based on user requirement to replace per-licensee AWS fields with env vars |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/licensee-form-wizard/phase-1/task-06-remove-aws/task.md
+++ b/.plans/licensee-form-wizard/phase-1/task-06-remove-aws/task.md
@@ -1,0 +1,108 @@
+# Task: Remove AWS Fields from Licensee — Use Env Vars
+
+**Plan**: Licensee Form Wizard
+**Task ID**: task-06
+**Task Path**: phase-1/task-06-remove-aws
+**Depends On**: None
+**JIRA**: N/A
+
+## Before You Start
+
+- [ ] Verify env vars exist in `.env` / Heroku config: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_BUCKET_NAME`
+- [ ] Confirm `Backup.js` and `ClearBackups.js` already use these env vars (they do — verified during planning)
+- [ ] Read `src/app/plugins/storage/S3.js` in full
+
+## Context
+
+`Backup.js` and `ClearBackups.js` already use `process.env.AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_BUCKET_NAME`. Only `S3.js` (per-message file uploads) still reads credentials from the licensee document. Per-licensee AWS credentials create unnecessary config surface and UX complexity. Switch `S3.js` to env vars and remove the three fields from the model.
+
+**Schema change**: `awsId`, `awsSecret`, `bucketName` removed from `Licensee`. Existing documents with these fields will simply have unread values — no migration needed (Mongoose ignores fields not in the schema).
+
+**Frontend removal** of the form fields is handled by `task-01-panel-general` — this task is backend-only.
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/app/plugins/storage/S3.js` | modify | Read credentials from env vars, drop licensee param dependency |
+| `src/app/models/Licensee.js` | modify | Remove `awsId`, `awsSecret`, `bucketName` fields |
+| `src/app/usecases/licensees/CreateLicensee.js` | modify | Remove from allowed-fields list |
+| `src/app/usecases/licensees/UpdateLicensee.js` | modify | Remove from allowed-fields list |
+| `src/app/factories/licensee.js` | modify | Remove `awsId`, `awsSecret`, `bucketName` from factory |
+| `src/app/models/Licensee.spec.js` | modify | Remove/update AWS field assertions |
+| `src/app/queries/LicenseesQuery.spec.js` | modify | Remove/update AWS field assertions if present |
+| `src/app/services/ResetChatbots.spec.js` | modify | Remove AWS fields from factory calls if present |
+
+### Do NOT Modify
+
+- `src/app/services/Backup.js` — already uses env vars, no change
+- `src/app/services/ClearBackups.js` — already uses env vars, no change
+- `client/src/pages/Licensees/scenes/Form/index.js` — owned by task-01
+- Any `panels/` files — owned by task-01/02/03
+
+## Conflict Avoidance Notes
+
+Runs in parallel with task-01, task-02, task-03. No file overlap — backend-only task.
+
+## Implementation Steps
+
+### Step 1: Update S3.js
+
+Replace licensee credential reads with env vars:
+
+```js
+this.aws = new S3Client({
+  region: process.env.AWS_DEFAULT_REGION ?? 'us-east-1',
+  credentials: {
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+  },
+})
+
+this.bucketName = process.env.AWS_BUCKET_NAME
+```
+
+The `licensee` constructor param may still be needed for `this.contact` path logic — keep it if used elsewhere; remove only the credential reads.
+
+### Step 2: Remove fields from Licensee.js model
+
+Remove the three field definitions from the schema:
+- `awsId`
+- `awsSecret`
+- `bucketName`
+
+### Step 3: Remove from CreateLicensee.js and UpdateLicensee.js
+
+Both files have an allowed-fields array. Remove `'awsId'`, `'awsSecret'`, `'bucketName'` from each list.
+
+### Step 4: Update factory and specs
+
+- `factories/licensee.js`: remove the three fields
+- `Licensee.spec.js`: remove assertions that reference these fields
+- `LicenseesQuery.spec.js` and `ResetChatbots.spec.js`: remove any AWS field usage in test setup
+
+### Step 5: Run tests
+
+```bash
+npx jest --testPathPattern="Licensee|S3|ResetChatbot"
+```
+
+## Testing
+
+- [ ] All affected tests pass
+- [ ] `npx jest` full suite passes
+- [ ] `npx eslint .` passes
+- [ ] Manual (if S3 upload path is reachable): verify file upload still works via env vars
+
+## Documentation / KB Updates
+
+No KB/doc updates required — straightforward env var migration following the pattern already established in Backup.js.
+
+## Completion Criteria
+
+- [ ] `S3.js` reads credentials from `process.env.*`
+- [ ] `awsId`, `awsSecret`, `bucketName` removed from Licensee schema
+- [ ] Removed from `CreateLicensee.js` and `UpdateLicensee.js` allowed-fields lists
+- [ ] Factory and specs updated
+- [ ] All tests pass
+- [ ] `npx eslint .` passes

--- a/.plans/licensee-form-wizard/phase-2/task-04-tab-shell/status.md
+++ b/.plans/licensee-form-wizard/phase-2/task-04-tab-shell/status.md
@@ -1,0 +1,25 @@
+# Status: Tab Shell in Form/index.js
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-06
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-06 | not-started | — | Plan created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/licensee-form-wizard/phase-2/task-04-tab-shell/task.md
+++ b/.plans/licensee-form-wizard/phase-2/task-04-tab-shell/task.md
@@ -9,118 +9,230 @@
 ## Before You Start
 
 - [ ] Confirm all Phase 1 tasks are `complete` or `adapted`
-- [ ] Read `Form/index.js` to see the current panel composition
-- [ ] Verify Bootstrap 5 is available (`client/package.json` should have bootstrap 5.x)
-- [ ] Review existing tab logic patterns in the codebase (if any)
+- [ ] Branch from task-03 (or main if all 3 were merged): `git switch plan/licensee-form-wizard/phase-1/task-03-panel-infra && git switch -c plan/licensee-form-wizard/phase-2/task-04-tab-shell`
+- [ ] Read `Form/index.js` — at this point it should only render panel components
 
 ## Context
 
-Add Bootstrap 5 Nav Tabs to `Form/index.js`. Each tab corresponds to a logical panel group. Tabs are shown/hidden via CSS based on `whatsappDefault` and `chatbotDefault` values — panels are **always mounted** so Formik captures all field values on submit.
+Add Bootstrap 5 Nav Tabs to `Form/index.js`. Six conditional tabs controlled by 6 question checkboxes in the MainPanel. All panes always mounted (CSS-driven).
 
-### Tab layout
+### Question state to add in Form/index.js
 
-| Tab Label | Panels | Always Visible? | Condition |
-|-----------|--------|-----------------|-----------|
-| Geral | GeneralPanel | Yes | Always |
-| Chatbot | ChatbotPanel | No | `chatbotDefault !== 'none'` |
-| Chat | ChatPanel | Yes | Always |
-| WhatsApp | WhatsAppPanel | No | `whatsappDefault !== ''` (i.e. any messenger selected) |
-| Infraestrutura | AwsPanel | Yes | Always |
-| Outros | CartPanel + FinancialPanel + OthersPanel | Yes | Always |
-
-> Adjust tab visibility rules as appropriate after reading the actual form logic.
-
-### Key constraint: always-mounted panes
-
-Use Bootstrap's tab CSS classes (`tab-pane`, `show`, `active`) controlled by `activeTab` state. Do NOT use `&&` to conditionally render panels — all panels must remain in the DOM.
-
-```jsx
-// Correct — always mounted, CSS-driven visibility:
-<div className={`tab-pane fade ${activeTab === 'geral' ? 'show active' : ''}`}>
-  <GeneralPanel ... />
-</div>
-
-// Wrong — unmounts on tab switch, Formik loses state:
-{activeTab === 'geral' && <GeneralPanel ... />}
+```js
+const [useChat, setUseChat] = useState(Boolean(initialValues?.chatDefault))
+const [useWhatsapp, setUseWhatsapp] = useState(Boolean(initialValues?.whatsappDefault))
+const [useCart, setUseCart] = useState(Boolean(initialValues?.cartDefault))
+const [usePagarMe, setUsePagarMe] = useState(
+  Boolean(initialValues?.holder_name || initialValues?.financial_player_fee !== '0.00')
+)
 ```
 
-### Tab nav buttons
+Q2 (`useChatbot`) is already a Formik field — use `props.values.useChatbot` directly.
+Q6 (Pedidos10) is `currentUser?.isPedidos10` — no extra state.
 
-Use `type="button"` on all nav buttons to prevent form submission on click:
+### Tab structure
+
+```
+activeTab: 'principal' | 'chat' | 'chatbot' | 'whatsapp' | 'carrinho' | 'pagarme' | 'pedidos10'
+```
+
+Default: `'principal'`
+
+### Nav tabs rendering
+
+Render the nav buttons first. Tab button visibility:
+- Principal: always
+- Chat: always (but only shown/meaningful when `useChat` is true; still show button so user can uncheck from main)
+  → Actually: hide nav button when `!useChat`; auto-switch to `principal` when `useChat` becomes false
+- ChatBot: hide when `!props.values.useChatbot`; auto-switch to `principal` when turned off
+- WhatsApp: hide when `!useWhatsapp`
+- Carrinho: hide when `!useCart`
+- PagarMe: hide when `!usePagarMe`
+- Pedidos10: hide when `!currentUser?.isPedidos10`
+
 ```jsx
-<button type="button" className="nav-link" onClick={() => setActiveTab('geral')}>
-  Geral
+// Nav button (always use type="button"):
+<button
+  type="button"
+  className={`nav-link ${activeTab === 'chat' ? 'active' : ''}`}
+  onClick={() => setActiveTab('chat')}
+>
+  Chat
 </button>
+```
+
+### Pane rendering
+
+All panes always in DOM — CSS drives visibility:
+
+```jsx
+<div className={`tab-pane fade ${activeTab === 'chat' ? 'show active' : ''}`}>
+  <ChatPanel ... />
+</div>
+```
+
+### Auto-switch on question uncheck
+
+Add a `useEffect` for each question:
+```js
+useEffect(() => {
+  if (!useChat && activeTab === 'chat') setActiveTab('principal')
+}, [useChat])
+// similar for useChatbot, useWhatsapp, useCart, usePagarMe
 ```
 
 ## File Ownership
 
 | File | Action | Notes |
 |------|--------|-------|
-| `client/src/pages/Licensees/scenes/Form/index.js` | modify | Add `activeTab` useState, Bootstrap Nav Tabs nav + panes |
+| `client/src/pages/Licensees/scenes/Form/index.js` | modify | Add question state, activeTab state, Bootstrap Nav Tabs layout |
 
 ### Do NOT Modify
 
-- Panel component files (owned by Phase 1 tasks — do not refactor panels during this task)
-
-## Conflict Avoidance Notes
-
-This is the only task in Phase 2 — no parallel conflicts.
+- Any `panels/*.js` files — layout only in this task
 
 ## Implementation Steps
 
-### Step 1: Add activeTab state
-```jsx
-const [activeTab, setActiveTab] = useState('geral')
+### Step 1: Add state to Form/index.js
+
+Inside `LicenseeForm`:
+```js
+const [activeTab, setActiveTab] = useState('principal')
+const [useChat, setUseChat] = useState(Boolean(initialValues?.chatDefault))
+const [useWhatsapp, setUseWhatsapp] = useState(Boolean(initialValues?.whatsappDefault))
+const [useCart, setUseCart] = useState(Boolean(initialValues?.cartDefault))
+const [usePagarMe, setUsePagarMe] = useState(
+  Boolean(initialValues?.holder_name || (initialValues?.financial_player_fee && initialValues?.financial_player_fee !== '0.00'))
+)
 ```
 
-### Step 2: Add Bootstrap Nav Tabs nav
-Inside the form, before the field content, add:
+### Step 2: Add useEffect auto-switches
+
+```js
+useEffect(() => { if (!useChat && activeTab === 'chat') setActiveTab('principal') }, [useChat])
+useEffect(() => { if (!props.values.useChatbot && activeTab === 'chatbot') setActiveTab('principal') }, [props.values.useChatbot])
+useEffect(() => { if (!useWhatsapp && activeTab === 'whatsapp') setActiveTab('principal') }, [useWhatsapp])
+useEffect(() => { if (!useCart && activeTab === 'carrinho') setActiveTab('principal') }, [useCart])
+useEffect(() => { if (!usePagarMe && activeTab === 'pagarme') setActiveTab('principal') }, [usePagarMe])
+```
+
+Note: these effects must be inside the Formik render function where `props` is available, or extracted to a child component.
+
+### Step 3: Wrap form content in Bootstrap Nav Tabs
+
 ```jsx
 <ul className="nav nav-tabs mb-3">
   <li className="nav-item">
-    <button type="button" className={`nav-link ${activeTab === 'geral' ? 'active' : ''}`} onClick={() => setActiveTab('geral')}>
-      Geral
+    <button type="button" className={`nav-link ${activeTab === 'principal' ? 'active' : ''}`} onClick={() => setActiveTab('principal')}>
+      Principal
     </button>
   </li>
-  {/* ... other tabs, conditionally rendered based on form values */}
+  {useChat && (
+    <li className="nav-item">
+      <button type="button" className={`nav-link ${activeTab === 'chat' ? 'active' : ''}`} onClick={() => setActiveTab('chat')}>
+        Chat
+      </button>
+    </li>
+  )}
+  {props.values.useChatbot && (
+    <li className="nav-item">
+      <button type="button" className={`nav-link ${activeTab === 'chatbot' ? 'active' : ''}`} onClick={() => setActiveTab('chatbot')}>
+        ChatBot
+      </button>
+    </li>
+  )}
+  {useWhatsapp && (
+    <li className="nav-item">
+      <button type="button" className={`nav-link ${activeTab === 'whatsapp' ? 'active' : ''}`} onClick={() => setActiveTab('whatsapp')}>
+        WhatsApp
+      </button>
+    </li>
+  )}
+  {useCart && (
+    <li className="nav-item">
+      <button type="button" className={`nav-link ${activeTab === 'carrinho' ? 'active' : ''}`} onClick={() => setActiveTab('carrinho')}>
+        Carrinho de Compras
+      </button>
+    </li>
+  )}
+  {usePagarMe && (
+    <li className="nav-item">
+      <button type="button" className={`nav-link ${activeTab === 'pagarme' ? 'active' : ''}`} onClick={() => setActiveTab('pagarme')}>
+        PagarMe
+      </button>
+    </li>
+  )}
+  {currentUser?.isPedidos10 && (
+    <li className="nav-item">
+      <button type="button" className={`nav-link ${activeTab === 'pedidos10' ? 'active' : ''}`} onClick={() => setActiveTab('pedidos10')}>
+        Pedidos10
+      </button>
+    </li>
+  )}
 </ul>
-```
 
-Tab nav items for conditional tabs (`chatbot`, `whatsapp`) should only render the **button** when the condition is met, but the **pane** should always be in the DOM.
-
-### Step 3: Wrap panels in tab panes
-```jsx
 <div className="tab-content">
-  <div className={`tab-pane fade ${activeTab === 'geral' ? 'show active' : ''}`}>
-    <GeneralPanel ... />
+  <div className={`tab-pane fade ${activeTab === 'principal' ? 'show active' : ''}`}>
+    <MainPanel
+      values={props.values}
+      errors={errors}
+      touched={props.touched}
+      handleChange={props.handleChange}
+      handleBlur={props.handleBlur}
+      setFieldValue={props.setFieldValue}
+      currentUser={currentUser}
+      useChat={useChat} setUseChat={setUseChat}
+      useWhatsapp={useWhatsapp} setUseWhatsapp={setUseWhatsapp}
+      useCart={useCart} setUseCart={setUseCart}
+      usePagarMe={usePagarMe} setUsePagarMe={setUsePagarMe}
+    />
   </div>
-  {/* ... */}
+  <div className={`tab-pane fade ${activeTab === 'chat' ? 'show active' : ''}`}>
+    <ChatPanel values={props.values} errors={errors} touched={props.touched} handleChange={props.handleChange} handleBlur={props.handleBlur} />
+  </div>
+  <div className={`tab-pane fade ${activeTab === 'chatbot' ? 'show active' : ''}`}>
+    <ChatbotPanel values={props.values} errors={errors} touched={props.touched} handleChange={props.handleChange} handleBlur={props.handleBlur} />
+  </div>
+  <div className={`tab-pane fade ${activeTab === 'whatsapp' ? 'show active' : ''}`}>
+    <WhatsAppPanel values={props.values} errors={errors} touched={props.touched} handleChange={props.handleChange} handleBlur={props.handleBlur} />
+  </div>
+  <div className={`tab-pane fade ${activeTab === 'carrinho' ? 'show active' : ''}`}>
+    <CartPanel values={props.values} errors={errors} touched={props.touched} handleChange={props.handleChange} handleBlur={props.handleBlur} />
+  </div>
+  <div className={`tab-pane fade ${activeTab === 'pagarme' ? 'show active' : ''}`}>
+    <PagarMePanel values={props.values} errors={errors} touched={props.touched} handleChange={props.handleChange} handleBlur={props.handleBlur} />
+  </div>
+  <div className={`tab-pane fade ${activeTab === 'pedidos10' ? 'show active' : ''}`}>
+    <Pedidos10Panel values={props.values} errors={errors} touched={props.touched} handleChange={props.handleChange} handleBlur={props.handleBlur} />
+  </div>
 </div>
 ```
 
-### Step 4: Auto-switch on value change
-When `whatsappDefault` changes to a value that hides the WhatsApp tab, auto-switch to 'geral' if the user is on the now-hidden tab. Use a `useEffect` watching `values.whatsappDefault` and `values.chatbotDefault`.
+### Step 4: Pass question props to MainPanel
+
+MainPanel renders the 6 questions as checkboxes. Each checkbox's `onChange` updates the local state and resets the field value when unchecked (as specified in task-01).
 
 ## Testing
 
-- [ ] Manual: switch between all tabs — verify correct panels shown
-- [ ] Manual: fill a field on tab A, switch to tab B, submit — verify field A value is saved
-- [ ] Manual: select `baileys` for whatsappDefault — verify WhatsApp tab appears and QR generation works
-- [ ] Manual: set `chatbotDefault` to 'none' — verify Chatbot tab disappears (or hides)
+- [ ] Manual: open Create Licensee — verify only "Principal" tab shown; all 6 questions unchecked
+- [ ] Manual: check "Integração com Plataforma de Chat?" → Chat tab appears; click it → Chat fields visible
+- [ ] Manual: fill a chatbot field, switch tabs, submit → chatbot value saved
+- [ ] Manual: open Edit Licensee that has chatDefault set → Chat tab visible on load
+- [ ] Manual: uncheck a question while on that tab → auto-switch to Principal
+- [ ] Manual: Baileys QR generation works on WhatsApp tab
 - [ ] Run `npx jest --testPathPattern=Licensees` — all tests pass
 
 ## Documentation / KB Updates
 
-If the tab/wizard pattern is non-obvious for future contributors, run `document-solution` after completion to capture the always-mounted panel constraint.
+After completion, run `document-solution` to capture the always-mounted pane pattern for future contributors.
 
 ## Completion Criteria
 
-- [ ] Bootstrap Nav Tabs rendered in Form/index.js
-- [ ] Active tab controlled by `activeTab` useState
-- [ ] Tab visibility driven by form values
-- [ ] All panels always mounted (no `&&` conditional rendering of panels)
-- [ ] Tab nav buttons have `type="button"`
-- [ ] QR code generation still works on WhatsApp tab
+- [ ] Bootstrap Nav Tabs rendered; `activeTab` state drives active pane
+- [ ] Nav tab buttons appear/disappear based on question checkboxes
+- [ ] All panes always mounted — no `&&` on pane content
+- [ ] Auto-switch to Principal when question is unchecked
+- [ ] Edit licensee loads correct tab visibility from initialValues
+- [ ] Submit saves all field values regardless of active tab
 - [ ] All tests pass
 - [ ] `npx eslint .` passes

--- a/.plans/licensee-form-wizard/phase-2/task-04-tab-shell/task.md
+++ b/.plans/licensee-form-wizard/phase-2/task-04-tab-shell/task.md
@@ -1,0 +1,126 @@
+# Task: Tab Shell in Form/index.js
+
+**Plan**: Licensee Form Wizard
+**Task ID**: task-04
+**Task Path**: phase-2/task-04-tab-shell
+**Depends On**: phase-1/task-01-panel-general, phase-1/task-02-panel-comms, phase-1/task-03-panel-infra
+**JIRA**: N/A
+
+## Before You Start
+
+- [ ] Confirm all Phase 1 tasks are `complete` or `adapted`
+- [ ] Read `Form/index.js` to see the current panel composition
+- [ ] Verify Bootstrap 5 is available (`client/package.json` should have bootstrap 5.x)
+- [ ] Review existing tab logic patterns in the codebase (if any)
+
+## Context
+
+Add Bootstrap 5 Nav Tabs to `Form/index.js`. Each tab corresponds to a logical panel group. Tabs are shown/hidden via CSS based on `whatsappDefault` and `chatbotDefault` values — panels are **always mounted** so Formik captures all field values on submit.
+
+### Tab layout
+
+| Tab Label | Panels | Always Visible? | Condition |
+|-----------|--------|-----------------|-----------|
+| Geral | GeneralPanel | Yes | Always |
+| Chatbot | ChatbotPanel | No | `chatbotDefault !== 'none'` |
+| Chat | ChatPanel | Yes | Always |
+| WhatsApp | WhatsAppPanel | No | `whatsappDefault !== ''` (i.e. any messenger selected) |
+| Infraestrutura | AwsPanel | Yes | Always |
+| Outros | CartPanel + FinancialPanel + OthersPanel | Yes | Always |
+
+> Adjust tab visibility rules as appropriate after reading the actual form logic.
+
+### Key constraint: always-mounted panes
+
+Use Bootstrap's tab CSS classes (`tab-pane`, `show`, `active`) controlled by `activeTab` state. Do NOT use `&&` to conditionally render panels — all panels must remain in the DOM.
+
+```jsx
+// Correct — always mounted, CSS-driven visibility:
+<div className={`tab-pane fade ${activeTab === 'geral' ? 'show active' : ''}`}>
+  <GeneralPanel ... />
+</div>
+
+// Wrong — unmounts on tab switch, Formik loses state:
+{activeTab === 'geral' && <GeneralPanel ... />}
+```
+
+### Tab nav buttons
+
+Use `type="button"` on all nav buttons to prevent form submission on click:
+```jsx
+<button type="button" className="nav-link" onClick={() => setActiveTab('geral')}>
+  Geral
+</button>
+```
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `client/src/pages/Licensees/scenes/Form/index.js` | modify | Add `activeTab` useState, Bootstrap Nav Tabs nav + panes |
+
+### Do NOT Modify
+
+- Panel component files (owned by Phase 1 tasks — do not refactor panels during this task)
+
+## Conflict Avoidance Notes
+
+This is the only task in Phase 2 — no parallel conflicts.
+
+## Implementation Steps
+
+### Step 1: Add activeTab state
+```jsx
+const [activeTab, setActiveTab] = useState('geral')
+```
+
+### Step 2: Add Bootstrap Nav Tabs nav
+Inside the form, before the field content, add:
+```jsx
+<ul className="nav nav-tabs mb-3">
+  <li className="nav-item">
+    <button type="button" className={`nav-link ${activeTab === 'geral' ? 'active' : ''}`} onClick={() => setActiveTab('geral')}>
+      Geral
+    </button>
+  </li>
+  {/* ... other tabs, conditionally rendered based on form values */}
+</ul>
+```
+
+Tab nav items for conditional tabs (`chatbot`, `whatsapp`) should only render the **button** when the condition is met, but the **pane** should always be in the DOM.
+
+### Step 3: Wrap panels in tab panes
+```jsx
+<div className="tab-content">
+  <div className={`tab-pane fade ${activeTab === 'geral' ? 'show active' : ''}`}>
+    <GeneralPanel ... />
+  </div>
+  {/* ... */}
+</div>
+```
+
+### Step 4: Auto-switch on value change
+When `whatsappDefault` changes to a value that hides the WhatsApp tab, auto-switch to 'geral' if the user is on the now-hidden tab. Use a `useEffect` watching `values.whatsappDefault` and `values.chatbotDefault`.
+
+## Testing
+
+- [ ] Manual: switch between all tabs — verify correct panels shown
+- [ ] Manual: fill a field on tab A, switch to tab B, submit — verify field A value is saved
+- [ ] Manual: select `baileys` for whatsappDefault — verify WhatsApp tab appears and QR generation works
+- [ ] Manual: set `chatbotDefault` to 'none' — verify Chatbot tab disappears (or hides)
+- [ ] Run `npx jest --testPathPattern=Licensees` — all tests pass
+
+## Documentation / KB Updates
+
+If the tab/wizard pattern is non-obvious for future contributors, run `document-solution` after completion to capture the always-mounted panel constraint.
+
+## Completion Criteria
+
+- [ ] Bootstrap Nav Tabs rendered in Form/index.js
+- [ ] Active tab controlled by `activeTab` useState
+- [ ] Tab visibility driven by form values
+- [ ] All panels always mounted (no `&&` conditional rendering of panels)
+- [ ] Tab nav buttons have `type="button"`
+- [ ] QR code generation still works on WhatsApp tab
+- [ ] All tests pass
+- [ ] `npx eslint .` passes

--- a/.plans/licensee-form-wizard/phase-3/task-05-tests/status.md
+++ b/.plans/licensee-form-wizard/phase-3/task-05-tests/status.md
@@ -1,0 +1,25 @@
+# Status: Vitest — Update Licensee Form Tests
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-06
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-06 | not-started | — | Plan created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/licensee-form-wizard/phase-3/task-05-tests/task.md
+++ b/.plans/licensee-form-wizard/phase-3/task-05-tests/task.md
@@ -1,0 +1,71 @@
+# Task: Vitest — Update Licensee Form Tests
+
+**Plan**: Licensee Form Wizard
+**Task ID**: task-05
+**Task Path**: phase-3/task-05-tests
+**Depends On**: phase-2/task-04-tab-shell
+**JIRA**: N/A
+
+## Before You Start
+
+- [ ] Confirm task-04 is `complete` or `adapted`
+- [ ] Run existing tests to establish baseline: `npx jest --testPathPattern=Licensees`
+- [ ] Read existing test files for the Licensees form to understand current assertions
+
+## Context
+
+After the tab shell is in place, some existing tests may need selector or structure updates. This task audits the current test coverage, updates failing assertions, and adds any new tests for tab-switching behavior.
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `client/src/pages/Licensees/**/*.spec.js` (or `.test.js`) | modify | Update selectors and add tab tests |
+| `client/src/pages/Licensees/**/*.spec.jsx` (or `.test.jsx`) | modify | If JSX test files exist |
+
+### Do NOT Modify
+
+- Panel component files (owned by Phase 1)
+- `Form/index.js` — test-only task
+
+## Conflict Avoidance Notes
+
+Only task in Phase 3 — no parallel conflicts.
+
+## Implementation Steps
+
+### Step 1: Run existing tests and capture failures
+```bash
+npx jest --testPathPattern=Licensees --verbose 2>&1 | head -100
+```
+
+### Step 2: Fix broken selectors
+Tests that previously queried fields by label or placeholder directly on the form page may need updating if the tab structure changes DOM nesting. Update selectors to match the new structure.
+
+### Step 3: Add tab-switching tests (if worthwhile)
+If the tests use a component renderer (e.g. @testing-library/react), add tests for:
+- Default active tab is 'Geral'
+- Clicking a tab activates it
+- Selecting 'baileys' as whatsappDefault shows the WhatsApp tab nav item
+
+### Step 4: Verify all tests pass
+```bash
+npx jest --testPathPattern=Licensees
+```
+
+## Testing
+
+- [ ] All existing Licensees tests pass
+- [ ] Any new tab-behavior tests added and passing
+- [ ] `npx eslint .` passes
+
+## Documentation / KB Updates
+
+No KB/doc updates required unless new non-obvious patterns were introduced.
+
+## Completion Criteria
+
+- [ ] All Licensees tests pass (including any new tab tests)
+- [ ] No skipped or xfailed tests introduced
+- [ ] `npx eslint .` passes
+- [ ] Status updated in status.md


### PR DESCRIPTION
## Summary

- Adds the `licensee-form-wizard` plan: split the ~960-line licensee form into Bootstrap 5 Nav Tabs driven by 6 integration questions in the main tab
- Plan refined against actual `Form/index.js` field groups and user-specified wizard rules
- Adds `task-06` to remove per-licensee AWS fields (`awsId`, `awsSecret`, `bucketName`) from the Licensee model and migrate `S3.js` to use env vars (matching `Backup.js` / `ClearBackups.js` pattern)

## Plan Structure (3 phases, 6 tasks)

| Task | Description |
|------|-------------|
| phase-1/task-01 | MainPanel — identity fields + 6 question checkboxes |
| phase-1/task-02 | ChatPanel + ChatbotPanel |
| phase-1/task-03 | WhatsAppPanel + CartPanel + PagarMePanel + Pedidos10Panel |
| phase-1/task-06 | Remove AWS fields from Licensee model; S3.js → env vars |
| phase-2/task-04 | Tab shell — Bootstrap Nav Tabs, question state, auto-switch effects |
| phase-3/task-05 | Update Vitest tests |

## Key Design Decisions

- Q1/Q3/Q4/Q5 are local `useState` in `Form/index.js`, initialised from existing field values (e.g. `chatDefault !== ''`) — no new model fields
- Q2 uses existing `useChatbot` Formik field; Q6 uses `currentUser.isPedidos10`
- All tab panes always mounted (CSS `show active`) — Formik captures all values on submit regardless of active tab
- Nav buttons use `type="button"` to prevent form submission

## Test plan

- [ ] Plan files only — no runnable code changes in this PR
- [ ] Execution starts with `/execute-task licensee-form-wizard/phase-1/task-01-panel-general`