### PR TITLE
plan(dashboard-widgets): role-aware dashboard widgets

### DIFF
--- a/.plans/README.md
+++ b/.plans/README.md
@@ -24,6 +24,7 @@ Git-native Markdown plans for multi-step work.
 |---|------|--------|--------|-------------|
 | 1 | [JS → TypeScript](./js-to-ts/overview.md) | `js-to-ts/` | not-started | Incremental migration of all source files (backend + client) to TypeScript using `allowJs: true` throughout |
 | 2 | [Remove PDV](./remove-pdv/overview.md) | `remove-pdv/` | not-started | Delete cart, payment (PagarMe), and order integration (Pedidos10) domain — strip PDV fields from Licensee and Contact |
+| 3 | [Dashboard Widgets](./dashboard-widgets/overview.md) | `dashboard-widgets/` | not-started | Add four REST-fed stat widgets to the empty Dashboard page (active licensees, plan breakdown, messages today, messages per day) |
 
 ---
 

--- a/.plans/README.md
+++ b/.plans/README.md
@@ -24,7 +24,6 @@ Git-native Markdown plans for multi-step work.
 |---|------|--------|--------|-------------|
 | 1 | [JS → TypeScript](./js-to-ts/overview.md) | `js-to-ts/` | not-started | Incremental migration of all source files (backend + client) to TypeScript using `allowJs: true` throughout |
 | 2 | [Remove PDV](./remove-pdv/overview.md) | `remove-pdv/` | not-started | Delete cart, payment (PagarMe), and order integration (Pedidos10) domain — strip PDV fields from Licensee and Contact |
-| 3 | [Dashboard Widgets](./dashboard-widgets/overview.md) | `dashboard-widgets/` | not-started | Add four REST-fed stat widgets to the empty Dashboard page (active licensees, plan breakdown, messages today, messages per day) |
 
 ---
 
@@ -36,6 +35,7 @@ Git-native Markdown plans for multi-step work.
 | 2 | [Baileys WhatsApp Plugin](./baileys-plugin/overview.md) | `baileys-plugin/` | 2026-05-05 | Add Baileys-based WhatsApp messenger plugin with session persistence (WhatsappSession model), following the Dialog plugin architecture |
 | 3 | [Licensee Form Wizard](./licensee-form-wizard/overview.md) | `licensee-form-wizard/` | 2026-05-07 | Split the licensee form into Bootstrap 5 Nav Tabs with panels shown/hidden based on question checkboxes; removed per-licensee AWS fields |
 | 4 | [Licensee Create Wizard](./licensee-wizard/overview.md) | `licensee-wizard/` | 2026-05-07 | Multi-step wizard for New Licensee (7 steps, Yes/No gates); removed question checkboxes from Edit form |
+| 5 | [Dashboard Widgets](./dashboard-widgets/overview.md) | `dashboard-widgets/` | 2026-05-07 | Role-aware dashboard: 5 super cards + 3 licensee cards, per-card REST endpoints, Redis caching, resend modal |
 
 ---
 

--- a/.plans/dashboard-widgets/overview.md
+++ b/.plans/dashboard-widgets/overview.md
@@ -1,6 +1,6 @@
 # Plan: Dashboard Widgets
 
-**Status**: not-started
+**Status**: complete
 **Created**: 2026-05-07
 **Last Updated**: 2026-05-07
 **Estimated Demo Date**: N/A

--- a/.plans/dashboard-widgets/overview.md
+++ b/.plans/dashboard-widgets/overview.md
@@ -1,0 +1,155 @@
+# Plan: Dashboard Widgets
+
+**Status**: not-started
+**Created**: 2026-05-07
+**Last Updated**: 2026-05-07
+**Estimated Demo Date**: N/A
+**Assigned Dev**: Alan Costa Facchini
+**Assigned QA**: unassigned
+**Master Plan**: None
+
+## Objective
+
+Replace the empty `Dashboard` stub with role-aware stat widgets fetched via REST. Super users see platform-wide operational metrics with a clickable failed-messages resend flow; licensee-linked users see their own scoped data.
+
+## User Kinds
+
+| Kind | Condition | Dashboard focus |
+|------|-----------|-----------------|
+| **Super** | `isSuper: true`, no `licensee` ref | Platform-wide: licensees, message volume, delivery rate, queue health, conversations |
+| **Licensee** | `isSuper: false`, has `licensee` ref | Scoped: their contacts + messages |
+
+## API Contract
+
+### `GET /resources/dashboard/stats`
+
+**Super user response:**
+```json
+{
+  "kind": "super",
+  "licensees": {
+    "total": 15, "active": 12,
+    "by_kind": { "demo": 3, "free": 5, "paid": 7 }
+  },
+  "message_volume": {
+    "per_day": [{ "date": "2026-05-01", "count": 150 }],
+    "per_hour": [{ "hour": "2026-05-07T14", "count": 45 }],
+    "peak_throughput": 87,
+    "avg_transfer_rate": 12.5
+  },
+  "delivery_rate": {
+    "sent_today": 423, "failed_today": 5,
+    "sent_pct": 98.8, "failed_pct": 1.2
+  },
+  "queue": {
+    "pending_messages": 12,
+    "avg_time_in_queue_seconds": 4.2
+  },
+  "conversations": {
+    "started_today": 34, "ended_today": 28,
+    "avg_messages_per_conversation": 6.3,
+    "avg_duration_seconds": 182.4
+  }
+}
+```
+
+**Licensee user response:**
+```json
+{
+  "kind": "licensee",
+  "contacts": { "total": 89, "in_chatbot": 12 },
+  "messages": {
+    "sent_today": 45, "failed_today": 2,
+    "per_day": [{ "date": "2026-05-01", "count": 38 }]
+  }
+}
+```
+
+### `POST /resources/messages/:id/resend`
+
+Resets message state (`sended: false`, `error: null`, `sendedAt: null`) and re-adds to Bull queue (`send-message-to-messenger`).
+Returns 200 with updated message, 403 if licensee user attempts to resend another licensee's message, 404 if not found.
+
+## Scope
+
+### In Scope
+- Room schema: `closedAt: Date` field + update 5 close sites across 3 plugin files
+- `GET /resources/dashboard/stats` — single endpoint, role-branched
+- `POST /resources/messages/:id/resend` — resets and re-queues failed message
+- Super widgets: licensees, message volume (day/hour/peak/rate), delivery rate (counts+%), queue (pending+avgTime), conversations (started/ended/avgMsgs/avgDuration)
+- Licensee widgets: contacts, messages today, messages per day
+- Clickable failed-messages card → Bootstrap modal with per-row resend buttons
+
+### Out of Scope
+- Socket.IO / real-time push — REST only (decided 2026-05-07)
+- Queue size, Consumer delay — dropped (decided 2026-05-07)
+- Tier 2 / Tier 3 widgets (carts, orders, revenue) — follow-on
+- Charts library — plain Bootstrap cards + tables only
+
+## Phases
+
+| Phase | Name | Tasks | Dependencies | Description |
+|-------|------|-------|--------------|-------------|
+| 1 | Schema | task-01 | None | Add `closedAt` to Room + update close logic in plugins |
+| 2 | Backend | task-02 | Phase 1 | DashboardController + resend endpoint + specs |
+| 3 | Frontend | task-03 | Phase 2 | Dashboard page + resend modal |
+
+## Task Summary
+
+| Task Path | Title | Phase | Status | Depends On |
+|-----------|-------|-------|--------|------------|
+| phase-1/task-01-room-schema | Room schema — closedAt field | 1 | not-started | — |
+| phase-2/task-02-backend | Backend — DashboardController + resend endpoint | 2 | not-started | phase-1/task-01-room-schema |
+| phase-3/task-03-frontend | Frontend dashboard widgets + resend modal | 3 | not-started | phase-2/task-02-backend |
+
+## Branch Convention
+
+Pattern: `plan/dashboard-widgets/{task-path}`
+
+Branches:
+- `plan/dashboard-widgets/phase-1/task-01-room-schema`
+- `plan/dashboard-widgets/phase-2/task-02-backend`
+- `plan/dashboard-widgets/phase-3/task-03-frontend`
+
+Base branch: `main`
+
+## Key Files
+
+| File/Directory | Relevance |
+|----------------|-----------|
+| `src/app/models/Room.js` | Add `closedAt: Date` (Phase 1) |
+| `src/app/plugins/chats/Rocketchat.js` | 2 close sites (Phase 1) |
+| `src/app/plugins/chats/Chatwoot.js` | 2 close sites (Phase 1) |
+| `src/app/plugins/chatbots/Landbot.js` | 1 close site (Phase 1) |
+| `src/app/controllers/DashboardController.js` | New controller (Phase 2) |
+| `src/app/controllers/MessagesController.js` | Add resend action (Phase 2) |
+| `src/app/routes/resources-routes.js` | Register both routes (Phase 2) |
+| `client/src/pages/Dashboard/index.js` | Implement widgets + modal (Phase 3) |
+| `client/src/services/dashboard.js` | New service (Phase 3) |
+| `client/src/services/message.js` | Add resendMessage (Phase 3) |
+
+## Risks
+
+- JWT payload only contains `user._id` — one extra DB read per stats call.
+- `avg_transfer_rate` = `total messages / 24` — messages-per-hour average, not byte rate.
+- `ended_today` uses `closedAt` (accurate after Phase 1); existing rooms closed before Phase 1 ships will not have `closedAt` set.
+- `avg_time_in_queue_seconds` excludes messages where `sendedAt` was never set (permanently failed).
+- Resend resets `sended`, `error`, and `sendedAt` — if the messenger plugin is offline the message will fail again silently; acceptable for now.
+
+## Success Criteria
+
+- [ ] Super user sees all 5 widget sections with real data
+- [ ] Licensee user sees 3 scoped widget cards
+- [ ] Failed stat in Delivery Rate card opens modal with resend buttons
+- [ ] Successful resend removes the row and decrements the failed count in the card
+- [ ] `avg_duration_seconds` uses `closedAt`, not `updatedAt`
+- [ ] Resend returns 403 for cross-licensee attempts
+- [ ] All existing tests pass (`npx jest`)
+- [ ] `npx eslint .` reports no new errors
+
+## References
+
+- **JIRA Epic**: N/A
+- **Weekly Plan Brief**: N/A
+- **Related Plans**: remove-pdv (may touch Message/Room models — coordinate if running in parallel)
+- **Rock Alignment**: N/A

--- a/.plans/dashboard-widgets/overview.md
+++ b/.plans/dashboard-widgets/overview.md
@@ -10,79 +10,118 @@
 
 ## Objective
 
-Replace the empty `Dashboard` stub with role-aware stat widgets fetched via REST. Super users see platform-wide operational metrics with a clickable failed-messages resend flow; licensee-linked users see their own scoped data.
+Replace the empty `Dashboard` stub with role-aware stat widgets. Each card is self-contained — it fires its own independent REST request and has its own loading/error state. All responses are cached in Redis for 10 minutes to avoid slow repeated aggregations.
 
 ## User Kinds
 
-| Kind | Condition | Dashboard focus |
-|------|-----------|-----------------|
-| **Super** | `isSuper: true`, no `licensee` ref | Platform-wide: licensees, message volume, delivery rate, queue health, conversations |
-| **Licensee** | `isSuper: false`, has `licensee` ref | Scoped: their contacts + messages |
+| Kind | Condition | Cards |
+|------|-----------|-------|
+| **Super** | `isSuper: true`, no `licensee` ref | 5 cards — platform-wide metrics |
+| **Licensee** | `isSuper: false`, has `licensee` ref | 3 cards — scoped to their licensee |
 
 ## API Contract
 
-### `GET /resources/dashboard/stats`
+One endpoint per card. All under `/resources/dashboard/`. The controller resolves user kind from `req.userId` on every request and gates access accordingly (403 if wrong kind).
 
-**Super user response:**
+### Super endpoints (5)
+
+| Endpoint | Card | Cache key |
+|----------|------|-----------|
+| `GET /resources/dashboard/licensees` | Licenciados | `dashboard:super:licensees` |
+| `GET /resources/dashboard/message-volume` | Volume de Mensagens | `dashboard:super:message-volume` |
+| `GET /resources/dashboard/delivery-rate` | Taxa de Entrega | `dashboard:super:delivery-rate` |
+| `GET /resources/dashboard/queue` | Fila | `dashboard:super:queue` |
+| `GET /resources/dashboard/conversations` | Conversas | `dashboard:super:conversations` |
+
+### Licensee endpoints (3)
+
+| Endpoint | Card | Cache key |
+|----------|------|-----------|
+| `GET /resources/dashboard/contacts` | Contatos | `dashboard:licensee:{licenseeId}:contacts` |
+| `GET /resources/dashboard/messages-today` | Mensagens Hoje | `dashboard:licensee:{licenseeId}:messages-today` |
+| `GET /resources/dashboard/messages-per-day` | Mensagens por Dia | `dashboard:licensee:{licenseeId}:messages-per-day` |
+
+### Response shapes
+
+**`/licensees`**
+```json
+{ "total": 15, "active": 12, "by_kind": { "demo": 3, "free": 5, "paid": 7 } }
+```
+
+**`/message-volume`**
 ```json
 {
-  "kind": "super",
-  "licensees": {
-    "total": 15, "active": 12,
-    "by_kind": { "demo": 3, "free": 5, "paid": 7 }
-  },
-  "message_volume": {
-    "per_day": [{ "date": "2026-05-01", "count": 150 }],
-    "per_hour": [{ "hour": "2026-05-07T14", "count": 45 }],
-    "peak_throughput": 87,
-    "avg_transfer_rate": 12.5
-  },
-  "delivery_rate": {
-    "sent_today": 423, "failed_today": 5,
-    "sent_pct": 98.8, "failed_pct": 1.2
-  },
-  "queue": {
-    "pending_messages": 12,
-    "avg_time_in_queue_seconds": 4.2
-  },
-  "conversations": {
-    "started_today": 34, "ended_today": 28,
-    "avg_messages_per_conversation": 6.3,
-    "avg_duration_seconds": 182.4
-  }
+  "per_day": [{ "date": "2026-05-01", "count": 150 }],
+  "per_hour": [{ "hour": "2026-05-07T14", "count": 45 }],
+  "peak_throughput": 87,
+  "avg_transfer_rate": 12.5
 }
 ```
 
-**Licensee user response:**
+**`/delivery-rate`**
+```json
+{ "sent_today": 423, "failed_today": 5, "sent_pct": 98.8, "failed_pct": 1.2 }
+```
+
+**`/queue`**
+```json
+{ "pending_messages": 12, "avg_time_in_queue_seconds": 4.2 }
+```
+
+**`/conversations`**
 ```json
 {
-  "kind": "licensee",
-  "contacts": { "total": 89, "in_chatbot": 12 },
-  "messages": {
-    "sent_today": 45, "failed_today": 2,
-    "per_day": [{ "date": "2026-05-01", "count": 38 }]
-  }
+  "started_today": 34, "ended_today": 28,
+  "avg_messages_per_conversation": 6.3, "avg_duration_seconds": 182.4
 }
+```
+
+**`/contacts`**
+```json
+{ "total": 89, "in_chatbot": 12 }
+```
+
+**`/messages-today`**
+```json
+{ "sent_today": 45, "failed_today": 2, "sent_pct": 97.8, "failed_pct": 2.2 }
+```
+
+**`/messages-per-day`**
+```json
+{ "per_day": [{ "date": "2026-05-01", "count": 38 }] }
 ```
 
 ### `POST /resources/messages/:id/resend`
 
-Resets message state (`sended: false`, `error: null`, `sendedAt: null`) and re-adds to Bull queue (`send-message-to-messenger`).
-Returns 200 with updated message, 403 if licensee user attempts to resend another licensee's message, 404 if not found.
+Resets message state (`sended: false`, `error: null`, `sendedAt: null`) and re-adds to Bull queue (`send-message-to-messenger`). Returns 200 with updated message, 403 for cross-licensee attempts, 404 if not found.
+
+## Caching
+
+- **Store**: Redis (`redisConnection` from `src/config/redis.js`)
+- **TTL**: 600 seconds (10 minutes)
+- **Pattern** (used in every dashboard action):
+  ```js
+  const cached = await redisConnection.get(cacheKey)
+  if (cached) return res.status(200).json(JSON.parse(cached))
+  // compute...
+  await redisConnection.setex(cacheKey, 600, JSON.stringify(data))
+  return res.status(200).json(data)
+  ```
+- Super keys are **global** (same data for all super users)
+- Licensee keys are **scoped** by `licenseeId`
 
 ## Scope
 
 ### In Scope
-- Room schema: `closedAt: Date` field + update 5 close sites across 3 plugin files
-- `GET /resources/dashboard/stats` — single endpoint, role-branched
-- `POST /resources/messages/:id/resend` — resets and re-queues failed message
-- Super widgets: licensees, message volume (day/hour/peak/rate), delivery rate (counts+%), queue (pending+avgTime), conversations (started/ended/avgMsgs/avgDuration)
-- Licensee widgets: contacts, messages today, messages per day
-- Clickable failed-messages card → Bootstrap modal with per-row resend buttons
+- Room schema: `closedAt: Date` + update 5 close sites
+- 8 dashboard endpoints + 1 resend endpoint, all in `DashboardController`
+- Redis caching (10 min TTL) on all dashboard endpoints
+- Frontend: 5 or 3 independent card components (based on user kind), each with own fetch + loading + error state
+- Clickable failed-count → Bootstrap modal with resend buttons
 
 ### Out of Scope
-- Socket.IO / real-time push — REST only (decided 2026-05-07)
-- Queue size, Consumer delay — dropped (decided 2026-05-07)
+- Socket.IO / real-time push — REST only
+- Queue size, Consumer delay — dropped
 - Tier 2 / Tier 3 widgets (carts, orders, revenue) — follow-on
 - Charts library — plain Bootstrap cards + tables only
 
@@ -91,16 +130,16 @@ Returns 200 with updated message, 403 if licensee user attempts to resend anothe
 | Phase | Name | Tasks | Dependencies | Description |
 |-------|------|-------|--------------|-------------|
 | 1 | Schema | task-01 | None | Add `closedAt` to Room + update close logic in plugins |
-| 2 | Backend | task-02 | Phase 1 | DashboardController + resend endpoint + specs |
-| 3 | Frontend | task-03 | Phase 2 | Dashboard page + resend modal |
+| 2 | Backend | task-02 | Phase 1 | 8 dashboard endpoints + resend endpoint + Redis caching + specs |
+| 3 | Frontend | task-03 | Phase 2 | Independent card components + resend modal |
 
 ## Task Summary
 
 | Task Path | Title | Phase | Status | Depends On |
 |-----------|-------|-------|--------|------------|
 | phase-1/task-01-room-schema | Room schema — closedAt field | 1 | not-started | — |
-| phase-2/task-02-backend | Backend — DashboardController + resend endpoint | 2 | not-started | phase-1/task-01-room-schema |
-| phase-3/task-03-frontend | Frontend dashboard widgets + resend modal | 3 | not-started | phase-2/task-02-backend |
+| phase-2/task-02-backend | Backend — dashboard endpoints + resend + caching | 2 | not-started | phase-1/task-01-room-schema |
+| phase-3/task-03-frontend | Frontend — independent card components + resend modal | 3 | not-started | phase-2/task-02-backend |
 
 ## Branch Convention
 
@@ -121,29 +160,29 @@ Base branch: `main`
 | `src/app/plugins/chats/Rocketchat.js` | 2 close sites (Phase 1) |
 | `src/app/plugins/chats/Chatwoot.js` | 2 close sites (Phase 1) |
 | `src/app/plugins/chatbots/Landbot.js` | 1 close site (Phase 1) |
-| `src/app/controllers/DashboardController.js` | New controller (Phase 2) |
+| `src/app/controllers/DashboardController.js` | 8 dashboard actions + resend (Phase 2) |
 | `src/app/controllers/MessagesController.js` | Add resend action (Phase 2) |
-| `src/app/routes/resources-routes.js` | Register both routes (Phase 2) |
-| `client/src/pages/Dashboard/index.js` | Implement widgets + modal (Phase 3) |
-| `client/src/services/dashboard.js` | New service (Phase 3) |
-| `client/src/services/message.js` | Add resendMessage (Phase 3) |
+| `src/app/routes/resources-routes.js` | Register all 9 routes (Phase 2) |
+| `src/config/redis.js` | `redisConnection` — used for caching (read-only ref) |
+| `client/src/pages/Dashboard/index.js` | Renders card components (Phase 3) |
+| `client/src/services/dashboard.js` | 8 service functions (Phase 3) |
+| `client/src/services/message.js` | Add `resendMessage` (Phase 3) |
 
 ## Risks
 
-- JWT payload only contains `user._id` — one extra DB read per stats call.
-- `avg_transfer_rate` = `total messages / 24` — messages-per-hour average, not byte rate.
-- `ended_today` uses `closedAt` (accurate after Phase 1); existing rooms closed before Phase 1 ships will not have `closedAt` set.
-- `avg_time_in_queue_seconds` excludes messages where `sendedAt` was never set (permanently failed).
-- Resend resets `sended`, `error`, and `sendedAt` — if the messenger plugin is offline the message will fail again silently; acceptable for now.
+- One extra DB read per request to resolve user kind — acceptable; could be eliminated later by encoding `isSuper`/`licenseeId` in the JWT.
+- Cache invalidation: stats are stale for up to 10 minutes after data changes — acceptable for a dashboard.
+- Rooms closed before Phase 1 ships will have no `closedAt` — `ended_today` and `avg_duration_seconds` will undercount until backfill or naturally over time.
+- `avg_time_in_queue_seconds` excludes messages where `sendedAt` was never set.
+- Resend resets message state; if the messenger is offline it will fail again silently.
 
 ## Success Criteria
 
-- [ ] Super user sees all 5 widget sections with real data
-- [ ] Licensee user sees 3 scoped widget cards
-- [ ] Failed stat in Delivery Rate card opens modal with resend buttons
-- [ ] Successful resend removes the row and decrements the failed count in the card
-- [ ] `avg_duration_seconds` uses `closedAt`, not `updatedAt`
-- [ ] Resend returns 403 for cross-licensee attempts
+- [ ] 8 dashboard endpoints return correct data for the right user kind; 403 for wrong kind
+- [ ] All responses are served from Redis cache on repeat requests within 10 minutes
+- [ ] Each frontend card loads independently — slow cards don't block fast ones
+- [ ] Failed stat opens modal; resend removes row and decrements count
+- [ ] `avg_duration_seconds` uses `closedAt`
 - [ ] All existing tests pass (`npx jest`)
 - [ ] `npx eslint .` reports no new errors
 

--- a/.plans/dashboard-widgets/overview.md
+++ b/.plans/dashboard-widgets/overview.md
@@ -25,21 +25,23 @@ One endpoint per card. All under `/resources/dashboard/`. The controller resolve
 
 ### Super endpoints (5)
 
-| Endpoint | Card | Cache key |
-|----------|------|-----------|
-| `GET /resources/dashboard/licensees` | Licenciados | `dashboard:super:licensees` |
-| `GET /resources/dashboard/message-volume` | Volume de Mensagens | `dashboard:super:message-volume` |
-| `GET /resources/dashboard/delivery-rate` | Taxa de Entrega | `dashboard:super:delivery-rate` |
-| `GET /resources/dashboard/queue` | Fila | `dashboard:super:queue` |
-| `GET /resources/dashboard/conversations` | Conversas | `dashboard:super:conversations` |
+| Endpoint | Card | Date params | Cache key |
+|----------|------|-------------|-----------|
+| `GET /resources/dashboard/licensees` | Licenciados | — | `dashboard:super:licensees` |
+| `GET /resources/dashboard/message-volume?startDate=&endDate=` | Volume de Mensagens | optional | `dashboard:super:message-volume:{start}:{end}` |
+| `GET /resources/dashboard/delivery-rate?startDate=&endDate=` | Taxa de Entrega | optional | `dashboard:super:delivery-rate:{start}:{end}` |
+| `GET /resources/dashboard/queue?startDate=&endDate=` | Fila | optional | `dashboard:super:queue:{start}:{end}` |
+| `GET /resources/dashboard/conversations?startDate=&endDate=` | Conversas | optional | `dashboard:super:conversations:{start}:{end}` |
 
 ### Licensee endpoints (3)
 
-| Endpoint | Card | Cache key |
-|----------|------|-----------|
-| `GET /resources/dashboard/contacts` | Contatos | `dashboard:licensee:{licenseeId}:contacts` |
-| `GET /resources/dashboard/messages-today` | Mensagens Hoje | `dashboard:licensee:{licenseeId}:messages-today` |
-| `GET /resources/dashboard/messages-per-day` | Mensagens por Dia | `dashboard:licensee:{licenseeId}:messages-per-day` |
+| Endpoint | Card | Date params | Cache key |
+|----------|------|-------------|-----------|
+| `GET /resources/dashboard/contacts` | Contatos | — | `dashboard:licensee:{id}:contacts` |
+| `GET /resources/dashboard/messages-today?startDate=&endDate=` | Mensagens Hoje | optional | `dashboard:licensee:{id}:messages-today:{start}:{end}` |
+| `GET /resources/dashboard/messages-per-day?startDate=&endDate=` | Mensagens por Dia | optional | `dashboard:licensee:{id}:messages-per-day:{start}:{end}` |
+
+> When `startDate`/`endDate` are absent, the backend defaults to today's range (start of day → end of day). This makes adding a calendar component a frontend-only change — just pass `{ startDate, endDate }` to the service function.
 
 ### Response shapes
 

--- a/.plans/dashboard-widgets/phase-1/task-01-backend-stats-endpoint/status.md
+++ b/.plans/dashboard-widgets/phase-1/task-01-backend-stats-endpoint/status.md
@@ -1,0 +1,25 @@
+# Status: Backend stats endpoint
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-07
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-07 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/dashboard-widgets/phase-1/task-01-backend-stats-endpoint/task.md
+++ b/.plans/dashboard-widgets/phase-1/task-01-backend-stats-endpoint/task.md
@@ -1,0 +1,313 @@
+# ~~SUPERSEDED~~ — see phase-2/task-02-backend
+
+# Task: Backend stats endpoint
+
+**Plan**: Dashboard Widgets
+**Phase**: 1
+**Task ID (phase-local)**: task-01
+**Task Path**: phase-1/task-01-backend-stats-endpoint
+**Depends On**: None
+**JIRA**: N/A
+
+## Objective
+
+Create `DashboardController` with a `stats` action that resolves the calling user's kind and returns a role-scoped JSON payload. Register `GET /resources/dashboard/stats` in the resources router.
+
+## Context
+
+**Auth:** JWT contains only `{ id: user._id }`. Middleware sets `req.userId`. Controller must fetch the user to resolve `isSuper` and `licensee`.
+
+**User model fields:** `isSuper: Boolean`, `licensee: ObjectId ref Licensee` (required when `!isSuper`).
+
+**Data sources — all MongoDB:**
+- `licenseeRepository.model()` — licensee counts
+- `messageRepository.model()` — all message metrics
+- `contactRepository.model()` — contact counts (licensee path only)
+- `roomRepository` — NOT currently in the resources-routes composition root; must be added (see Step 2)
+
+**Existing controller pattern:** `src/app/controllers/LicenseesController.js` — constructor injection, method binding, `{ errors: { message } }` error shape.
+
+---
+
+## API Contract
+
+See `overview.md` for full response shapes. Key computed fields:
+
+| Field | Computation |
+|-------|-------------|
+| `peak_throughput` | `Math.max(...per_hour.map(h => h.count))` |
+| `avg_transfer_rate` | `totalMessages24h / 24` (messages per hour average) |
+| `sent_pct` | `sent / (sent + failed) * 100` — return `0` if both are 0 |
+| `failed_pct` | `failed / (sent + failed) * 100` |
+| `pending_messages` | `Message.countDocuments({ sended: false, destination: 'to-messenger' })` |
+| `avg_time_in_queue_seconds` | `avg(sendedAt - createdAt)` in seconds, for messages where `sendedAt` exists |
+| `started_today` | `Room.countDocuments({ createdAt: { $gte: startOfDay, $lt: endOfDay } })` |
+| `ended_today` | `Room.countDocuments({ closed: true, updatedAt: { $gte: startOfDay, $lt: endOfDay } })` |
+| `avg_messages_per_conversation` | `avg(message count per room)` via aggregation |
+
+---
+
+## Aggregation Pipelines
+
+### Per-day (last 7 days, optional licensee filter)
+```js
+const perDayPipeline = (licenseeId) => [
+  { $match: { createdAt: { $gte: sevenDaysAgo, $lt: endOfDay }, ...(licenseeId ? { licensee: licenseeId } : {}) } },
+  { $group: { _id: { $dateToString: { format: '%Y-%m-%d', date: '$createdAt' } }, count: { $sum: 1 } } },
+  { $sort: { _id: 1 } },
+]
+```
+
+### Per-hour (last 24h, super only)
+```js
+const perHourPipeline = [
+  { $match: { createdAt: { $gte: startOfDay, $lt: endOfDay } } },
+  { $group: { _id: { $dateToString: { format: '%Y-%m-%dT%H', date: '$createdAt' } }, count: { $sum: 1 } } },
+  { $sort: { _id: 1 } },
+]
+```
+
+### Average time in queue (super only)
+```js
+const avgTimeInQueuePipeline = [
+  { $match: { sendedAt: { $exists: true }, createdAt: { $gte: startOfDay, $lt: endOfDay } } },
+  { $group: { _id: null, avg: { $avg: { $divide: [{ $subtract: ['$sendedAt', '$createdAt'] }, 1000] } } } },
+]
+```
+
+### Average messages per conversation (super only)
+```js
+const avgMsgPerConvPipeline = [
+  { $match: { room: { $exists: true }, createdAt: { $gte: startOfDay, $lt: endOfDay } } },
+  { $group: { _id: '$room', count: { $sum: 1 } } },
+  { $group: { _id: null, avg: { $avg: '$count' } } },
+]
+```
+
+---
+
+## Before You Start
+
+- [ ] `git switch main && git pull --rebase origin main`
+- [ ] Create branch: `git switch -c plan/dashboard-widgets/phase-1/task-01-backend-stats-endpoint`
+- [ ] Read `docs/kb/architecture/dependency-injection-runtime-wiring.md`
+- [ ] Read `docs/kb/architecture/express-conventions.md`
+- [ ] Read `src/app/controllers/LicenseesController.js`
+- [ ] Read `src/app/routes/resources-routes.js` — understand `createRuntimeDependencies()` and what repositories are already destructured
+- [ ] Check `status.md` — must be `not-started`
+- [ ] Mark `status.md` as `in-progress`
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/app/controllers/DashboardController.js` | create | New controller |
+| `src/app/controllers/DashboardController.spec.js` | create | Unit specs |
+| `src/app/routes/resources-routes.js` | modify | Add roomRepository destructure, DashboardController import + wiring + route |
+
+### Do NOT Modify
+
+- `client/src/**` — owned by phase-2/task-02-frontend-dashboard
+- Any other existing controller files
+
+## Implementation Steps
+
+### Step 1: Check if roomRepository exists in createRuntimeDependencies
+
+Open `src/app/runtime/dependencies.js` and check whether `roomRepository` is already exported. If not, add it following the same pattern as other repositories. This is a prerequisite for the conversation metrics.
+
+### Step 2: Update resources-routes.js
+
+Add `roomRepository` to the destructure from `createRuntimeDependencies()` if needed.
+
+Add import:
+```js
+import { DashboardController } from '../controllers/DashboardController.js'
+```
+
+Add to composition root:
+```js
+const dashboardController = new DashboardController({
+  userRepository,
+  licenseeRepository,
+  contactRepository,
+  messageRepository,
+  roomRepository,
+})
+```
+
+Add route (after `router.get('/messages', messagesController.index)`):
+```js
+router.get('/dashboard/stats', dashboardController.stats)
+```
+
+### Step 3: Create DashboardController
+
+Create `src/app/controllers/DashboardController.js`:
+
+```js
+class DashboardController {
+  constructor({ userRepository, licenseeRepository, contactRepository, messageRepository, roomRepository } = {}) {
+    this.userRepository = userRepository
+    this.licenseeRepository = licenseeRepository
+    this.contactRepository = contactRepository
+    this.messageRepository = messageRepository
+    this.roomRepository = roomRepository
+    this.stats = this.stats.bind(this)
+  }
+
+  async stats(req, res) {
+    try {
+      const user = await this.userRepository.findFirst({ _id: req.userId })
+      if (!user) return res.status(404).send({ errors: { message: 'Usuário não encontrado' } })
+
+      const now = new Date()
+      const startOfDay = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+      const endOfDay = new Date(startOfDay.getTime() + 24 * 60 * 60 * 1000)
+      const sevenDaysAgo = new Date(startOfDay.getTime() - 6 * 24 * 60 * 60 * 1000)
+
+      if (user.isSuper) {
+        return res.status(200).json(await this._superStats(startOfDay, endOfDay, sevenDaysAgo))
+      }
+
+      return res.status(200).json(await this._licenseeStats(user.licensee, startOfDay, endOfDay, sevenDaysAgo))
+    } catch (err) {
+      return res.status(500).send({ errors: { message: err.toString() } })
+    }
+  }
+
+  async _superStats(startOfDay, endOfDay, sevenDaysAgo) {
+    const perDayPipeline = [
+      { $match: { createdAt: { $gte: sevenDaysAgo, $lt: endOfDay } } },
+      { $group: { _id: { $dateToString: { format: '%Y-%m-%d', date: '$createdAt' } }, count: { $sum: 1 } } },
+      { $sort: { _id: 1 } },
+    ]
+    const perHourPipeline = [
+      { $match: { createdAt: { $gte: startOfDay, $lt: endOfDay } } },
+      { $group: { _id: { $dateToString: { format: '%Y-%m-%dT%H', date: '$createdAt' } }, count: { $sum: 1 } } },
+      { $sort: { _id: 1 } },
+    ]
+    const avgTimeInQueuePipeline = [
+      { $match: { sendedAt: { $exists: true }, createdAt: { $gte: startOfDay, $lt: endOfDay } } },
+      { $group: { _id: null, avg: { $avg: { $divide: [{ $subtract: ['$sendedAt', '$createdAt'] }, 1000] } } } },
+    ]
+    const avgMsgPerConvPipeline = [
+      { $match: { room: { $exists: true }, createdAt: { $gte: startOfDay, $lt: endOfDay } } },
+      { $group: { _id: '$room', count: { $sum: 1 } } },
+      { $group: { _id: null, avg: { $avg: '$count' } } },
+    ]
+
+    const [
+      total, active, demo, free, paid,
+      sentToday, failedToday,
+      perDay, perHour, avgTimeResult, avgMsgResult,
+      pendingMessages,
+      startedToday, endedToday,
+    ] = await Promise.all([
+      this.licenseeRepository.model().countDocuments({}),
+      this.licenseeRepository.model().countDocuments({ active: true }),
+      this.licenseeRepository.model().countDocuments({ licenseKind: 'demo' }),
+      this.licenseeRepository.model().countDocuments({ licenseKind: 'free' }),
+      this.licenseeRepository.model().countDocuments({ licenseKind: 'paid' }),
+      this.messageRepository.model().countDocuments({ sended: true, createdAt: { $gte: startOfDay, $lt: endOfDay } }),
+      this.messageRepository.model().countDocuments({ sended: false, createdAt: { $gte: startOfDay, $lt: endOfDay } }),
+      this.messageRepository.model().aggregate(perDayPipeline),
+      this.messageRepository.model().aggregate(perHourPipeline),
+      this.messageRepository.model().aggregate(avgTimeInQueuePipeline),
+      this.messageRepository.model().aggregate(avgMsgPerConvPipeline),
+      this.messageRepository.model().countDocuments({ sended: false, destination: 'to-messenger' }),
+      this.roomRepository.model().countDocuments({ createdAt: { $gte: startOfDay, $lt: endOfDay } }),
+      this.roomRepository.model().countDocuments({ closed: true, updatedAt: { $gte: startOfDay, $lt: endOfDay } }),
+    ])
+
+    const total24h = sentToday + failedToday
+    const perHourMapped = perHour.map(({ _id, count }) => ({ hour: _id, count }))
+
+    return {
+      kind: 'super',
+      licensees: { total, active, by_kind: { demo, free, paid } },
+      message_volume: {
+        per_day: perDay.map(({ _id, count }) => ({ date: _id, count })),
+        per_hour: perHourMapped,
+        peak_throughput: perHourMapped.length ? Math.max(...perHourMapped.map((h) => h.count)) : 0,
+        avg_transfer_rate: total24h > 0 ? parseFloat((total24h / 24).toFixed(2)) : 0,
+      },
+      delivery_rate: {
+        sent_today: sentToday,
+        failed_today: failedToday,
+        sent_pct: total24h > 0 ? parseFloat(((sentToday / total24h) * 100).toFixed(1)) : 0,
+        failed_pct: total24h > 0 ? parseFloat(((failedToday / total24h) * 100).toFixed(1)) : 0,
+      },
+      queue: {
+        pending_messages: pendingMessages,
+        avg_time_in_queue_seconds: avgTimeResult[0] ? parseFloat(avgTimeResult[0].avg.toFixed(2)) : 0,
+      },
+      conversations: {
+        started_today: startedToday,
+        ended_today: endedToday,
+        avg_messages_per_conversation: avgMsgResult[0] ? parseFloat(avgMsgResult[0].avg.toFixed(1)) : 0,
+      },
+    }
+  }
+
+  async _licenseeStats(licenseeId, startOfDay, endOfDay, sevenDaysAgo) {
+    const perDayPipeline = [
+      { $match: { licensee: licenseeId, createdAt: { $gte: sevenDaysAgo, $lt: endOfDay } } },
+      { $group: { _id: { $dateToString: { format: '%Y-%m-%d', date: '$createdAt' } }, count: { $sum: 1 } } },
+      { $sort: { _id: 1 } },
+    ]
+
+    const [totalContacts, inChatbot, sentToday, failedToday, perDay] = await Promise.all([
+      this.contactRepository.model().countDocuments({ licensee: licenseeId }),
+      this.contactRepository.model().countDocuments({ licensee: licenseeId, talkingWithChatBot: true }),
+      this.messageRepository.model().countDocuments({ licensee: licenseeId, sended: true, createdAt: { $gte: startOfDay, $lt: endOfDay } }),
+      this.messageRepository.model().countDocuments({ licensee: licenseeId, sended: false, createdAt: { $gte: startOfDay, $lt: endOfDay } }),
+      this.messageRepository.model().aggregate(perDayPipeline),
+    ])
+
+    return {
+      kind: 'licensee',
+      contacts: { total: totalContacts, in_chatbot: inChatbot },
+      messages: {
+        sent_today: sentToday,
+        failed_today: failedToday,
+        per_day: perDay.map(({ _id, count }) => ({ date: _id, count })),
+      },
+    }
+  }
+}
+
+export { DashboardController }
+```
+
+### Step 4: Write specs
+
+Create `src/app/controllers/DashboardController.spec.js`. Cover:
+
+1. **Super user — success**: mock all repositories; assert `kind: 'super'`, correct top-level keys, `peak_throughput` equals max of `per_hour` counts, percentages sum to 100.
+2. **Licensee user — success**: mock user with `isSuper: false`; assert `kind: 'licensee'`, `countDocuments` called with `{ licensee: user.licensee, ... }`.
+3. **User not found**: `findFirst` returns null → HTTP 404.
+4. **Repository error**: `findFirst` throws → HTTP 500 with `errors.message`.
+
+## Testing
+
+- [ ] `npx jest src/app/controllers/DashboardController.spec.js` passes
+- [ ] `npx jest` (full suite) passes
+- [ ] `npx eslint .` reports no new errors
+
+## Documentation / KB Updates
+
+- [ ] No KB/doc updates required — follows existing patterns.
+- [ ] If `roomRepository` was missing from `dependencies.js` and had to be added, run `document-solution` after completing the task.
+
+## Completion Criteria
+
+- [ ] `GET /resources/dashboard/stats` returns correct shape for both user kinds
+- [ ] All 4 spec cases pass
+- [ ] No lint errors
+- [ ] Changes committed to `plan/dashboard-widgets/phase-1/task-01-backend-stats-endpoint`
+- [ ] `status.md` updated to `complete`
+
+## Conflict Avoidance Notes
+
+- Phase 2 touches `client/src/**` only — no overlap.

--- a/.plans/dashboard-widgets/phase-1/task-01-room-schema/status.md
+++ b/.plans/dashboard-widgets/phase-1/task-01-room-schema/status.md
@@ -1,0 +1,25 @@
+# Status: Room schema — add closedAt field
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-07
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-07 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/dashboard-widgets/phase-1/task-01-room-schema/status.md
+++ b/.plans/dashboard-widgets/phase-1/task-01-room-schema/status.md
@@ -1,9 +1,9 @@
 # Status: Room schema — add closedAt field
 
-**Current Status**: not-started
+**Current Status**: complete
 **Last Updated**: 2026-05-07
-**Agent**: —
-**Branch**: —
+**Agent**: Alpha-VII
+**Branch**: plan/dashboard-widgets/phase-1/task-01-room-schema
 **PR**: —
 
 ## Status History
@@ -11,6 +11,8 @@
 | Timestamp | Status | Agent | Notes |
 |-----------|--------|-------|-------|
 | 2026-05-07 | not-started | — | Task created |
+| 2026-05-07 | in-progress | Alpha-VII | Implementation started |
+| 2026-05-07 | complete | Alpha-VII | All 5 close sites updated, all tests pass, eslint clean |
 
 ## Blockers
 
@@ -18,7 +20,10 @@ None
 
 ## Artifacts
 
-None
+- `src/app/models/Room.js` — added `closedAt: { type: Date }` field
+- `src/app/plugins/chats/Rocketchat.js` — set `room.closedAt = new Date()` at 2 close sites
+- `src/app/plugins/chats/Chatwoot.js` — set `closedAt = new Date()` at 2 close sites
+- `src/app/plugins/chatbots/Landbot.js` — set `room.closedAt = new Date()` at 1 close site
 
 ## Adaptations
 

--- a/.plans/dashboard-widgets/phase-1/task-01-room-schema/task.md
+++ b/.plans/dashboard-widgets/phase-1/task-01-room-schema/task.md
@@ -1,0 +1,100 @@
+# Task: Room schema — add closedAt field
+
+**Plan**: Dashboard Widgets
+**Phase**: 1
+**Task ID (phase-local)**: task-01
+**Task Path**: phase-1/task-01-room-schema
+**Depends On**: None
+**JIRA**: N/A
+
+## Objective
+
+Add `closedAt: Date` to the Room schema and set it wherever `room.closed = true` is written, so that Phase 2 can use it for accurate conversation-end metrics.
+
+## Context
+
+`Room` model (`src/app/models/Room.js`) currently has `closed: Boolean` and `timestamps: true` (`createdAt`, `updatedAt`). `updatedAt` is not a reliable proxy for close time because it updates on any field change.
+
+`closedAt` must be set **at the same moment** `room.closed = true` is written. A grep for `\.closed\s*=\s*true` / `closed: true` across the plugins reveals 5 locations in 3 files:
+
+| File | Lines | Context |
+|------|-------|---------|
+| `src/app/plugins/chats/Rocketchat.js` | ~172 | Closes room when chat is reset |
+| `src/app/plugins/chats/Rocketchat.js` | ~197 | Closes room on explicit close event |
+| `src/app/plugins/chats/Chatwoot.js` | ~336 | Closes room on conversation close |
+| `src/app/plugins/chats/Chatwoot.js` | ~469 | Closes room on omnichannel resolve |
+| `src/app/plugins/chatbots/Landbot.js` | ~12 | Closes room when chatbot flow ends |
+
+In each location, after `room.closed = true` add `room.closedAt = new Date()`.
+
+## Before You Start
+
+- [ ] `git switch main && git pull --rebase origin main`
+- [ ] Create branch: `git switch -c plan/dashboard-widgets/phase-1/task-01-room-schema`
+- [ ] Read `src/app/models/Room.js` to understand the current schema
+- [ ] Read each of the 3 plugin files above to locate the exact lines
+- [ ] Check `status.md` — must be `not-started`
+- [ ] Mark `status.md` as `in-progress`
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/app/models/Room.js` | modify | Add `closedAt: Date` field |
+| `src/app/plugins/chats/Rocketchat.js` | modify | Set `room.closedAt = new Date()` at both close sites |
+| `src/app/plugins/chats/Chatwoot.js` | modify | Set `room.closedAt = new Date()` at both close sites |
+| `src/app/plugins/chatbots/Landbot.js` | modify | Set `room.closedAt = new Date()` at the close site |
+
+### Do NOT Modify
+
+- `src/app/controllers/**` — owned by phase-2/task-02-backend
+- `src/app/routes/**` — owned by phase-2/task-02-backend
+- `client/src/**` — owned by phase-3/task-03-frontend
+
+## Implementation Steps
+
+### Step 1: Update Room model
+
+In `src/app/models/Room.js`, add to the schema definition:
+```js
+closedAt: { type: Date },
+```
+
+No default, no required — it is only populated when the room is actually closed.
+
+### Step 2: Update close sites
+
+In each of the 5 locations, immediately after `room.closed = true`, add:
+```js
+room.closedAt = new Date()
+```
+
+Do not change any other logic in those files.
+
+### Step 3: Verify existing specs still pass
+
+The existing specs in `Rocketchat.spec.js`, `Chatwoot.spec.js`, and `Landbot.spec.js` assert `closed: true` — they should continue to pass unchanged. If any spec also checks the full saved object shape and fails because of the new field, update the expectation minimally (add `closedAt: expect.any(Date)`).
+
+## Testing
+
+- [ ] `npx jest src/app/plugins/chats/Rocketchat.spec.js` passes
+- [ ] `npx jest src/app/plugins/chats/Chatwoot.spec.js` passes
+- [ ] `npx jest src/app/plugins/chatbots/Landbot.spec.js` passes
+- [ ] `npx jest` (full suite) passes
+- [ ] `npx eslint .` reports no new errors
+
+## Documentation / KB Updates
+
+- [ ] No KB/doc updates required — additive schema change, no architectural novelty.
+
+## Completion Criteria
+
+- [ ] `Room` schema has `closedAt: Date`
+- [ ] All 5 close sites set `room.closedAt = new Date()`
+- [ ] All existing room/plugin specs pass
+- [ ] Changes committed to `plan/dashboard-widgets/phase-1/task-01-room-schema`
+- [ ] `status.md` updated to `complete`
+
+## Conflict Avoidance Notes
+
+- Phase 2 task does not touch any of these files — no overlap.

--- a/.plans/dashboard-widgets/phase-2/task-02-backend/status.md
+++ b/.plans/dashboard-widgets/phase-2/task-02-backend/status.md
@@ -1,9 +1,9 @@
 # Status: Backend — DashboardController + resend endpoint
 
-**Current Status**: not-started
+**Current Status**: complete
 **Last Updated**: 2026-05-07
-**Agent**: —
-**Branch**: —
+**Agent**: claude-sonnet-4-6
+**Branch**: plan/dashboard-widgets
 **PR**: —
 
 ## Status History
@@ -11,6 +11,8 @@
 | Timestamp | Status | Agent | Notes |
 |-----------|--------|-------|-------|
 | 2026-05-07 | not-started | — | Task created |
+| 2026-05-07 | in-progress | claude-sonnet-4-6 | Implementation started |
+| 2026-05-07 | complete | claude-sonnet-4-6 | All specs pass, lint clean |
 
 ## Blockers
 
@@ -18,8 +20,13 @@ None
 
 ## Artifacts
 
-None
+- `src/app/controllers/DashboardController.js` — 8 actions + Redis caching
+- `src/app/controllers/DashboardController.spec.js` — 27 unit specs
+- `src/app/controllers/MessagesController.js` — resend action added
+- `src/app/controllers/MessagesController.spec.js` — 4 resend specs added
+- `src/app/routes/resources-routes.js` — 9 new routes + DI wiring
 
 ## Adaptations
 
-None
+- Branch `plan/dashboard-widgets/phase-2/task-02-backend` could not be created because `plan/dashboard-widgets` exists as a branch. Worked from `plan/dashboard-widgets`.
+- `MessagesController` also received `userRepository` (not just `messageRepository` + `queueServer`) since resend needs to resolve user isSuper/licensee.

--- a/.plans/dashboard-widgets/phase-2/task-02-backend/status.md
+++ b/.plans/dashboard-widgets/phase-2/task-02-backend/status.md
@@ -1,0 +1,25 @@
+# Status: Backend — DashboardController + resend endpoint
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-07
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-07 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/dashboard-widgets/phase-2/task-02-backend/task.md
+++ b/.plans/dashboard-widgets/phase-2/task-02-backend/task.md
@@ -1,4 +1,4 @@
-# Task: Backend — DashboardController + resend endpoint
+# Task: Backend — dashboard endpoints + resend + Redis caching
 
 **Plan**: Dashboard Widgets
 **Phase**: 2
@@ -9,76 +9,92 @@
 
 ## Objective
 
-Create `DashboardController` (role-aware stats) and add a `resend` action to `MessagesController`. Register both routes in `resources-routes.js`.
-
-Both endpoints touch `resources-routes.js`, so they are intentionally in the same task to avoid merge conflicts.
+Create `DashboardController` with 8 card-specific actions (5 super + 3 licensee), add a `resend` action to `MessagesController`, register all 9 routes in `resources-routes.js`, and add Redis caching (10 min TTL) to every dashboard action.
 
 ## Context
 
 ### Auth & user resolution
-JWT payload: `{ id: user._id }`. Middleware sets `req.userId`. Controller fetches user to resolve `isSuper` / `licensee`.
+JWT payload: `{ id: user._id }`. Middleware sets `req.userId`. Each action fetches the user to resolve `isSuper` / `licensee`, then gates access:
+- Super-only endpoints return `403` if `!user.isSuper`
+- Licensee-only endpoints return `403` if `user.isSuper`
 
-### Stats endpoint
-`GET /resources/dashboard/stats` — returns role-branched JSON. Full response shapes in `overview.md`.
-
-Key notes:
-- `ended_today` now uses `closedAt` (available after Phase 1): `Room.countDocuments({ closedAt: { $gte: startOfDay, $lt: endOfDay } })`
-- `avg_duration_seconds`: `avg(closedAt - createdAt)` in seconds for rooms closed today
-- `avg_transfer_rate`: `(sent_today + failed_today) / 24` — messages per hour average
-- `peak_throughput`: `Math.max(...per_hour.map(h => h.count))`, 0 if empty
-
-### Resend endpoint
-`POST /resources/messages/:id/resend`
-
-Flow:
-1. Find message by `_id`
-2. Return 404 if not found
-3. **Authorization**: if user is not super, verify `message.licensee.toString() === user.licensee.toString()` — return 403 if mismatch
-4. Reset message state: set `sended = false`, clear `error = null`, clear `sendedAt = null`
-5. Save the message
-6. Re-add to Bull queue: `queueServer.addJob('send-message-to-messenger', { messageId: message._id })`
-7. Return 200 with the updated message
-
-> Before implementing step 6, read `src/app/services/SendMessageToMessenger.js` to confirm the expected `body` payload. If it expects more than `{ messageId }`, adjust accordingly.
-
-`MessagesController` will need `messageRepository` and `queueServer` injected. Check current constructor — it only has `createMessagesQuery`. Add the new deps without breaking the existing `index` action.
-
-### Aggregation pipelines (super stats)
-
+### Caching
+`redisConnection` is exported from `src/config/redis.js` — import it directly into `DashboardController`. Pattern for every action:
 ```js
-// Per-day (last 7 days)
+const cached = await redisConnection.get(cacheKey)
+if (cached) return res.status(200).json(JSON.parse(cached))
+// ... compute data ...
+await redisConnection.setex(cacheKey, 600, JSON.stringify(data))
+return res.status(200).json(data)
+```
+
+Cache keys:
+- Super (global): `dashboard:super:licensees`, `dashboard:super:message-volume`, `dashboard:super:delivery-rate`, `dashboard:super:queue`, `dashboard:super:conversations`
+- Licensee (per licensee): `dashboard:licensee:{licenseeId}:contacts`, `dashboard:licensee:{licenseeId}:messages-today`, `dashboard:licensee:{licenseeId}:messages-per-day`
+
+### Date helpers (reused across actions)
+```js
+const now = new Date()
+const startOfDay = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+const endOfDay = new Date(startOfDay.getTime() + 24 * 60 * 60 * 1000)
+const sevenDaysAgo = new Date(startOfDay.getTime() - 6 * 24 * 60 * 60 * 1000)
+```
+
+### Aggregation pipelines
+
+**Per-day (7 days, optional licenseeId filter)**
+```js
 [
-  { $match: { createdAt: { $gte: sevenDaysAgo, $lt: endOfDay } } },
+  { $match: { createdAt: { $gte: sevenDaysAgo, $lt: endOfDay }, ...(licenseeId ? { licensee: licenseeId } : {}) } },
   { $group: { _id: { $dateToString: { format: '%Y-%m-%d', date: '$createdAt' } }, count: { $sum: 1 } } },
   { $sort: { _id: 1 } },
 ]
+```
 
-// Per-hour (today)
+**Per-hour (today, super only)**
+```js
 [
   { $match: { createdAt: { $gte: startOfDay, $lt: endOfDay } } },
   { $group: { _id: { $dateToString: { format: '%Y-%m-%dT%H', date: '$createdAt' } }, count: { $sum: 1 } } },
   { $sort: { _id: 1 } },
 ]
+```
 
-// Avg time in queue (messages sent today where sendedAt exists)
+**Avg time in queue (today)**
+```js
 [
   { $match: { sendedAt: { $exists: true }, createdAt: { $gte: startOfDay, $lt: endOfDay } } },
   { $group: { _id: null, avg: { $avg: { $divide: [{ $subtract: ['$sendedAt', '$createdAt'] }, 1000] } } } },
 ]
+```
 
-// Avg messages per conversation (today)
+**Avg messages per conversation (today)**
+```js
 [
   { $match: { room: { $exists: true }, createdAt: { $gte: startOfDay, $lt: endOfDay } } },
   { $group: { _id: '$room', count: { $sum: 1 } } },
   { $group: { _id: null, avg: { $avg: '$count' } } },
 ]
+```
 
-// Avg conversation duration (rooms closed today)
+**Avg conversation duration (rooms closed today)**
+```js
 [
   { $match: { closedAt: { $gte: startOfDay, $lt: endOfDay } } },
   { $group: { _id: null, avg: { $avg: { $divide: [{ $subtract: ['$closedAt', '$createdAt'] }, 1000] } } } },
 ]
 ```
+
+### Resend endpoint
+`POST /resources/messages/:id/resend`
+1. Fetch user + message by `req.params.id`; 404 if not found
+2. If `!user.isSuper`: verify `message.licensee.toString() === user.licensee.toString()` → 403 if mismatch
+3. Reset: `message.sended = false`, `message.error = null`, `message.sendedAt = null`
+4. Save message
+5. `queueServer.addJob('send-message-to-messenger', { messageId: message._id })`
+6. Return 200 with updated message
+
+> Before implementing step 5, read `src/app/services/SendMessageToMessenger.js` to confirm the expected `body` payload. Adjust if it expects more than `{ messageId }`.
 
 ### Existing patterns
 - Controller structure: `src/app/controllers/LicenseesController.js`
@@ -93,7 +109,7 @@ Flow:
 - [ ] Read `docs/kb/architecture/dependency-injection-runtime-wiring.md`
 - [ ] Read `src/app/controllers/MessagesController.js` — understand current constructor
 - [ ] Read `src/app/services/SendMessageToMessenger.js` — confirm resend payload shape
-- [ ] Read `src/app/runtime/dependencies.js` — check if `roomRepository` is already exported
+- [ ] Read `src/app/runtime/dependencies.js` — check if `roomRepository` is exported
 - [ ] Check `status.md` — must be `not-started`
 - [ ] Mark `status.md` as `in-progress`
 
@@ -101,95 +117,148 @@ Flow:
 
 | File | Action | Notes |
 |------|--------|-------|
-| `src/app/controllers/DashboardController.js` | create | Stats action |
+| `src/app/controllers/DashboardController.js` | create | 8 actions + Redis caching |
 | `src/app/controllers/DashboardController.spec.js` | create | Unit specs |
-| `src/app/controllers/MessagesController.js` | modify | Add `resend` action + inject `messageRepository` + `queueServer` |
+| `src/app/controllers/MessagesController.js` | modify | Add `resend` action |
 | `src/app/controllers/MessagesController.spec.js` | modify | Add resend specs |
-| `src/app/routes/resources-routes.js` | modify | Add DashboardController wiring + route; add resend route |
+| `src/app/routes/resources-routes.js` | modify | 9 new routes + DI wiring |
 | `src/app/runtime/dependencies.js` | modify if needed | Add `roomRepository` if missing |
 
 ### Do NOT Modify
 
-- `src/app/models/**` — owned by phase-1 (complete)
-- `src/app/plugins/**` — owned by phase-1 (complete)
-- `client/src/**` — owned by phase-3/task-03-frontend
+- `src/app/models/**` — Phase 1 (complete)
+- `src/app/plugins/**` — Phase 1 (complete)
+- `client/src/**` — Phase 3
 
 ## Implementation Steps
 
 ### Step 1: Check roomRepository in dependencies.js
 
-If `roomRepository` is not exported from `src/app/runtime/dependencies.js`, add it following the same pattern as the other repositories.
+If not present, add it following the same pattern as the other repositories.
 
 ### Step 2: Create DashboardController
 
-Create `src/app/controllers/DashboardController.js` with constructor accepting `{ userRepository, licenseeRepository, contactRepository, messageRepository, roomRepository }`.
-
-Implement `stats(req, res)`:
-- Fetch user by `req.userId`; 404 if not found
-- Compute `startOfDay`, `endOfDay`, `sevenDaysAgo`
-- Branch on `user.isSuper` → call private `_superStats` or `_licenseeStats`
-- Both private methods run all queries in `Promise.all`
-
-See **Aggregation pipelines** section above for query details. Private methods return the plain object; `stats` wraps with `res.status(200).json(...)`.
-
-**Super response shape:**
+Create `src/app/controllers/DashboardController.js`. Constructor receives:
 ```js
-{
-  kind: 'super',
-  licensees: { total, active, by_kind: { demo, free, paid } },
-  message_volume: { per_day, per_hour, peak_throughput, avg_transfer_rate },
-  delivery_rate: { sent_today, failed_today, sent_pct, failed_pct },
-  queue: { pending_messages, avg_time_in_queue_seconds },
-  conversations: { started_today, ended_today, avg_messages_per_conversation, avg_duration_seconds },
+{ userRepository, licenseeRepository, contactRepository, messageRepository, roomRepository, redisConnection }
+```
+
+Store all as `this.*`. Bind all 8 action methods in the constructor.
+
+**Helper: `_resolveUser(req, res)`**
+```js
+async _resolveUser(req) {
+  return await this.userRepository.findFirst({ _id: req.userId })
 }
 ```
 
-**Licensee response shape:**
+**Helper: `_cached(key, fn)`** — wraps the Redis get/compute/set pattern:
 ```js
-{
-  kind: 'licensee',
-  contacts: { total, in_chatbot },
-  messages: { sent_today, failed_today, per_day },
+async _cached(key, fn) {
+  const cached = await this.redisConnection.get(key)
+  if (cached) return JSON.parse(cached)
+  const data = await fn()
+  await this.redisConnection.setex(key, 600, JSON.stringify(data))
+  return data
 }
 ```
+
+**Super actions (5)** — each follows: fetch user → check `isSuper` → check cache → compute → store cache → return
+
+`licensees(req, res)`:
+- Gate: `!user.isSuper` → 403
+- Cache key: `dashboard:super:licensees`
+- Queries (Promise.all): countDocuments for total, active, demo, free, paid
+- Returns: `{ total, active, by_kind: { demo, free, paid } }`
+
+`messageVolume(req, res)`:
+- Gate: `!user.isSuper` → 403
+- Cache key: `dashboard:super:message-volume`
+- Queries: per-day pipeline, per-hour pipeline
+- Computes: `peak_throughput = Math.max(...perHour.map(h => h.count))` (0 if empty), `avg_transfer_rate = parseFloat(((sentToday + failedToday) / 24).toFixed(2))`
+- Note: needs `sentToday` + `failedToday` counts for avg_transfer_rate — include them in the Promise.all
+- Returns: `{ per_day, per_hour, peak_throughput, avg_transfer_rate }`
+
+`deliveryRate(req, res)`:
+- Gate: `!user.isSuper` → 403
+- Cache key: `dashboard:super:delivery-rate`
+- Queries: countDocuments sended:true today, sended:false today
+- Computes percentages (0 if total is 0)
+- Returns: `{ sent_today, failed_today, sent_pct, failed_pct }`
+
+`queue(req, res)`:
+- Gate: `!user.isSuper` → 403
+- Cache key: `dashboard:super:queue`
+- Queries: countDocuments `{ sended: false, destination: 'to-messenger' }`, avg-time-in-queue pipeline
+- Returns: `{ pending_messages, avg_time_in_queue_seconds }`
+
+`conversations(req, res)`:
+- Gate: `!user.isSuper` → 403
+- Cache key: `dashboard:super:conversations`
+- Queries: Room.countDocuments started today, Room.countDocuments `{ closedAt: { $gte, $lt } }`, avg-msg-per-conv pipeline, avg-duration pipeline
+- Returns: `{ started_today, ended_today, avg_messages_per_conversation, avg_duration_seconds }`
+
+**Licensee actions (3)** — cache key scoped by `user.licensee`
+
+`contacts(req, res)`:
+- Gate: `user.isSuper` → 403
+- Cache key: `dashboard:licensee:${user.licensee}:contacts`
+- Queries: countDocuments total, countDocuments talkingWithChatBot:true
+- Returns: `{ total, in_chatbot }`
+
+`messagesToday(req, res)`:
+- Gate: `user.isSuper` → 403
+- Cache key: `dashboard:licensee:${user.licensee}:messages-today`
+- Queries: countDocuments sended:true today, sended:false today (both filtered by licensee)
+- Returns: `{ sent_today, failed_today, sent_pct, failed_pct }`
+
+`messagesPerDay(req, res)`:
+- Gate: `user.isSuper` → 403
+- Cache key: `dashboard:licensee:${user.licensee}:messages-per-day`
+- Queries: per-day pipeline with `licensee: user.licensee` filter
+- Returns: `{ per_day }`
 
 ### Step 3: Update MessagesController
 
-Add to constructor: `messageRepository` and `queueServer`. Bind `this.resend = this.resend.bind(this)`.
-
-Add `resend` action following the flow described in the Context section.
+Add `messageRepository` and `queueServer` to constructor. Bind `this.resend`. Implement `resend(req, res)` per the flow in the Context section.
 
 ### Step 4: Update resources-routes.js
 
-Add `roomRepository` to the `createRuntimeDependencies()` destructure if needed.
-
-Import `DashboardController`. Add to composition root:
+Import `DashboardController` and `redisConnection`. Add `roomRepository` to destructure if needed. Instantiate:
 ```js
 const dashboardController = new DashboardController({
-  userRepository, licenseeRepository, contactRepository, messageRepository, roomRepository,
+  userRepository, licenseeRepository, contactRepository, messageRepository, roomRepository, redisConnection,
 })
 ```
 
-Update `messagesController` instantiation to pass `messageRepository` and `queueServer`.
+Update `messagesController` to receive `messageRepository` and `queueServer`.
 
 Add routes:
 ```js
-router.get('/dashboard/stats', dashboardController.stats)
+router.get('/dashboard/licensees', dashboardController.licensees)
+router.get('/dashboard/message-volume', dashboardController.messageVolume)
+router.get('/dashboard/delivery-rate', dashboardController.deliveryRate)
+router.get('/dashboard/queue', dashboardController.queue)
+router.get('/dashboard/conversations', dashboardController.conversations)
+router.get('/dashboard/contacts', dashboardController.contacts)
+router.get('/dashboard/messages-today', dashboardController.messagesToday)
+router.get('/dashboard/messages-per-day', dashboardController.messagesPerDay)
 router.post('/messages/:id/resend', messagesController.resend)
 ```
 
 ### Step 5: Write specs
 
-**DashboardController.spec.js** — 4 cases minimum:
-1. Super user success: assert `kind: 'super'`, correct top-level keys, `peak_throughput = max(per_hour)`, percentages sum to 100
-2. Licensee user success: assert `kind: 'licensee'`, all queries scoped to `user.licensee`
-3. User not found: 404
-4. Repository error: 500
+**DashboardController.spec.js** — per action, cover:
+- Cache hit: `redisConnection.get` returns JSON → response served from cache, no DB queries
+- Cache miss: DB queries run, result stored in Redis, response returned
+- Wrong user kind: 403
+- User not found: 404
+- Repository error: 500
 
-**MessagesController.spec.js** additions — 4 cases:
-1. Resend success (super user): finds message, resets fields, calls `queueServer.addJob`, returns 200
-2. Resend success (licensee user, owns message): same, passes ownership check
-3. Resend 403: licensee user attempts resend of another licensee's message
+**MessagesController.spec.js** additions:
+1. Resend success (super): resets fields, enqueues, returns 200
+2. Resend success (licensee, owns message): passes ownership check
+3. Resend 403: licensee attempts cross-licensee resend
 4. Resend 404: message not found
 
 ## Testing
@@ -201,14 +270,15 @@ router.post('/messages/:id/resend', messagesController.resend)
 
 ## Documentation / KB Updates
 
-- [ ] No KB/doc updates required.
-- [ ] If `roomRepository` was missing from `dependencies.js`, run `document-solution` after completing.
+- [ ] No KB/doc updates required — Redis is already used in the project; caching pattern is self-documented in controller.
+- [ ] If `roomRepository` was missing from `dependencies.js`, run `document-solution`.
 
 ## Completion Criteria
 
-- [ ] `GET /resources/dashboard/stats` returns correct shape for both user kinds
-- [ ] `POST /resources/messages/:id/resend` re-queues the message and resets its state
-- [ ] 403 returned when a licensee user attempts to resend another licensee's message
+- [ ] All 8 dashboard endpoints return correct data and gate on user kind
+- [ ] Repeat requests within 10 minutes are served from Redis cache (no DB hit)
+- [ ] Resend resets message state and re-queues
+- [ ] 403 on cross-licensee resend attempt
 - [ ] All specs pass
 - [ ] No lint errors
 - [ ] Changes committed to `plan/dashboard-widgets/phase-2/task-02-backend`

--- a/.plans/dashboard-widgets/phase-2/task-02-backend/task.md
+++ b/.plans/dashboard-widgets/phase-2/task-02-backend/task.md
@@ -18,6 +18,24 @@ JWT payload: `{ id: user._id }`. Middleware sets `req.userId`. Each action fetch
 - Super-only endpoints return `403` if `!user.isSuper`
 - Licensee-only endpoints return `403` if `user.isSuper`
 
+### Date range params
+All time-scoped endpoints accept optional query params `startDate` and `endDate` (ISO 8601 strings). When absent, default to today's range.
+
+**Helper: `_parseDateRange(query)`** — used in every time-scoped action:
+```js
+_parseDateRange(query) {
+  const now = new Date()
+  const startOfDay = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const endOfDay = new Date(startOfDay.getTime() + 24 * 60 * 60 * 1000)
+  return {
+    startDate: query.startDate ? new Date(query.startDate) : startOfDay,
+    endDate:   query.endDate   ? new Date(query.endDate)   : endOfDay,
+  }
+}
+```
+
+Cards **not** date-scoped (no params): `licensees`, `contacts` — these are point-in-time counts.
+
 ### Caching
 `redisConnection` is exported from `src/config/redis.js` — import it directly into `DashboardController`. Pattern for every action:
 ```js
@@ -28,17 +46,17 @@ await redisConnection.setex(cacheKey, 600, JSON.stringify(data))
 return res.status(200).json(data)
 ```
 
-Cache keys:
-- Super (global): `dashboard:super:licensees`, `dashboard:super:message-volume`, `dashboard:super:delivery-rate`, `dashboard:super:queue`, `dashboard:super:conversations`
-- Licensee (per licensee): `dashboard:licensee:{licenseeId}:contacts`, `dashboard:licensee:{licenseeId}:messages-today`, `dashboard:licensee:{licenseeId}:messages-per-day`
+Cache keys — time-scoped endpoints **include the date range** so different calendar selections get independent cache entries:
+- `dashboard:super:licensees` (no dates)
+- `dashboard:super:message-volume:{startDate}:{endDate}`
+- `dashboard:super:delivery-rate:{startDate}:{endDate}`
+- `dashboard:super:queue:{startDate}:{endDate}`
+- `dashboard:super:conversations:{startDate}:{endDate}`
+- `dashboard:licensee:{licenseeId}:contacts` (no dates)
+- `dashboard:licensee:{licenseeId}:messages-today:{startDate}:{endDate}`
+- `dashboard:licensee:{licenseeId}:messages-per-day:{startDate}:{endDate}`
 
-### Date helpers (reused across actions)
-```js
-const now = new Date()
-const startOfDay = new Date(now.getFullYear(), now.getMonth(), now.getDate())
-const endOfDay = new Date(startOfDay.getTime() + 24 * 60 * 60 * 1000)
-const sevenDaysAgo = new Date(startOfDay.getTime() - 6 * 24 * 60 * 60 * 1000)
-```
+Where `{startDate}` and `{endDate}` are the ISO strings as received (or the default values formatted as ISO).
 
 ### Aggregation pipelines
 
@@ -163,59 +181,66 @@ async _cached(key, fn) {
 }
 ```
 
-**Super actions (5)** — each follows: fetch user → check `isSuper` → check cache → compute → store cache → return
+**Super actions (5)** — each follows: fetch user → check `isSuper` → parse date range → check cache → compute → store cache → return
 
 `licensees(req, res)`:
 - Gate: `!user.isSuper` → 403
+- **No date params** — point-in-time count
 - Cache key: `dashboard:super:licensees`
 - Queries (Promise.all): countDocuments for total, active, demo, free, paid
 - Returns: `{ total, active, by_kind: { demo, free, paid } }`
 
 `messageVolume(req, res)`:
 - Gate: `!user.isSuper` → 403
-- Cache key: `dashboard:super:message-volume`
-- Queries: per-day pipeline, per-hour pipeline
-- Computes: `peak_throughput = Math.max(...perHour.map(h => h.count))` (0 if empty), `avg_transfer_rate = parseFloat(((sentToday + failedToday) / 24).toFixed(2))`
-- Note: needs `sentToday` + `failedToday` counts for avg_transfer_rate — include them in the Promise.all
+- Parses `startDate`/`endDate` from `req.query` via `_parseDateRange`
+- Cache key: `dashboard:super:message-volume:${startDate.toISOString()}:${endDate.toISOString()}`
+- Queries: per-day pipeline, per-hour pipeline, sentCount + failedCount (for avg_transfer_rate)
+- Computes: `peak_throughput = Math.max(...perHour.map(h => h.count))` (0 if empty), `avg_transfer_rate = parseFloat(((sent + failed) / hourSpan).toFixed(2))` where `hourSpan = (endDate - startDate) / 3_600_000`
 - Returns: `{ per_day, per_hour, peak_throughput, avg_transfer_rate }`
 
 `deliveryRate(req, res)`:
 - Gate: `!user.isSuper` → 403
-- Cache key: `dashboard:super:delivery-rate`
-- Queries: countDocuments sended:true today, sended:false today
+- Parses date range
+- Cache key: `dashboard:super:delivery-rate:${startDate.toISOString()}:${endDate.toISOString()}`
+- Queries: countDocuments sended:true in range, sended:false in range
 - Computes percentages (0 if total is 0)
-- Returns: `{ sent_today, failed_today, sent_pct, failed_pct }`
+- Returns: `{ sent_today: sentCount, failed_today: failedCount, sent_pct, failed_pct }`
 
 `queue(req, res)`:
 - Gate: `!user.isSuper` → 403
-- Cache key: `dashboard:super:queue`
-- Queries: countDocuments `{ sended: false, destination: 'to-messenger' }`, avg-time-in-queue pipeline
+- Parses date range
+- Cache key: `dashboard:super:queue:${startDate.toISOString()}:${endDate.toISOString()}`
+- Queries: countDocuments `{ sended: false, destination: 'to-messenger' }` (current, no date filter), avg-time-in-queue pipeline scoped to date range
 - Returns: `{ pending_messages, avg_time_in_queue_seconds }`
 
 `conversations(req, res)`:
 - Gate: `!user.isSuper` → 403
-- Cache key: `dashboard:super:conversations`
-- Queries: Room.countDocuments started today, Room.countDocuments `{ closedAt: { $gte, $lt } }`, avg-msg-per-conv pipeline, avg-duration pipeline
-- Returns: `{ started_today, ended_today, avg_messages_per_conversation, avg_duration_seconds }`
+- Parses date range
+- Cache key: `dashboard:super:conversations:${startDate.toISOString()}:${endDate.toISOString()}`
+- Queries: Room.countDocuments started in range, Room.countDocuments `{ closedAt: { $gte, $lt } }`, avg-msg-per-conv pipeline scoped to range, avg-duration pipeline scoped to range
+- Returns: `{ started_today: startedCount, ended_today: endedCount, avg_messages_per_conversation, avg_duration_seconds }`
 
 **Licensee actions (3)** — cache key scoped by `user.licensee`
 
 `contacts(req, res)`:
 - Gate: `user.isSuper` → 403
+- **No date params** — point-in-time count
 - Cache key: `dashboard:licensee:${user.licensee}:contacts`
 - Queries: countDocuments total, countDocuments talkingWithChatBot:true
 - Returns: `{ total, in_chatbot }`
 
 `messagesToday(req, res)`:
 - Gate: `user.isSuper` → 403
-- Cache key: `dashboard:licensee:${user.licensee}:messages-today`
-- Queries: countDocuments sended:true today, sended:false today (both filtered by licensee)
-- Returns: `{ sent_today, failed_today, sent_pct, failed_pct }`
+- Parses date range
+- Cache key: `dashboard:licensee:${user.licensee}:messages-today:${startDate.toISOString()}:${endDate.toISOString()}`
+- Queries: countDocuments sended:true/false in range, both filtered by licensee
+- Returns: `{ sent_today: sentCount, failed_today: failedCount, sent_pct, failed_pct }`
 
 `messagesPerDay(req, res)`:
 - Gate: `user.isSuper` → 403
-- Cache key: `dashboard:licensee:${user.licensee}:messages-per-day`
-- Queries: per-day pipeline with `licensee: user.licensee` filter
+- Parses date range
+- Cache key: `dashboard:licensee:${user.licensee}:messages-per-day:${startDate.toISOString()}:${endDate.toISOString()}`
+- Queries: per-day pipeline with `licensee: user.licensee` filter and the parsed date range
 - Returns: `{ per_day }`
 
 ### Step 3: Update MessagesController

--- a/.plans/dashboard-widgets/phase-2/task-02-backend/task.md
+++ b/.plans/dashboard-widgets/phase-2/task-02-backend/task.md
@@ -1,0 +1,219 @@
+# Task: Backend — DashboardController + resend endpoint
+
+**Plan**: Dashboard Widgets
+**Phase**: 2
+**Task ID (phase-local)**: task-02
+**Task Path**: phase-2/task-02-backend
+**Depends On**: phase-1/task-01-room-schema
+**JIRA**: N/A
+
+## Objective
+
+Create `DashboardController` (role-aware stats) and add a `resend` action to `MessagesController`. Register both routes in `resources-routes.js`.
+
+Both endpoints touch `resources-routes.js`, so they are intentionally in the same task to avoid merge conflicts.
+
+## Context
+
+### Auth & user resolution
+JWT payload: `{ id: user._id }`. Middleware sets `req.userId`. Controller fetches user to resolve `isSuper` / `licensee`.
+
+### Stats endpoint
+`GET /resources/dashboard/stats` — returns role-branched JSON. Full response shapes in `overview.md`.
+
+Key notes:
+- `ended_today` now uses `closedAt` (available after Phase 1): `Room.countDocuments({ closedAt: { $gte: startOfDay, $lt: endOfDay } })`
+- `avg_duration_seconds`: `avg(closedAt - createdAt)` in seconds for rooms closed today
+- `avg_transfer_rate`: `(sent_today + failed_today) / 24` — messages per hour average
+- `peak_throughput`: `Math.max(...per_hour.map(h => h.count))`, 0 if empty
+
+### Resend endpoint
+`POST /resources/messages/:id/resend`
+
+Flow:
+1. Find message by `_id`
+2. Return 404 if not found
+3. **Authorization**: if user is not super, verify `message.licensee.toString() === user.licensee.toString()` — return 403 if mismatch
+4. Reset message state: set `sended = false`, clear `error = null`, clear `sendedAt = null`
+5. Save the message
+6. Re-add to Bull queue: `queueServer.addJob('send-message-to-messenger', { messageId: message._id })`
+7. Return 200 with the updated message
+
+> Before implementing step 6, read `src/app/services/SendMessageToMessenger.js` to confirm the expected `body` payload. If it expects more than `{ messageId }`, adjust accordingly.
+
+`MessagesController` will need `messageRepository` and `queueServer` injected. Check current constructor — it only has `createMessagesQuery`. Add the new deps without breaking the existing `index` action.
+
+### Aggregation pipelines (super stats)
+
+```js
+// Per-day (last 7 days)
+[
+  { $match: { createdAt: { $gte: sevenDaysAgo, $lt: endOfDay } } },
+  { $group: { _id: { $dateToString: { format: '%Y-%m-%d', date: '$createdAt' } }, count: { $sum: 1 } } },
+  { $sort: { _id: 1 } },
+]
+
+// Per-hour (today)
+[
+  { $match: { createdAt: { $gte: startOfDay, $lt: endOfDay } } },
+  { $group: { _id: { $dateToString: { format: '%Y-%m-%dT%H', date: '$createdAt' } }, count: { $sum: 1 } } },
+  { $sort: { _id: 1 } },
+]
+
+// Avg time in queue (messages sent today where sendedAt exists)
+[
+  { $match: { sendedAt: { $exists: true }, createdAt: { $gte: startOfDay, $lt: endOfDay } } },
+  { $group: { _id: null, avg: { $avg: { $divide: [{ $subtract: ['$sendedAt', '$createdAt'] }, 1000] } } } },
+]
+
+// Avg messages per conversation (today)
+[
+  { $match: { room: { $exists: true }, createdAt: { $gte: startOfDay, $lt: endOfDay } } },
+  { $group: { _id: '$room', count: { $sum: 1 } } },
+  { $group: { _id: null, avg: { $avg: '$count' } } },
+]
+
+// Avg conversation duration (rooms closed today)
+[
+  { $match: { closedAt: { $gte: startOfDay, $lt: endOfDay } } },
+  { $group: { _id: null, avg: { $avg: { $divide: [{ $subtract: ['$closedAt', '$createdAt'] }, 1000] } } } },
+]
+```
+
+### Existing patterns
+- Controller structure: `src/app/controllers/LicenseesController.js`
+- Error shape: `{ errors: { message: err.toString() } }`
+- DI wiring: `src/app/routes/resources-routes.js` composition root
+
+## Before You Start
+
+- [ ] Verify `phase-1/task-01-room-schema/status.md` shows `complete`
+- [ ] `git switch main && git pull --rebase origin main`
+- [ ] Create branch: `git switch -c plan/dashboard-widgets/phase-2/task-02-backend`
+- [ ] Read `docs/kb/architecture/dependency-injection-runtime-wiring.md`
+- [ ] Read `src/app/controllers/MessagesController.js` — understand current constructor
+- [ ] Read `src/app/services/SendMessageToMessenger.js` — confirm resend payload shape
+- [ ] Read `src/app/runtime/dependencies.js` — check if `roomRepository` is already exported
+- [ ] Check `status.md` — must be `not-started`
+- [ ] Mark `status.md` as `in-progress`
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/app/controllers/DashboardController.js` | create | Stats action |
+| `src/app/controllers/DashboardController.spec.js` | create | Unit specs |
+| `src/app/controllers/MessagesController.js` | modify | Add `resend` action + inject `messageRepository` + `queueServer` |
+| `src/app/controllers/MessagesController.spec.js` | modify | Add resend specs |
+| `src/app/routes/resources-routes.js` | modify | Add DashboardController wiring + route; add resend route |
+| `src/app/runtime/dependencies.js` | modify if needed | Add `roomRepository` if missing |
+
+### Do NOT Modify
+
+- `src/app/models/**` — owned by phase-1 (complete)
+- `src/app/plugins/**` — owned by phase-1 (complete)
+- `client/src/**` — owned by phase-3/task-03-frontend
+
+## Implementation Steps
+
+### Step 1: Check roomRepository in dependencies.js
+
+If `roomRepository` is not exported from `src/app/runtime/dependencies.js`, add it following the same pattern as the other repositories.
+
+### Step 2: Create DashboardController
+
+Create `src/app/controllers/DashboardController.js` with constructor accepting `{ userRepository, licenseeRepository, contactRepository, messageRepository, roomRepository }`.
+
+Implement `stats(req, res)`:
+- Fetch user by `req.userId`; 404 if not found
+- Compute `startOfDay`, `endOfDay`, `sevenDaysAgo`
+- Branch on `user.isSuper` → call private `_superStats` or `_licenseeStats`
+- Both private methods run all queries in `Promise.all`
+
+See **Aggregation pipelines** section above for query details. Private methods return the plain object; `stats` wraps with `res.status(200).json(...)`.
+
+**Super response shape:**
+```js
+{
+  kind: 'super',
+  licensees: { total, active, by_kind: { demo, free, paid } },
+  message_volume: { per_day, per_hour, peak_throughput, avg_transfer_rate },
+  delivery_rate: { sent_today, failed_today, sent_pct, failed_pct },
+  queue: { pending_messages, avg_time_in_queue_seconds },
+  conversations: { started_today, ended_today, avg_messages_per_conversation, avg_duration_seconds },
+}
+```
+
+**Licensee response shape:**
+```js
+{
+  kind: 'licensee',
+  contacts: { total, in_chatbot },
+  messages: { sent_today, failed_today, per_day },
+}
+```
+
+### Step 3: Update MessagesController
+
+Add to constructor: `messageRepository` and `queueServer`. Bind `this.resend = this.resend.bind(this)`.
+
+Add `resend` action following the flow described in the Context section.
+
+### Step 4: Update resources-routes.js
+
+Add `roomRepository` to the `createRuntimeDependencies()` destructure if needed.
+
+Import `DashboardController`. Add to composition root:
+```js
+const dashboardController = new DashboardController({
+  userRepository, licenseeRepository, contactRepository, messageRepository, roomRepository,
+})
+```
+
+Update `messagesController` instantiation to pass `messageRepository` and `queueServer`.
+
+Add routes:
+```js
+router.get('/dashboard/stats', dashboardController.stats)
+router.post('/messages/:id/resend', messagesController.resend)
+```
+
+### Step 5: Write specs
+
+**DashboardController.spec.js** — 4 cases minimum:
+1. Super user success: assert `kind: 'super'`, correct top-level keys, `peak_throughput = max(per_hour)`, percentages sum to 100
+2. Licensee user success: assert `kind: 'licensee'`, all queries scoped to `user.licensee`
+3. User not found: 404
+4. Repository error: 500
+
+**MessagesController.spec.js** additions — 4 cases:
+1. Resend success (super user): finds message, resets fields, calls `queueServer.addJob`, returns 200
+2. Resend success (licensee user, owns message): same, passes ownership check
+3. Resend 403: licensee user attempts resend of another licensee's message
+4. Resend 404: message not found
+
+## Testing
+
+- [ ] `npx jest src/app/controllers/DashboardController.spec.js` passes
+- [ ] `npx jest src/app/controllers/MessagesController.spec.js` passes
+- [ ] `npx jest` (full suite) passes
+- [ ] `npx eslint .` reports no new errors
+
+## Documentation / KB Updates
+
+- [ ] No KB/doc updates required.
+- [ ] If `roomRepository` was missing from `dependencies.js`, run `document-solution` after completing.
+
+## Completion Criteria
+
+- [ ] `GET /resources/dashboard/stats` returns correct shape for both user kinds
+- [ ] `POST /resources/messages/:id/resend` re-queues the message and resets its state
+- [ ] 403 returned when a licensee user attempts to resend another licensee's message
+- [ ] All specs pass
+- [ ] No lint errors
+- [ ] Changes committed to `plan/dashboard-widgets/phase-2/task-02-backend`
+- [ ] `status.md` updated to `complete`
+
+## Conflict Avoidance Notes
+
+- No parallel tasks in Phase 2.

--- a/.plans/dashboard-widgets/phase-2/task-02-frontend-dashboard/status.md
+++ b/.plans/dashboard-widgets/phase-2/task-02-frontend-dashboard/status.md
@@ -1,0 +1,25 @@
+# Status: Frontend dashboard widgets
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-07
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-07 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/dashboard-widgets/phase-2/task-02-frontend-dashboard/task.md
+++ b/.plans/dashboard-widgets/phase-2/task-02-frontend-dashboard/task.md
@@ -1,0 +1,149 @@
+# ~~SUPERSEDED~~ — see phase-3/task-03-frontend
+
+# Task: Frontend dashboard widgets
+
+**Plan**: Dashboard Widgets
+**Phase**: 2
+**Task ID (phase-local)**: task-02
+**Task Path**: phase-2/task-02-frontend-dashboard
+**Depends On**: phase-1/task-01-backend-stats-endpoint
+**JIRA**: N/A
+
+## Objective
+
+Replace the empty Dashboard stub with role-aware stat widgets. The `kind` field in the API response drives which layout is rendered.
+
+## Context
+
+**Dashboard page**: `client/src/pages/Dashboard/index.js` — currently `<h1>Dashboard</h1>`.
+
+**Service pattern**: `client/src/services/licensee.js` — `getToken()` → header → `api().get(url, { headers })`.
+
+**UI stack**: Bootstrap 5 + Bootswatch Flatly. No new library installs. Use Bootstrap card grid and plain `<table>` for tabular data.
+
+---
+
+## Widget Specs
+
+### Super user layout
+
+**Row 1 — Licensees (1 card)**
+- Total / Active count
+- By-kind breakdown: demo / free / paid
+
+**Row 2 — Message Volume (1 card)**
+- Per-day table (last 7 days): date | count
+- Per-hour table (today): hour | count
+- Peak throughput: `peak_throughput` msgs/hr
+- Avg transfer rate: `avg_transfer_rate` msgs/hr
+
+**Row 3 — Delivery Rate (1 card)**
+- Sent today: `sent_today` (`sent_pct`%)
+- Failed today: `failed_today` (`failed_pct`%) — **this card section is clickable** (deferred: see note below)
+
+**Row 4 — Queue (1 card)**
+- Pending messages: `pending_messages`
+- Avg time in queue: `avg_time_in_queue_seconds`s
+
+**Row 5 — Conversations (1 card)**
+- Started today: `started_today`
+- Ended today: `ended_today`
+- Avg messages/conversation: `avg_messages_per_conversation`
+
+> **Deferred**: The failed-messages clickable/resend interaction is not implemented in this task — the open decision on resend strategy must be resolved first (see `overview.md`). Render the failed count as a plain stat for now; add a `// TODO: make clickable when resend strategy is decided` comment.
+
+---
+
+### Licensee user layout
+
+**Row 1 — Contacts (1 card)**
+- Total contacts
+- Currently in chatbot
+
+**Row 2 — Messages Today (1 card)**
+- Sent: `sent_today`
+- Failed: `failed_today`
+
+**Row 3 — Messages per Day (1 card)**
+- Table: date | count (last 7 days)
+
+---
+
+## Before You Start
+
+- [ ] Verify `phase-1/task-01-backend-stats-endpoint/status.md` shows `complete`
+- [ ] `git switch main && git pull --rebase origin main`
+- [ ] Create branch: `git switch -c plan/dashboard-widgets/phase-2/task-02-frontend-dashboard`
+- [ ] Read `client/src/services/licensee.js` — confirm service pattern
+- [ ] Read `client/src/pages/Reports/Billing/scenes/Index/index.js` — confirm page pattern
+- [ ] Check `status.md` — must be `not-started`
+- [ ] Mark `status.md` as `in-progress`
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `client/src/services/dashboard.js` | create | `getDashboardStats()` |
+| `client/src/pages/Dashboard/index.js` | modify | Replace stub with widgets |
+
+### Do NOT Modify
+
+- `src/app/**` — backend complete; leave as-is
+- Any other client pages or services
+
+## Implementation Steps
+
+### Step 1: Create service
+
+`client/src/services/dashboard.js`:
+```js
+import { getToken } from './auth'
+import api from './api'
+
+function getDashboardStats() {
+  const headers = { 'x-access-token': getToken() }
+  return api().get('resources/dashboard/stats', { headers })
+}
+
+export { getDashboardStats }
+```
+
+### Step 2: Implement Dashboard page
+
+State: `stats` (null), `loading` (true), `error` (null).
+
+`useEffect` on mount → `getDashboardStats()` → set state. Render:
+- `loading`: spinner / "Carregando..."
+- `error`: dismissible Bootstrap alert
+- `stats.kind === 'super'`: super layout (5 rows of cards)
+- `stats.kind === 'licensee'`: licensee layout (3 cards)
+
+Keep all markup inline. Extract only if the per-day/per-hour tables appear in both layouts and reducing the repetition is obviously cleaner — a small `<DayTable rows={...} />` helper is acceptable in that case only.
+
+### Step 3: Manual smoke
+
+`yarn run dev`. Log in as super user and licensee user. Confirm correct card sets, spinner, and no console errors.
+
+## Testing
+
+- [ ] `npx jest` (full suite) passes
+- [ ] `npx eslint .` reports no new errors
+- [ ] Manual smoke: both layouts render correctly with real data
+
+## Documentation / KB Updates
+
+- [ ] No KB/doc updates required.
+
+## Completion Criteria
+
+- [ ] Super layout: 5 widget sections with real data
+- [ ] Licensee layout: 3 widget cards with scoped data
+- [ ] Failed stat includes `// TODO` comment noting deferred resend interaction
+- [ ] Loading and error states work
+- [ ] No lint errors
+- [ ] Changes committed to `plan/dashboard-widgets/phase-2/task-02-frontend-dashboard`
+- [ ] `status.md` updated to `complete`
+
+## Conflict Avoidance Notes
+
+- No parallel tasks in Phase 2.

--- a/.plans/dashboard-widgets/phase-3/task-03-frontend/status.md
+++ b/.plans/dashboard-widgets/phase-3/task-03-frontend/status.md
@@ -1,0 +1,25 @@
+# Status: Frontend dashboard widgets + resend modal
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-07
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-07 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/dashboard-widgets/phase-3/task-03-frontend/status.md
+++ b/.plans/dashboard-widgets/phase-3/task-03-frontend/status.md
@@ -1,9 +1,9 @@
 # Status: Frontend dashboard widgets + resend modal
 
-**Current Status**: not-started
+**Current Status**: complete
 **Last Updated**: 2026-05-07
-**Agent**: —
-**Branch**: —
+**Agent**: claude-sonnet-4-6
+**Branch**: plan/dashboard-widgets/phase-3/task-03-frontend
 **PR**: —
 
 ## Status History
@@ -11,6 +11,8 @@
 | Timestamp | Status | Agent | Notes |
 |-----------|--------|-------|-------|
 | 2026-05-07 | not-started | — | Task created |
+| 2026-05-07 | in-progress | claude-sonnet-4-6 | Implementation started |
+| 2026-05-07 | complete | claude-sonnet-4-6 | All 11 files created/modified, tests pass, no new lint errors |
 
 ## Blockers
 

--- a/.plans/dashboard-widgets/phase-3/task-03-frontend/task.md
+++ b/.plans/dashboard-widgets/phase-3/task-03-frontend/task.md
@@ -1,4 +1,4 @@
-# Task: Frontend dashboard widgets + resend modal
+# Task: Frontend — independent card components + resend modal
 
 **Plan**: Dashboard Widgets
 **Phase**: 3
@@ -9,52 +9,155 @@
 
 ## Objective
 
-Replace the empty Dashboard stub with role-aware stat widgets. Super users get 5 widget sections including a clickable failed-messages card that opens a modal with per-message resend buttons. Licensee users get 3 scoped cards.
+Replace the empty Dashboard stub with role-aware card components. Each card is self-contained: it fires its own request on mount, manages its own loading and error state, and renders independently. Super users see 5 cards; licensee users see 3 cards.
 
 ## Context
 
 **Dashboard page**: `client/src/pages/Dashboard/index.js` — currently `<h1>Dashboard</h1>`.
 
+**User kind detection**: call `fetchLoggedUser()` (from `client/src/services/auth.js`) once in the Dashboard page on mount to determine `isSuper`. Pass it down as a prop to decide which card set to render. Do not duplicate this call inside each card.
+
 **Service pattern**: `client/src/services/licensee.js` — `getToken()` → `api().get/post(url, { headers })`.
 
-**API endpoints available after Phase 2:**
-- `GET /resources/dashboard/stats` — returns `kind`-tagged payload (see `overview.md`)
-- `POST /resources/messages/:id/resend` — re-queues a failed message; returns updated message
+**UI stack**: Bootstrap 5 + Bootswatch Flatly. No new library installs. Each card is a Bootstrap `.card` inside a responsive grid.
 
-**UI stack**: Bootstrap 5 + Bootswatch Flatly. No new library installs. Bootstrap cards, modals, and tables only.
+**Available backend endpoints (from Phase 2):**
+
+| Endpoint | Used by |
+|----------|---------|
+| `GET /resources/dashboard/licensees` | SuperLicenseesCard |
+| `GET /resources/dashboard/message-volume` | SuperMessageVolumeCard |
+| `GET /resources/dashboard/delivery-rate` | SuperDeliveryRateCard |
+| `GET /resources/dashboard/queue` | SuperQueueCard |
+| `GET /resources/dashboard/conversations` | SuperConversationsCard |
+| `GET /resources/dashboard/contacts` | LicenseeContactsCard |
+| `GET /resources/dashboard/messages-today` | LicenseeMessagesTodayCard |
+| `GET /resources/dashboard/messages-per-day` | LicenseeMessagesPerDayCard |
+| `GET /resources/messages?sended=false&limit=50` | FailedMessagesModal (lazy) |
+| `POST /resources/messages/:id/resend` | FailedMessagesModal resend button |
 
 ---
 
-## Widget Specs
+## Card Component Pattern
 
-### Super user layout
+Every card follows this structure (adapt naming per card):
 
-| Widget | Data | Notes |
-|--------|------|-------|
-| Licenciados | `licensees.total`, `licensees.active`, `licensees.by_kind` | 3 inline stats |
-| Volume de Mensagens | `message_volume.per_day` (table), `message_volume.per_hour` (table), `peak_throughput`, `avg_transfer_rate` | Two small tables + 2 stats |
-| Taxa de Entrega | `delivery_rate.sent_today` + `sent_pct`, `delivery_rate.failed_today` + `failed_pct` | Failed stat is **clickable** → opens modal |
-| Fila | `queue.pending_messages`, `queue.avg_time_in_queue_seconds` | 2 stats |
-| Conversas | `conversations.started_today`, `conversations.ended_today`, `conversations.avg_messages_per_conversation`, `conversations.avg_duration_seconds` | 4 stats |
+```jsx
+function SuperLicenseesCard() {
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
 
-### Failed messages modal
+  useEffect(() => {
+    getDashboardLicensees()
+      .then(res => setData(res.data))
+      .catch(() => setError('Erro ao carregar dados.'))
+      .finally(() => setLoading(false))
+  }, [])
 
-Triggered by clicking the failed count in the Delivery Rate card.
+  if (loading) return <div className="card"><div className="card-body">Carregando...</div></div>
+  if (error)   return <div className="card"><div className="card-body text-danger">{error}</div></div>
 
-On open:
-- Call `GET /resources/messages?sended=false&page=1&limit=50` (existing endpoint, filtered) to fetch failed messages
-- Render a Bootstrap modal with a table: contact number | text preview | error | "Reenviar" button
-- Each "Reenviar" button calls `POST /resources/messages/:id/resend`
-- On success: remove the row from the table; update the failed count in the card
-- On error: show an inline error on the row
+  return (
+    <div className="card">
+      <div className="card-header">Licenciados</div>
+      <div className="card-body">
+        {/* render data */}
+      </div>
+    </div>
+  )
+}
+```
 
-### Licensee user layout
+Each card lives in its own file under `client/src/pages/Dashboard/cards/`.
 
-| Widget | Data |
-|--------|------|
-| Contatos | `contacts.total`, `contacts.in_chatbot` |
-| Mensagens Hoje | `messages.sent_today`, `messages.failed_today` |
-| Mensagens por Dia | `messages.per_day` table (7 days) |
+---
+
+## Card Specs
+
+### Super cards
+
+**`SuperLicenseesCard`** (`cards/SuperLicenseesCard.js`)
+- `total` / `active` inline stats
+- `by_kind`: demo / free / paid counts
+
+**`SuperMessageVolumeCard`** (`cards/SuperMessageVolumeCard.js`)
+- `peak_throughput` and `avg_transfer_rate` as stat numbers
+- `per_day`: table with date | count (7 rows)
+- `per_hour`: table with hour | count (up to 24 rows)
+
+**`SuperDeliveryRateCard`** (`cards/SuperDeliveryRateCard.js`)
+- Sent: `sent_today` (`sent_pct`%)
+- Failed: `failed_today` (`failed_pct`%) — **clickable**, opens `FailedMessagesModal`
+
+**`SuperQueueCard`** (`cards/SuperQueueCard.js`)
+- `pending_messages`
+- `avg_time_in_queue_seconds`
+
+**`SuperConversationsCard`** (`cards/SuperConversationsCard.js`)
+- `started_today`, `ended_today`
+- `avg_messages_per_conversation`, `avg_duration_seconds`
+
+### Licensee cards
+
+**`LicenseeContactsCard`** (`cards/LicenseeContactsCard.js`)
+- `total`, `in_chatbot`
+
+**`LicenseeMessagesTodayCard`** (`cards/LicenseeMessagesTodayCard.js`)
+- `sent_today`, `failed_today`, percentages
+
+**`LicenseeMessagesPerDayCard`** (`cards/LicenseeMessagesPerDayCard.js`)
+- `per_day` table (7 rows)
+
+### `FailedMessagesModal` (`cards/FailedMessagesModal.js`)
+
+Props: `{ isOpen, onClose, onResendSuccess }`
+
+On open: calls `getMessages({ sended: false, limit: 50 })` → renders Bootstrap modal table:
+- Columns: contact number | text preview | error | "Reenviar" button
+- "Reenviar" calls `resendMessage(id)` → on success: removes row, calls `onResendSuccess()` (parent decrements count)
+- On error: shows inline row error
+
+---
+
+## Dashboard Page
+
+`client/src/pages/Dashboard/index.js`:
+
+```jsx
+export default function Dashboard() {
+  const [user, setUser] = useState(null)
+  const [loadingUser, setLoadingUser] = useState(true)
+
+  useEffect(() => {
+    fetchLoggedUser()
+      .then(setUser)
+      .finally(() => setLoadingUser(false))
+  }, [])
+
+  if (loadingUser) return <p>Carregando...</p>
+
+  if (user?.isSuper) {
+    return (
+      <div className="row g-3">
+        <div className="col-12 col-md-6"><SuperLicenseesCard /></div>
+        <div className="col-12 col-md-6"><SuperMessageVolumeCard /></div>
+        <div className="col-12 col-md-6"><SuperDeliveryRateCard /></div>
+        <div className="col-12 col-md-6"><SuperQueueCard /></div>
+        <div className="col-12"><SuperConversationsCard /></div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="row g-3">
+      <div className="col-12 col-md-4"><LicenseeContactsCard /></div>
+      <div className="col-12 col-md-4"><LicenseeMessagesTodayCard /></div>
+      <div className="col-12 col-md-4"><LicenseeMessagesPerDayCard /></div>
+    </div>
+  )
+}
+```
 
 ---
 
@@ -64,8 +167,8 @@ On open:
 - [ ] `git switch main && git pull --rebase origin main`
 - [ ] Create branch: `git switch -c plan/dashboard-widgets/phase-3/task-03-frontend`
 - [ ] Read `client/src/services/licensee.js` — confirm service pattern
-- [ ] Read `client/src/services/message.js` — confirm how messages are fetched (filters available)
-- [ ] Read `client/src/pages/Reports/Billing/scenes/Index/index.js` — confirm page pattern
+- [ ] Read `client/src/services/auth.js` — confirm `fetchLoggedUser()` shape
+- [ ] Read `client/src/services/message.js` — confirm `getMessages` query params
 - [ ] Check `status.md` — must be `not-started`
 - [ ] Mark `status.md` as `in-progress`
 
@@ -73,35 +176,47 @@ On open:
 
 | File | Action | Notes |
 |------|--------|-------|
-| `client/src/services/dashboard.js` | create | `getDashboardStats()` |
-| `client/src/services/message.js` | modify | Add `resendMessage(id)` function |
-| `client/src/pages/Dashboard/index.js` | modify | Replace stub with widget layout |
+| `client/src/services/dashboard.js` | create | 8 service functions |
+| `client/src/services/message.js` | modify | Add `resendMessage(id)` |
+| `client/src/pages/Dashboard/index.js` | modify | Orchestrate card layout by user kind |
+| `client/src/pages/Dashboard/cards/SuperLicenseesCard.js` | create | |
+| `client/src/pages/Dashboard/cards/SuperMessageVolumeCard.js` | create | |
+| `client/src/pages/Dashboard/cards/SuperDeliveryRateCard.js` | create | |
+| `client/src/pages/Dashboard/cards/SuperQueueCard.js` | create | |
+| `client/src/pages/Dashboard/cards/SuperConversationsCard.js` | create | |
+| `client/src/pages/Dashboard/cards/LicenseeContactsCard.js` | create | |
+| `client/src/pages/Dashboard/cards/LicenseeMessagesTodayCard.js` | create | |
+| `client/src/pages/Dashboard/cards/LicenseeMessagesPerDayCard.js` | create | |
+| `client/src/pages/Dashboard/cards/FailedMessagesModal.js` | create | |
 
 ### Do NOT Modify
 
 - `src/app/**` — backend complete
-- Any other client pages or services
 
 ## Implementation Steps
 
-### Step 1: Dashboard service
+### Step 1: Create dashboard service
 
-`client/src/services/dashboard.js`:
+`client/src/services/dashboard.js` — 8 functions, one per endpoint:
 ```js
 import { getToken } from './auth'
 import api from './api'
 
-function getDashboardStats() {
-  const headers = { 'x-access-token': getToken() }
-  return api().get('resources/dashboard/stats', { headers })
-}
+const headers = () => ({ 'x-access-token': getToken() })
 
-export { getDashboardStats }
+export function getDashboardLicensees()    { return api().get('resources/dashboard/licensees',       { headers: headers() }) }
+export function getDashboardMessageVolume(){ return api().get('resources/dashboard/message-volume',  { headers: headers() }) }
+export function getDashboardDeliveryRate() { return api().get('resources/dashboard/delivery-rate',   { headers: headers() }) }
+export function getDashboardQueue()        { return api().get('resources/dashboard/queue',            { headers: headers() }) }
+export function getDashboardConversations(){ return api().get('resources/dashboard/conversations',    { headers: headers() }) }
+export function getDashboardContacts()     { return api().get('resources/dashboard/contacts',         { headers: headers() }) }
+export function getDashboardMessagesToday(){ return api().get('resources/dashboard/messages-today',   { headers: headers() }) }
+export function getDashboardMessagesPerDay(){ return api().get('resources/dashboard/messages-per-day',{ headers: headers() }) }
 ```
 
 ### Step 2: Add resendMessage to message service
 
-In `client/src/services/message.js`, add:
+In `client/src/services/message.js`:
 ```js
 function resendMessage(id) {
   const headers = { 'x-access-token': getToken() }
@@ -109,40 +224,23 @@ function resendMessage(id) {
 }
 ```
 
-Export it alongside the existing exports.
+### Step 3: Create card components
 
-### Step 3: Implement Dashboard page
+One file per card following the pattern defined above. All live in `client/src/pages/Dashboard/cards/`.
 
-State:
-- `stats` (null) — from getDashboardStats
-- `loading` (true)
-- `error` (null)
-- `failedMessages` ([]) — loaded lazily when modal opens
-- `modalOpen` (false)
-- `modalLoading` (false)
+### Step 4: Implement Dashboard page
 
-On mount: call `getDashboardStats()` → set `stats`, `loading: false`. On error set `error`.
+Replace `index.js` stub with the orchestration component shown above.
 
-Render based on `stats.kind`:
-- `'super'` → super layout (5 sections)
-- `'licensee'` → licensee layout (3 cards)
+### Step 5: Manual smoke
 
-**Modal behaviour:**
-- Clicking the failed stat sets `modalOpen: true` and triggers `getMessages({ sended: false, limit: 50 })` → `failedMessages`
-- Each row has a "Reenviar" button that calls `resendMessage(id)`, then removes the row on success
-- After a successful resend, decrement `stats.delivery_rate.failed_today` in local state
-
-Keep all markup inline. Extract only a `<DayTable rows={[]} />` helper if the per-day table appears in more than one place.
-
-### Step 4: Manual smoke
-
-`yarn run dev`. Test as both user types. Confirm: correct widgets, failed modal opens, resend removes the row.
+`yarn run dev`. Log in as super and licensee. Confirm: cards load independently (staggered if one is slow), failed modal opens, resend removes row.
 
 ## Testing
 
 - [ ] `npx jest` (full suite) passes
 - [ ] `npx eslint .` reports no new errors
-- [ ] Manual smoke: both layouts, modal open/close, resend flow
+- [ ] Manual smoke: both user kinds, independent card loading, resend modal
 
 ## Documentation / KB Updates
 
@@ -150,11 +248,10 @@ Keep all markup inline. Extract only a `<DayTable rows={[]} />` helper if the pe
 
 ## Completion Criteria
 
-- [ ] Super layout: 5 widget sections with real data
-- [ ] Failed stat is clickable and opens modal with resend buttons
-- [ ] Successful resend removes the row and decrements the failed count
-- [ ] Licensee layout: 3 scoped widget cards
-- [ ] Loading and error states work
+- [ ] Super: 5 card components render independently with real data
+- [ ] Licensee: 3 card components render independently with scoped data
+- [ ] Each card shows its own loading/error state
+- [ ] Failed stat opens modal; resend removes row and decrements count in parent card
 - [ ] No lint errors
 - [ ] Changes committed to `plan/dashboard-widgets/phase-3/task-03-frontend`
 - [ ] `status.md` updated to `complete`

--- a/.plans/dashboard-widgets/phase-3/task-03-frontend/task.md
+++ b/.plans/dashboard-widgets/phase-3/task-03-frontend/task.md
@@ -1,0 +1,164 @@
+# Task: Frontend dashboard widgets + resend modal
+
+**Plan**: Dashboard Widgets
+**Phase**: 3
+**Task ID (phase-local)**: task-03
+**Task Path**: phase-3/task-03-frontend
+**Depends On**: phase-2/task-02-backend
+**JIRA**: N/A
+
+## Objective
+
+Replace the empty Dashboard stub with role-aware stat widgets. Super users get 5 widget sections including a clickable failed-messages card that opens a modal with per-message resend buttons. Licensee users get 3 scoped cards.
+
+## Context
+
+**Dashboard page**: `client/src/pages/Dashboard/index.js` — currently `<h1>Dashboard</h1>`.
+
+**Service pattern**: `client/src/services/licensee.js` — `getToken()` → `api().get/post(url, { headers })`.
+
+**API endpoints available after Phase 2:**
+- `GET /resources/dashboard/stats` — returns `kind`-tagged payload (see `overview.md`)
+- `POST /resources/messages/:id/resend` — re-queues a failed message; returns updated message
+
+**UI stack**: Bootstrap 5 + Bootswatch Flatly. No new library installs. Bootstrap cards, modals, and tables only.
+
+---
+
+## Widget Specs
+
+### Super user layout
+
+| Widget | Data | Notes |
+|--------|------|-------|
+| Licenciados | `licensees.total`, `licensees.active`, `licensees.by_kind` | 3 inline stats |
+| Volume de Mensagens | `message_volume.per_day` (table), `message_volume.per_hour` (table), `peak_throughput`, `avg_transfer_rate` | Two small tables + 2 stats |
+| Taxa de Entrega | `delivery_rate.sent_today` + `sent_pct`, `delivery_rate.failed_today` + `failed_pct` | Failed stat is **clickable** → opens modal |
+| Fila | `queue.pending_messages`, `queue.avg_time_in_queue_seconds` | 2 stats |
+| Conversas | `conversations.started_today`, `conversations.ended_today`, `conversations.avg_messages_per_conversation`, `conversations.avg_duration_seconds` | 4 stats |
+
+### Failed messages modal
+
+Triggered by clicking the failed count in the Delivery Rate card.
+
+On open:
+- Call `GET /resources/messages?sended=false&page=1&limit=50` (existing endpoint, filtered) to fetch failed messages
+- Render a Bootstrap modal with a table: contact number | text preview | error | "Reenviar" button
+- Each "Reenviar" button calls `POST /resources/messages/:id/resend`
+- On success: remove the row from the table; update the failed count in the card
+- On error: show an inline error on the row
+
+### Licensee user layout
+
+| Widget | Data |
+|--------|------|
+| Contatos | `contacts.total`, `contacts.in_chatbot` |
+| Mensagens Hoje | `messages.sent_today`, `messages.failed_today` |
+| Mensagens por Dia | `messages.per_day` table (7 days) |
+
+---
+
+## Before You Start
+
+- [ ] Verify `phase-2/task-02-backend/status.md` shows `complete`
+- [ ] `git switch main && git pull --rebase origin main`
+- [ ] Create branch: `git switch -c plan/dashboard-widgets/phase-3/task-03-frontend`
+- [ ] Read `client/src/services/licensee.js` — confirm service pattern
+- [ ] Read `client/src/services/message.js` — confirm how messages are fetched (filters available)
+- [ ] Read `client/src/pages/Reports/Billing/scenes/Index/index.js` — confirm page pattern
+- [ ] Check `status.md` — must be `not-started`
+- [ ] Mark `status.md` as `in-progress`
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `client/src/services/dashboard.js` | create | `getDashboardStats()` |
+| `client/src/services/message.js` | modify | Add `resendMessage(id)` function |
+| `client/src/pages/Dashboard/index.js` | modify | Replace stub with widget layout |
+
+### Do NOT Modify
+
+- `src/app/**` — backend complete
+- Any other client pages or services
+
+## Implementation Steps
+
+### Step 1: Dashboard service
+
+`client/src/services/dashboard.js`:
+```js
+import { getToken } from './auth'
+import api from './api'
+
+function getDashboardStats() {
+  const headers = { 'x-access-token': getToken() }
+  return api().get('resources/dashboard/stats', { headers })
+}
+
+export { getDashboardStats }
+```
+
+### Step 2: Add resendMessage to message service
+
+In `client/src/services/message.js`, add:
+```js
+function resendMessage(id) {
+  const headers = { 'x-access-token': getToken() }
+  return api().post(`resources/messages/${id}/resend`, { headers })
+}
+```
+
+Export it alongside the existing exports.
+
+### Step 3: Implement Dashboard page
+
+State:
+- `stats` (null) — from getDashboardStats
+- `loading` (true)
+- `error` (null)
+- `failedMessages` ([]) — loaded lazily when modal opens
+- `modalOpen` (false)
+- `modalLoading` (false)
+
+On mount: call `getDashboardStats()` → set `stats`, `loading: false`. On error set `error`.
+
+Render based on `stats.kind`:
+- `'super'` → super layout (5 sections)
+- `'licensee'` → licensee layout (3 cards)
+
+**Modal behaviour:**
+- Clicking the failed stat sets `modalOpen: true` and triggers `getMessages({ sended: false, limit: 50 })` → `failedMessages`
+- Each row has a "Reenviar" button that calls `resendMessage(id)`, then removes the row on success
+- After a successful resend, decrement `stats.delivery_rate.failed_today` in local state
+
+Keep all markup inline. Extract only a `<DayTable rows={[]} />` helper if the per-day table appears in more than one place.
+
+### Step 4: Manual smoke
+
+`yarn run dev`. Test as both user types. Confirm: correct widgets, failed modal opens, resend removes the row.
+
+## Testing
+
+- [ ] `npx jest` (full suite) passes
+- [ ] `npx eslint .` reports no new errors
+- [ ] Manual smoke: both layouts, modal open/close, resend flow
+
+## Documentation / KB Updates
+
+- [ ] No KB/doc updates required.
+
+## Completion Criteria
+
+- [ ] Super layout: 5 widget sections with real data
+- [ ] Failed stat is clickable and opens modal with resend buttons
+- [ ] Successful resend removes the row and decrements the failed count
+- [ ] Licensee layout: 3 scoped widget cards
+- [ ] Loading and error states work
+- [ ] No lint errors
+- [ ] Changes committed to `plan/dashboard-widgets/phase-3/task-03-frontend`
+- [ ] `status.md` updated to `complete`
+
+## Conflict Avoidance Notes
+
+- No parallel tasks in Phase 3.

--- a/.plans/dashboard-widgets/phase-3/task-03-frontend/task.md
+++ b/.plans/dashboard-widgets/phase-3/task-03-frontend/task.md
@@ -197,22 +197,45 @@ export default function Dashboard() {
 
 ### Step 1: Create dashboard service
 
-`client/src/services/dashboard.js` — 8 functions, one per endpoint:
+`client/src/services/dashboard.js` — 8 functions, one per endpoint. Time-scoped functions accept an optional `{ startDate, endDate }` object; non-date-scoped ones (`licensees`, `contacts`) do not.
+
 ```js
 import { getToken } from './auth'
 import api from './api'
+import parseUrl from './objectToQueryParameter'
 
 const headers = () => ({ 'x-access-token': getToken() })
 
-export function getDashboardLicensees()    { return api().get('resources/dashboard/licensees',       { headers: headers() }) }
-export function getDashboardMessageVolume(){ return api().get('resources/dashboard/message-volume',  { headers: headers() }) }
-export function getDashboardDeliveryRate() { return api().get('resources/dashboard/delivery-rate',   { headers: headers() }) }
-export function getDashboardQueue()        { return api().get('resources/dashboard/queue',            { headers: headers() }) }
-export function getDashboardConversations(){ return api().get('resources/dashboard/conversations',    { headers: headers() }) }
-export function getDashboardContacts()     { return api().get('resources/dashboard/contacts',         { headers: headers() }) }
-export function getDashboardMessagesToday(){ return api().get('resources/dashboard/messages-today',   { headers: headers() }) }
-export function getDashboardMessagesPerDay(){ return api().get('resources/dashboard/messages-per-day',{ headers: headers() }) }
+// Point-in-time — no date params
+export function getDashboardLicensees() {
+  return api().get('resources/dashboard/licensees', { headers: headers() })
+}
+export function getDashboardContacts() {
+  return api().get('resources/dashboard/contacts', { headers: headers() })
+}
+
+// Time-scoped — accept optional { startDate, endDate }
+export function getDashboardMessageVolume(params = {}) {
+  return api().get(parseUrl('resources/dashboard/message-volume', params), { headers: headers() })
+}
+export function getDashboardDeliveryRate(params = {}) {
+  return api().get(parseUrl('resources/dashboard/delivery-rate', params), { headers: headers() })
+}
+export function getDashboardQueue(params = {}) {
+  return api().get(parseUrl('resources/dashboard/queue', params), { headers: headers() })
+}
+export function getDashboardConversations(params = {}) {
+  return api().get(parseUrl('resources/dashboard/conversations', params), { headers: headers() })
+}
+export function getDashboardMessagesToday(params = {}) {
+  return api().get(parseUrl('resources/dashboard/messages-today', params), { headers: headers() })
+}
+export function getDashboardMessagesPerDay(params = {}) {
+  return api().get(parseUrl('resources/dashboard/messages-per-day', params), { headers: headers() })
+}
 ```
+
+Each time-scoped card calls its function with no args initially (backend defaults to today). When a calendar component is added later, pass `{ startDate: isoString, endDate: isoString }` as the argument — no other changes required.
 
 ### Step 2: Add resendMessage to message service
 

--- a/client/src/pages/Dashboard/cards/FailedMessagesModal.js
+++ b/client/src/pages/Dashboard/cards/FailedMessagesModal.js
@@ -1,0 +1,104 @@
+import { useState, useEffect } from 'react'
+import { getMessages, resendMessage } from '../../../services/message'
+
+export default function FailedMessagesModal({ isOpen, onClose, onResendSuccess }) {
+  const [messages, setMessages] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [fetchError, setFetchError] = useState(null)
+  const [rowErrors, setRowErrors] = useState({})
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    setLoading(true)
+    setFetchError(null)
+    setRowErrors({})
+
+    getMessages({ sended: false, limit: 50 })
+      .then((res) => setMessages(res.data))
+      .catch(() => setFetchError('Erro ao carregar mensagens falhas.'))
+      .finally(() => setLoading(false))
+  }, [isOpen])
+
+  function handleResend(id) {
+    resendMessage(id)
+      .then(() => {
+        setMessages((prev) => prev.filter((m) => m._id !== id))
+        setRowErrors((prev) => {
+          const next = { ...prev }
+          delete next[id]
+          return next
+        })
+        onResendSuccess()
+      })
+      .catch(() => {
+        setRowErrors((prev) => ({ ...prev, [id]: 'Erro ao reenviar.' }))
+      })
+  }
+
+  if (!isOpen) return null
+
+  return (
+    <div
+      className="modal fade show d-block"
+      tabIndex="-1"
+      role="dialog"
+      style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
+    >
+      <div className="modal-dialog modal-lg" role="document">
+        <div className="modal-content">
+          <div className="modal-header">
+            <h5 className="modal-title">Mensagens com Falha</h5>
+            <button type="button" className="btn-close" onClick={onClose} aria-label="Fechar" />
+          </div>
+          <div className="modal-body">
+            {loading && <p>Carregando...</p>}
+            {fetchError && <p className="text-danger">{fetchError}</p>}
+            {!loading && !fetchError && messages.length === 0 && (
+              <p className="text-muted">Nenhuma mensagem com falha.</p>
+            )}
+            {!loading && !fetchError && messages.length > 0 && (
+              <table className="table table-sm">
+                <thead>
+                  <tr>
+                    <th>Contato</th>
+                    <th>Mensagem</th>
+                    <th>Erro</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {messages.map((msg) => (
+                    <tr key={msg._id}>
+                      <td>{msg.contact?.number || '—'}</td>
+                      <td>{msg.text ? msg.text.slice(0, 80) : '—'}</td>
+                      <td className="text-danger small">{msg.error || '—'}</td>
+                      <td>
+                        {rowErrors[msg._id] && (
+                          <span className="text-danger small me-2">{rowErrors[msg._id]}</span>
+                        )}
+                        <button
+                          type="button"
+                          className="btn btn-sm btn-outline-primary"
+                          onClick={() => handleResend(msg._id)}
+                        >
+                          Reenviar
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+          <div className="modal-footer">
+            <button type="button" className="btn btn-secondary" onClick={onClose}>
+              Fechar
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/client/src/pages/Dashboard/cards/FailedMessagesModal.spec.js
+++ b/client/src/pages/Dashboard/cards/FailedMessagesModal.spec.js
@@ -1,0 +1,98 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import FailedMessagesModal from './FailedMessagesModal'
+import { getMessages, resendMessage } from '../../../services/message'
+
+vi.mock('../../../services/message')
+
+const noop = () => {}
+
+describe('<FailedMessagesModal />', () => {
+  it('does not render anything when isOpen is false', () => {
+    render(<FailedMessagesModal isOpen={false} onClose={noop} onResendSuccess={noop} />)
+
+    expect(screen.queryByText('Mensagens com Falha')).not.toBeInTheDocument()
+  })
+
+  it('fetches failed messages on open and renders them in the table', async () => {
+    getMessages.mockResolvedValue({
+      data: [
+        { _id: 'msg1', contact: { number: '5511999990001' }, text: 'Hello world', error: 'timeout' },
+        { _id: 'msg2', contact: { number: '5511999990002' }, text: null, error: null },
+      ],
+    })
+
+    render(<FailedMessagesModal isOpen={true} onClose={noop} onResendSuccess={noop} />)
+
+    expect(await screen.findByText('5511999990001')).toBeInTheDocument()
+    expect(screen.getByText('Hello world')).toBeInTheDocument()
+    expect(screen.getByText('timeout')).toBeInTheDocument()
+    expect(screen.getByText('5511999990002')).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: 'Reenviar' })).toHaveLength(2)
+
+    expect(getMessages).toHaveBeenCalledWith({ sended: false, limit: 50 })
+  })
+
+  it('shows empty state when no failed messages are returned', async () => {
+    getMessages.mockResolvedValue({ data: [] })
+
+    render(<FailedMessagesModal isOpen={true} onClose={noop} onResendSuccess={noop} />)
+
+    expect(await screen.findByText('Nenhuma mensagem com falha.')).toBeInTheDocument()
+  })
+
+  it('shows a fetch error when getMessages rejects', async () => {
+    getMessages.mockRejectedValue(new Error('network error'))
+
+    render(<FailedMessagesModal isOpen={true} onClose={noop} onResendSuccess={noop} />)
+
+    expect(await screen.findByText('Erro ao carregar mensagens falhas.')).toBeInTheDocument()
+  })
+
+  it('removes the row and calls onResendSuccess when resend succeeds', async () => {
+    getMessages.mockResolvedValue({
+      data: [
+        { _id: 'msg1', contact: { number: '5511111111111' }, text: 'Test', error: 'err' },
+      ],
+    })
+    resendMessage.mockResolvedValue({})
+    const onResendSuccess = vi.fn()
+
+    render(<FailedMessagesModal isOpen={true} onClose={noop} onResendSuccess={onResendSuccess} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Reenviar' }))
+
+    await screen.findByText('Nenhuma mensagem com falha.')
+
+    expect(resendMessage).toHaveBeenCalledWith('msg1')
+    expect(onResendSuccess).toHaveBeenCalledTimes(1)
+    expect(screen.queryByText('5511111111111')).not.toBeInTheDocument()
+  })
+
+  it('shows an inline row error when resend fails', async () => {
+    getMessages.mockResolvedValue({
+      data: [
+        { _id: 'msg1', contact: { number: '5511111111111' }, text: 'Test', error: 'err' },
+      ],
+    })
+    resendMessage.mockRejectedValue(new Error('resend failed'))
+
+    render(<FailedMessagesModal isOpen={true} onClose={noop} onResendSuccess={noop} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Reenviar' }))
+
+    expect(await screen.findByText('Erro ao reenviar.')).toBeInTheDocument()
+    expect(screen.getByText('5511111111111')).toBeInTheDocument()
+  })
+
+  it('falls back to em-dash for missing contact number and text', async () => {
+    getMessages.mockResolvedValue({
+      data: [{ _id: 'msg1', contact: null, text: null, error: null }],
+    })
+
+    render(<FailedMessagesModal isOpen={true} onClose={noop} onResendSuccess={noop} />)
+
+    await screen.findByRole('button', { name: 'Reenviar' })
+
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(3)
+  })
+})

--- a/client/src/pages/Dashboard/cards/LicenseeContactsCard.js
+++ b/client/src/pages/Dashboard/cards/LicenseeContactsCard.js
@@ -1,0 +1,36 @@
+import { useState, useEffect } from 'react'
+import { getDashboardContacts } from '../../../services/dashboard'
+
+export default function LicenseeContactsCard() {
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    getDashboardContacts()
+      .then((res) => setData(res.data))
+      .catch(() => setError('Erro ao carregar dados.'))
+      .finally(() => setLoading(false))
+  }, [])
+
+  if (loading) return <div className="card"><div className="card-body">Carregando...</div></div>
+  if (error) return <div className="card"><div className="card-body text-danger">{error}</div></div>
+
+  return (
+    <div className="card">
+      <div className="card-header">Contatos</div>
+      <div className="card-body">
+        <div className="d-flex gap-4">
+          <div>
+            <div className="fs-4 fw-bold">{data.total}</div>
+            <div className="text-muted small">Total</div>
+          </div>
+          <div>
+            <div className="fs-4 fw-bold text-info">{data.in_chatbot}</div>
+            <div className="text-muted small">No Chatbot</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/client/src/pages/Dashboard/cards/LicenseeContactsCard.spec.js
+++ b/client/src/pages/Dashboard/cards/LicenseeContactsCard.spec.js
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react'
+import LicenseeContactsCard from './LicenseeContactsCard'
+import { getDashboardContacts } from '../../../services/dashboard'
+
+vi.mock('../../../services/dashboard')
+
+describe('<LicenseeContactsCard />', () => {
+  it('shows loading state while the request is in flight', () => {
+    getDashboardContacts.mockReturnValue(new Promise(() => {}))
+
+    render(<LicenseeContactsCard />)
+
+    expect(screen.getByText('Carregando...')).toBeInTheDocument()
+  })
+
+  it('shows an error message when the request fails', async () => {
+    getDashboardContacts.mockRejectedValue(new Error('fail'))
+
+    render(<LicenseeContactsCard />)
+
+    expect(await screen.findByText('Erro ao carregar dados.')).toBeInTheDocument()
+  })
+
+  it('renders total and chatbot contact counts on success', async () => {
+    getDashboardContacts.mockResolvedValue({
+      data: { total: 500, in_chatbot: 120 },
+    })
+
+    render(<LicenseeContactsCard />)
+
+    expect(await screen.findByText('500')).toBeInTheDocument()
+    expect(screen.getByText('120')).toBeInTheDocument()
+    expect(screen.getByText('Contatos')).toBeInTheDocument()
+    expect(screen.getByText('Total')).toBeInTheDocument()
+    expect(screen.getByText('No Chatbot')).toBeInTheDocument()
+  })
+})

--- a/client/src/pages/Dashboard/cards/LicenseeMessagesPerDayCard.js
+++ b/client/src/pages/Dashboard/cards/LicenseeMessagesPerDayCard.js
@@ -1,0 +1,42 @@
+import { useState, useEffect } from 'react'
+import { getDashboardMessagesPerDay } from '../../../services/dashboard'
+
+export default function LicenseeMessagesPerDayCard() {
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    getDashboardMessagesPerDay()
+      .then((res) => setData(res.data))
+      .catch(() => setError('Erro ao carregar dados.'))
+      .finally(() => setLoading(false))
+  }, [])
+
+  if (loading) return <div className="card"><div className="card-body">Carregando...</div></div>
+  if (error) return <div className="card"><div className="card-body text-danger">{error}</div></div>
+
+  return (
+    <div className="card">
+      <div className="card-header">Mensagens por Dia</div>
+      <div className="card-body">
+        <table className="table table-sm mb-0">
+          <thead>
+            <tr>
+              <th>Data</th>
+              <th>Total</th>
+            </tr>
+          </thead>
+          <tbody>
+            {(data.per_day || []).map((row) => (
+              <tr key={row.date}>
+                <td>{row.date}</td>
+                <td>{row.count}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/client/src/pages/Dashboard/cards/LicenseeMessagesPerDayCard.spec.js
+++ b/client/src/pages/Dashboard/cards/LicenseeMessagesPerDayCard.spec.js
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react'
+import LicenseeMessagesPerDayCard from './LicenseeMessagesPerDayCard'
+import { getDashboardMessagesPerDay } from '../../../services/dashboard'
+
+vi.mock('../../../services/dashboard')
+
+describe('<LicenseeMessagesPerDayCard />', () => {
+  it('shows loading state while the request is in flight', () => {
+    getDashboardMessagesPerDay.mockReturnValue(new Promise(() => {}))
+
+    render(<LicenseeMessagesPerDayCard />)
+
+    expect(screen.getByText('Carregando...')).toBeInTheDocument()
+  })
+
+  it('shows an error message when the request fails', async () => {
+    getDashboardMessagesPerDay.mockRejectedValue(new Error('fail'))
+
+    render(<LicenseeMessagesPerDayCard />)
+
+    expect(await screen.findByText('Erro ao carregar dados.')).toBeInTheDocument()
+  })
+
+  it('renders a row per day with date and count on success', async () => {
+    getDashboardMessagesPerDay.mockResolvedValue({
+      data: {
+        per_day: [
+          { date: '2026-05-05', count: 110 },
+          { date: '2026-05-06', count: 95 },
+        ],
+      },
+    })
+
+    render(<LicenseeMessagesPerDayCard />)
+
+    expect(await screen.findByText('2026-05-05')).toBeInTheDocument()
+    expect(screen.getByText('110')).toBeInTheDocument()
+    expect(screen.getByText('2026-05-06')).toBeInTheDocument()
+    expect(screen.getByText('95')).toBeInTheDocument()
+    expect(screen.getByText('Mensagens por Dia')).toBeInTheDocument()
+  })
+
+  it('renders an empty table when per_day is absent', async () => {
+    getDashboardMessagesPerDay.mockResolvedValue({ data: {} })
+
+    render(<LicenseeMessagesPerDayCard />)
+
+    await screen.findByText('Mensagens por Dia')
+
+    expect(screen.getByRole('table')).toBeInTheDocument()
+    expect(screen.queryByRole('cell')).not.toBeInTheDocument()
+  })
+})

--- a/client/src/pages/Dashboard/cards/LicenseeMessagesTodayCard.js
+++ b/client/src/pages/Dashboard/cards/LicenseeMessagesTodayCard.js
@@ -1,0 +1,36 @@
+import { useState, useEffect } from 'react'
+import { getDashboardMessagesToday } from '../../../services/dashboard'
+
+export default function LicenseeMessagesTodayCard() {
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    getDashboardMessagesToday()
+      .then((res) => setData(res.data))
+      .catch(() => setError('Erro ao carregar dados.'))
+      .finally(() => setLoading(false))
+  }, [])
+
+  if (loading) return <div className="card"><div className="card-body">Carregando...</div></div>
+  if (error) return <div className="card"><div className="card-body text-danger">{error}</div></div>
+
+  return (
+    <div className="card">
+      <div className="card-header">Mensagens Hoje</div>
+      <div className="card-body">
+        <div className="d-flex gap-4">
+          <div>
+            <div className="fs-4 fw-bold text-success">{data.sent_today}</div>
+            <div className="text-muted small">Enviadas ({data.sent_pct}%)</div>
+          </div>
+          <div>
+            <div className="fs-4 fw-bold text-danger">{data.failed_today}</div>
+            <div className="text-muted small">Falhas ({data.failed_pct}%)</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/client/src/pages/Dashboard/cards/LicenseeMessagesTodayCard.spec.js
+++ b/client/src/pages/Dashboard/cards/LicenseeMessagesTodayCard.spec.js
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react'
+import LicenseeMessagesTodayCard from './LicenseeMessagesTodayCard'
+import { getDashboardMessagesToday } from '../../../services/dashboard'
+
+vi.mock('../../../services/dashboard')
+
+describe('<LicenseeMessagesTodayCard />', () => {
+  it('shows loading state while the request is in flight', () => {
+    getDashboardMessagesToday.mockReturnValue(new Promise(() => {}))
+
+    render(<LicenseeMessagesTodayCard />)
+
+    expect(screen.getByText('Carregando...')).toBeInTheDocument()
+  })
+
+  it('shows an error message when the request fails', async () => {
+    getDashboardMessagesToday.mockRejectedValue(new Error('fail'))
+
+    render(<LicenseeMessagesTodayCard />)
+
+    expect(await screen.findByText('Erro ao carregar dados.')).toBeInTheDocument()
+  })
+
+  it('renders sent and failed message counts with percentages on success', async () => {
+    getDashboardMessagesToday.mockResolvedValue({
+      data: { sent_today: 300, sent_pct: 97, failed_today: 9, failed_pct: 3 },
+    })
+
+    render(<LicenseeMessagesTodayCard />)
+
+    expect(await screen.findByText('300')).toBeInTheDocument()
+    expect(screen.getByText('Enviadas (97%)')).toBeInTheDocument()
+    expect(screen.getByText('9')).toBeInTheDocument()
+    expect(screen.getByText('Falhas (3%)')).toBeInTheDocument()
+    expect(screen.getByText('Mensagens Hoje')).toBeInTheDocument()
+  })
+})

--- a/client/src/pages/Dashboard/cards/SuperConversationsCard.js
+++ b/client/src/pages/Dashboard/cards/SuperConversationsCard.js
@@ -1,0 +1,44 @@
+import { useState, useEffect } from 'react'
+import { getDashboardConversations } from '../../../services/dashboard'
+
+export default function SuperConversationsCard() {
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    getDashboardConversations()
+      .then((res) => setData(res.data))
+      .catch(() => setError('Erro ao carregar dados.'))
+      .finally(() => setLoading(false))
+  }, [])
+
+  if (loading) return <div className="card"><div className="card-body">Carregando...</div></div>
+  if (error) return <div className="card"><div className="card-body text-danger">{error}</div></div>
+
+  return (
+    <div className="card">
+      <div className="card-header">Conversas</div>
+      <div className="card-body">
+        <div className="d-flex gap-4">
+          <div>
+            <div className="fs-4 fw-bold text-success">{data.started_today}</div>
+            <div className="text-muted small">Iniciadas hoje</div>
+          </div>
+          <div>
+            <div className="fs-4 fw-bold">{data.ended_today}</div>
+            <div className="text-muted small">Encerradas hoje</div>
+          </div>
+          <div>
+            <div className="fs-4 fw-bold">{data.avg_messages_per_conversation}</div>
+            <div className="text-muted small">Média msg/conversa</div>
+          </div>
+          <div>
+            <div className="fs-4 fw-bold">{data.avg_duration_seconds}s</div>
+            <div className="text-muted small">Duração média</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/client/src/pages/Dashboard/cards/SuperConversationsCard.spec.js
+++ b/client/src/pages/Dashboard/cards/SuperConversationsCard.spec.js
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react'
+import SuperConversationsCard from './SuperConversationsCard'
+import { getDashboardConversations } from '../../../services/dashboard'
+
+vi.mock('../../../services/dashboard')
+
+describe('<SuperConversationsCard />', () => {
+  it('shows loading state while the request is in flight', () => {
+    getDashboardConversations.mockReturnValue(new Promise(() => {}))
+
+    render(<SuperConversationsCard />)
+
+    expect(screen.getByText('Carregando...')).toBeInTheDocument()
+  })
+
+  it('shows an error message when the request fails', async () => {
+    getDashboardConversations.mockRejectedValue(new Error('fail'))
+
+    render(<SuperConversationsCard />)
+
+    expect(await screen.findByText('Erro ao carregar dados.')).toBeInTheDocument()
+  })
+
+  it('renders conversation metrics on success', async () => {
+    getDashboardConversations.mockResolvedValue({
+      data: {
+        started_today: 80,
+        ended_today: 60,
+        avg_messages_per_conversation: 5,
+        avg_duration_seconds: 120,
+      },
+    })
+
+    render(<SuperConversationsCard />)
+
+    expect(await screen.findByText('80')).toBeInTheDocument()
+    expect(screen.getByText('60')).toBeInTheDocument()
+    expect(screen.getByText('5')).toBeInTheDocument()
+    expect(screen.getByText('120s')).toBeInTheDocument()
+    expect(screen.getByText('Conversas')).toBeInTheDocument()
+    expect(screen.getByText('Iniciadas hoje')).toBeInTheDocument()
+    expect(screen.getByText('Encerradas hoje')).toBeInTheDocument()
+    expect(screen.getByText('Média msg/conversa')).toBeInTheDocument()
+    expect(screen.getByText('Duração média')).toBeInTheDocument()
+  })
+})

--- a/client/src/pages/Dashboard/cards/SuperDeliveryRateCard.js
+++ b/client/src/pages/Dashboard/cards/SuperDeliveryRateCard.js
@@ -1,0 +1,60 @@
+import { useState, useEffect } from 'react'
+import { getDashboardDeliveryRate } from '../../../services/dashboard'
+import FailedMessagesModal from './FailedMessagesModal'
+
+export default function SuperDeliveryRateCard() {
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [modalOpen, setModalOpen] = useState(false)
+
+  useEffect(() => {
+    getDashboardDeliveryRate()
+      .then((res) => setData(res.data))
+      .catch(() => setError('Erro ao carregar dados.'))
+      .finally(() => setLoading(false))
+  }, [])
+
+  function handleResendSuccess() {
+    setData((prev) => ({
+      ...prev,
+      failed_today: Math.max(0, (prev.failed_today || 0) - 1),
+    }))
+  }
+
+  if (loading) return <div className="card"><div className="card-body">Carregando...</div></div>
+  if (error) return <div className="card"><div className="card-body text-danger">{error}</div></div>
+
+  return (
+    <>
+      <div className="card">
+        <div className="card-header">Taxa de Entrega</div>
+        <div className="card-body">
+          <div className="d-flex gap-4">
+            <div>
+              <div className="fs-4 fw-bold text-success">{data.sent_today}</div>
+              <div className="text-muted small">Enviadas ({data.sent_pct}%)</div>
+            </div>
+            <div>
+              <div
+                className="fs-4 fw-bold text-danger"
+                role="button"
+                style={{ cursor: 'pointer', textDecoration: 'underline' }}
+                onClick={() => setModalOpen(true)}
+              >
+                {data.failed_today}
+              </div>
+              <div className="text-muted small">Falhas ({data.failed_pct}%)</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <FailedMessagesModal
+        isOpen={modalOpen}
+        onClose={() => setModalOpen(false)}
+        onResendSuccess={handleResendSuccess}
+      />
+    </>
+  )
+}

--- a/client/src/pages/Dashboard/cards/SuperDeliveryRateCard.spec.js
+++ b/client/src/pages/Dashboard/cards/SuperDeliveryRateCard.spec.js
@@ -1,0 +1,57 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import SuperDeliveryRateCard from './SuperDeliveryRateCard'
+import { getDashboardDeliveryRate } from '../../../services/dashboard'
+import { getMessages } from '../../../services/message'
+
+vi.mock('../../../services/dashboard')
+vi.mock('../../../services/message')
+
+describe('<SuperDeliveryRateCard />', () => {
+  it('shows loading state while the request is in flight', () => {
+    getDashboardDeliveryRate.mockReturnValue(new Promise(() => {}))
+
+    render(<SuperDeliveryRateCard />)
+
+    expect(screen.getByText('Carregando...')).toBeInTheDocument()
+  })
+
+  it('shows an error message when the request fails', async () => {
+    getDashboardDeliveryRate.mockRejectedValue(new Error('fail'))
+
+    render(<SuperDeliveryRateCard />)
+
+    expect(await screen.findByText('Erro ao carregar dados.')).toBeInTheDocument()
+  })
+
+  it('renders sent and failed counts with percentages on success', async () => {
+    getDashboardDeliveryRate.mockResolvedValue({
+      data: {
+        sent_today: 950,
+        sent_pct: 95,
+        failed_today: 50,
+        failed_pct: 5,
+      },
+    })
+
+    render(<SuperDeliveryRateCard />)
+
+    expect(await screen.findByText('950')).toBeInTheDocument()
+    expect(screen.getByText('Enviadas (95%)')).toBeInTheDocument()
+    expect(screen.getByText('50')).toBeInTheDocument()
+    expect(screen.getByText('Falhas (5%)')).toBeInTheDocument()
+    expect(screen.getByText('Taxa de Entrega')).toBeInTheDocument()
+  })
+
+  it('opens FailedMessagesModal when the failed count is clicked', async () => {
+    getDashboardDeliveryRate.mockResolvedValue({
+      data: { sent_today: 900, sent_pct: 90, failed_today: 10, failed_pct: 10 },
+    })
+    getMessages.mockResolvedValue({ data: [] })
+
+    render(<SuperDeliveryRateCard />)
+
+    fireEvent.click(await screen.findByText('10'))
+
+    expect(await screen.findByText('Mensagens com Falha')).toBeInTheDocument()
+  })
+})

--- a/client/src/pages/Dashboard/cards/SuperLicenseesCard.js
+++ b/client/src/pages/Dashboard/cards/SuperLicenseesCard.js
@@ -1,0 +1,58 @@
+import { useState, useEffect } from 'react'
+import { getDashboardLicensees } from '../../../services/dashboard'
+
+export default function SuperLicenseesCard() {
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    getDashboardLicensees()
+      .then((res) => setData(res.data))
+      .catch(() => setError('Erro ao carregar dados.'))
+      .finally(() => setLoading(false))
+  }, [])
+
+  if (loading) return <div className="card"><div className="card-body">Carregando...</div></div>
+  if (error) return <div className="card"><div className="card-body text-danger">{error}</div></div>
+
+  return (
+    <div className="card">
+      <div className="card-header">Licenciados</div>
+      <div className="card-body">
+        <div className="d-flex gap-4 mb-3">
+          <div>
+            <div className="fs-4 fw-bold">{data.total}</div>
+            <div className="text-muted small">Total</div>
+          </div>
+          <div>
+            <div className="fs-4 fw-bold text-success">{data.active}</div>
+            <div className="text-muted small">Ativos</div>
+          </div>
+        </div>
+        <table className="table table-sm mb-0">
+          <thead>
+            <tr>
+              <th>Tipo</th>
+              <th>Quantidade</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Demo</td>
+              <td>{data.by_kind?.demo ?? 0}</td>
+            </tr>
+            <tr>
+              <td>Grátis</td>
+              <td>{data.by_kind?.free ?? 0}</td>
+            </tr>
+            <tr>
+              <td>Pago</td>
+              <td>{data.by_kind?.paid ?? 0}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/client/src/pages/Dashboard/cards/SuperLicenseesCard.spec.js
+++ b/client/src/pages/Dashboard/cards/SuperLicenseesCard.spec.js
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react'
+import SuperLicenseesCard from './SuperLicenseesCard'
+import { getDashboardLicensees } from '../../../services/dashboard'
+
+vi.mock('../../../services/dashboard')
+
+describe('<SuperLicenseesCard />', () => {
+  it('shows loading state while the request is in flight', () => {
+    getDashboardLicensees.mockReturnValue(new Promise(() => {}))
+
+    render(<SuperLicenseesCard />)
+
+    expect(screen.getByText('Carregando...')).toBeInTheDocument()
+  })
+
+  it('shows an error message when the request fails', async () => {
+    getDashboardLicensees.mockRejectedValue(new Error('fail'))
+
+    render(<SuperLicenseesCard />)
+
+    expect(await screen.findByText('Erro ao carregar dados.')).toBeInTheDocument()
+  })
+
+  it('renders licensee totals and kind breakdown on success', async () => {
+    getDashboardLicensees.mockResolvedValue({
+      data: {
+        total: 42,
+        active: 30,
+        by_kind: { demo: 5, free: 10, paid: 27 },
+      },
+    })
+
+    render(<SuperLicenseesCard />)
+
+    expect(await screen.findByText('42')).toBeInTheDocument()
+    expect(screen.getByText('30')).toBeInTheDocument()
+    expect(screen.getByText('5')).toBeInTheDocument()
+    expect(screen.getByText('10')).toBeInTheDocument()
+    expect(screen.getByText('27')).toBeInTheDocument()
+    expect(screen.getByText('Licenciados')).toBeInTheDocument()
+  })
+
+  it('falls back to 0 when by_kind values are absent', async () => {
+    getDashboardLicensees.mockResolvedValue({
+      data: { total: 1, active: 1, by_kind: {} },
+    })
+
+    render(<SuperLicenseesCard />)
+
+    await screen.findByText('Licenciados')
+
+    const zeroCells = screen.getAllByText('0')
+    expect(zeroCells.length).toBeGreaterThanOrEqual(3)
+  })
+})

--- a/client/src/pages/Dashboard/cards/SuperMessageVolumeCard.js
+++ b/client/src/pages/Dashboard/cards/SuperMessageVolumeCard.js
@@ -1,0 +1,77 @@
+import { useState, useEffect } from 'react'
+import { getDashboardMessageVolume } from '../../../services/dashboard'
+
+export default function SuperMessageVolumeCard() {
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    getDashboardMessageVolume()
+      .then((res) => setData(res.data))
+      .catch(() => setError('Erro ao carregar dados.'))
+      .finally(() => setLoading(false))
+  }, [])
+
+  if (loading) return <div className="card"><div className="card-body">Carregando...</div></div>
+  if (error) return <div className="card"><div className="card-body text-danger">{error}</div></div>
+
+  return (
+    <div className="card">
+      <div className="card-header">Volume de Mensagens</div>
+      <div className="card-body">
+        <div className="d-flex gap-4 mb-3">
+          <div>
+            <div className="fs-4 fw-bold">{data.peak_throughput}</div>
+            <div className="text-muted small">Pico (msg/s)</div>
+          </div>
+          <div>
+            <div className="fs-4 fw-bold">{data.avg_transfer_rate}</div>
+            <div className="text-muted small">Média (msg/s)</div>
+          </div>
+        </div>
+
+        <div className="row">
+          <div className="col-6">
+            <div className="fw-semibold mb-1 small">Por Dia</div>
+            <table className="table table-sm mb-0">
+              <thead>
+                <tr>
+                  <th>Data</th>
+                  <th>Total</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(data.per_day || []).map((row) => (
+                  <tr key={row.date}>
+                    <td>{row.date}</td>
+                    <td>{row.count}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div className="col-6">
+            <div className="fw-semibold mb-1 small">Por Hora</div>
+            <table className="table table-sm mb-0">
+              <thead>
+                <tr>
+                  <th>Hora</th>
+                  <th>Total</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(data.per_hour || []).map((row) => (
+                  <tr key={row.hour}>
+                    <td>{row.hour}h</td>
+                    <td>{row.count}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/client/src/pages/Dashboard/cards/SuperMessageVolumeCard.spec.js
+++ b/client/src/pages/Dashboard/cards/SuperMessageVolumeCard.spec.js
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react'
+import SuperMessageVolumeCard from './SuperMessageVolumeCard'
+import { getDashboardMessageVolume } from '../../../services/dashboard'
+
+vi.mock('../../../services/dashboard')
+
+describe('<SuperMessageVolumeCard />', () => {
+  it('shows loading state while the request is in flight', () => {
+    getDashboardMessageVolume.mockReturnValue(new Promise(() => {}))
+
+    render(<SuperMessageVolumeCard />)
+
+    expect(screen.getByText('Carregando...')).toBeInTheDocument()
+  })
+
+  it('shows an error message when the request fails', async () => {
+    getDashboardMessageVolume.mockRejectedValue(new Error('fail'))
+
+    render(<SuperMessageVolumeCard />)
+
+    expect(await screen.findByText('Erro ao carregar dados.')).toBeInTheDocument()
+  })
+
+  it('renders throughput metrics and per-day/per-hour rows on success', async () => {
+    getDashboardMessageVolume.mockResolvedValue({
+      data: {
+        peak_throughput: 120,
+        avg_transfer_rate: 45,
+        per_day: [
+          { date: '2026-05-01', count: 200 },
+          { date: '2026-05-02', count: 180 },
+        ],
+        per_hour: [
+          { hour: 9, count: 30 },
+          { hour: 10, count: 50 },
+        ],
+      },
+    })
+
+    render(<SuperMessageVolumeCard />)
+
+    expect(await screen.findByText('120')).toBeInTheDocument()
+    expect(screen.getByText('45')).toBeInTheDocument()
+    expect(screen.getByText('2026-05-01')).toBeInTheDocument()
+    expect(screen.getByText('2026-05-02')).toBeInTheDocument()
+    expect(screen.getByText('9h')).toBeInTheDocument()
+    expect(screen.getByText('10h')).toBeInTheDocument()
+    expect(screen.getByText('Volume de Mensagens')).toBeInTheDocument()
+  })
+
+  it('renders empty tables when per_day and per_hour are absent', async () => {
+    getDashboardMessageVolume.mockResolvedValue({
+      data: { peak_throughput: 0, avg_transfer_rate: 0 },
+    })
+
+    render(<SuperMessageVolumeCard />)
+
+    await screen.findByText('Volume de Mensagens')
+
+    expect(screen.getByText('Por Dia')).toBeInTheDocument()
+    expect(screen.getByText('Por Hora')).toBeInTheDocument()
+  })
+})

--- a/client/src/pages/Dashboard/cards/SuperQueueCard.js
+++ b/client/src/pages/Dashboard/cards/SuperQueueCard.js
@@ -1,0 +1,36 @@
+import { useState, useEffect } from 'react'
+import { getDashboardQueue } from '../../../services/dashboard'
+
+export default function SuperQueueCard() {
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    getDashboardQueue()
+      .then((res) => setData(res.data))
+      .catch(() => setError('Erro ao carregar dados.'))
+      .finally(() => setLoading(false))
+  }, [])
+
+  if (loading) return <div className="card"><div className="card-body">Carregando...</div></div>
+  if (error) return <div className="card"><div className="card-body text-danger">{error}</div></div>
+
+  return (
+    <div className="card">
+      <div className="card-header">Fila de Mensagens</div>
+      <div className="card-body">
+        <div className="d-flex gap-4">
+          <div>
+            <div className="fs-4 fw-bold">{data.pending_messages}</div>
+            <div className="text-muted small">Pendentes</div>
+          </div>
+          <div>
+            <div className="fs-4 fw-bold">{data.avg_time_in_queue_seconds}s</div>
+            <div className="text-muted small">Tempo médio na fila</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/client/src/pages/Dashboard/cards/SuperQueueCard.spec.js
+++ b/client/src/pages/Dashboard/cards/SuperQueueCard.spec.js
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react'
+import SuperQueueCard from './SuperQueueCard'
+import { getDashboardQueue } from '../../../services/dashboard'
+
+vi.mock('../../../services/dashboard')
+
+describe('<SuperQueueCard />', () => {
+  it('shows loading state while the request is in flight', () => {
+    getDashboardQueue.mockReturnValue(new Promise(() => {}))
+
+    render(<SuperQueueCard />)
+
+    expect(screen.getByText('Carregando...')).toBeInTheDocument()
+  })
+
+  it('shows an error message when the request fails', async () => {
+    getDashboardQueue.mockRejectedValue(new Error('fail'))
+
+    render(<SuperQueueCard />)
+
+    expect(await screen.findByText('Erro ao carregar dados.')).toBeInTheDocument()
+  })
+
+  it('renders pending messages and average queue time on success', async () => {
+    getDashboardQueue.mockResolvedValue({
+      data: { pending_messages: 14, avg_time_in_queue_seconds: 3 },
+    })
+
+    render(<SuperQueueCard />)
+
+    expect(await screen.findByText('14')).toBeInTheDocument()
+    expect(screen.getByText('3s')).toBeInTheDocument()
+    expect(screen.getByText('Fila de Mensagens')).toBeInTheDocument()
+    expect(screen.getByText('Pendentes')).toBeInTheDocument()
+    expect(screen.getByText('Tempo médio na fila')).toBeInTheDocument()
+  })
+})

--- a/client/src/pages/Dashboard/index.js
+++ b/client/src/pages/Dashboard/index.js
@@ -1,14 +1,43 @@
-// import SelectLicenseesWithFilter from '../../components/SelectLicenseesWithFilter'
+import { useState, useEffect } from 'react'
+import { fetchLoggedUser } from '../../services/auth'
+import SuperLicenseesCard from './cards/SuperLicenseesCard'
+import SuperMessageVolumeCard from './cards/SuperMessageVolumeCard'
+import SuperDeliveryRateCard from './cards/SuperDeliveryRateCard'
+import SuperQueueCard from './cards/SuperQueueCard'
+import SuperConversationsCard from './cards/SuperConversationsCard'
+import LicenseeContactsCard from './cards/LicenseeContactsCard'
+import LicenseeMessagesTodayCard from './cards/LicenseeMessagesTodayCard'
+import LicenseeMessagesPerDayCard from './cards/LicenseeMessagesPerDayCard'
 
 export default function Dashboard() {
-  // const [valor, setValor] = useState('olá')
-  // const marcela = { id: 4, name: 'Marcela' }
+  const [user, setUser] = useState(null)
+  const [loadingUser, setLoadingUser] = useState(true)
+
+  useEffect(() => {
+    fetchLoggedUser()
+      .then(setUser)
+      .finally(() => setLoadingUser(false))
+  }, [])
+
+  if (loadingUser) return <p>Carregando...</p>
+
+  if (user?.isSuper) {
+    return (
+      <div className="row g-3">
+        <div className="col-12 col-md-6"><SuperLicenseesCard /></div>
+        <div className="col-12 col-md-6"><SuperMessageVolumeCard /></div>
+        <div className="col-12 col-md-6"><SuperDeliveryRateCard /></div>
+        <div className="col-12 col-md-6"><SuperQueueCard /></div>
+        <div className="col-12"><SuperConversationsCard /></div>
+      </div>
+    )
+  }
 
   return (
-    <>
-      <h1>Dashboard</h1>
-      {/* <p>{valor}</p>
-      <SelectLicenseesWithFilter isDisabled={false} selectedItem={marcela} onChange={(e) => setValor(JSON.stringify(e))} /> */}
-    </>
+    <div className="row g-3">
+      <div className="col-12 col-md-4"><LicenseeContactsCard /></div>
+      <div className="col-12 col-md-4"><LicenseeMessagesTodayCard /></div>
+      <div className="col-12 col-md-4"><LicenseeMessagesPerDayCard /></div>
+    </div>
   )
 }

--- a/client/src/pages/Dashboard/index.js
+++ b/client/src/pages/Dashboard/index.js
@@ -23,21 +23,27 @@ export default function Dashboard() {
 
   if (user?.isSuper) {
     return (
-      <div className="row g-3">
-        <div className="col-12 col-md-6"><SuperLicenseesCard /></div>
-        <div className="col-12 col-md-6"><SuperMessageVolumeCard /></div>
-        <div className="col-12 col-md-6"><SuperDeliveryRateCard /></div>
-        <div className="col-12 col-md-6"><SuperQueueCard /></div>
-        <div className="col-12"><SuperConversationsCard /></div>
-      </div>
+      <>
+        <h1>Dashboard</h1>
+        <div className="row g-3">
+          <div className="col-12 col-md-6"><SuperLicenseesCard /></div>
+          <div className="col-12 col-md-6"><SuperMessageVolumeCard /></div>
+          <div className="col-12 col-md-6"><SuperDeliveryRateCard /></div>
+          <div className="col-12 col-md-6"><SuperQueueCard /></div>
+          <div className="col-12"><SuperConversationsCard /></div>
+        </div>
+      </>
     )
   }
 
   return (
-    <div className="row g-3">
-      <div className="col-12 col-md-4"><LicenseeContactsCard /></div>
-      <div className="col-12 col-md-4"><LicenseeMessagesTodayCard /></div>
-      <div className="col-12 col-md-4"><LicenseeMessagesPerDayCard /></div>
-    </div>
+    <>
+      <h1>Dashboard</h1>
+      <div className="row g-3">
+        <div className="col-12 col-md-4"><LicenseeContactsCard /></div>
+        <div className="col-12 col-md-4"><LicenseeMessagesTodayCard /></div>
+        <div className="col-12 col-md-4"><LicenseeMessagesPerDayCard /></div>
+      </div>
+    </>
   )
 }

--- a/client/src/pages/Dashboard/index.js
+++ b/client/src/pages/Dashboard/index.js
@@ -24,7 +24,6 @@ export default function Dashboard() {
   if (user?.isSuper) {
     return (
       <>
-        <h1>Dashboard</h1>
         <div className="row g-3">
           <div className="col-12 col-md-6"><SuperLicenseesCard /></div>
           <div className="col-12 col-md-6"><SuperMessageVolumeCard /></div>
@@ -38,7 +37,6 @@ export default function Dashboard() {
 
   return (
     <>
-      <h1>Dashboard</h1>
       <div className="row g-3">
         <div className="col-12 col-md-4"><LicenseeContactsCard /></div>
         <div className="col-12 col-md-4"><LicenseeMessagesTodayCard /></div>

--- a/client/src/pages/routes.spec.js
+++ b/client/src/pages/routes.spec.js
@@ -40,10 +40,8 @@ describe('<RootRoutes>', () => {
 
     await screen.findByText('Contatos')
 
-    const title = screen.getByRole('heading', { name: 'Dashboard' })
     const navbar = screen.getByRole('navigation')
 
-    expect(title).toBeInTheDocument()
     expect(navbar).toBeInTheDocument()
     expect(isAuthenticatedSpy).toHaveBeenCalled()
   })

--- a/client/src/services/dashboard.js
+++ b/client/src/services/dashboard.js
@@ -1,0 +1,33 @@
+import { getToken } from './auth'
+import api from './api'
+import parseUrl from './objectToQueryParameter'
+
+const headers = () => ({ 'x-access-token': getToken() })
+
+// Point-in-time — no date params
+export function getDashboardLicensees() {
+  return api().get('resources/dashboard/licensees', { headers: headers() })
+}
+export function getDashboardContacts() {
+  return api().get('resources/dashboard/contacts', { headers: headers() })
+}
+
+// Time-scoped — accept optional { startDate, endDate }
+export function getDashboardMessageVolume(params = {}) {
+  return api().get(parseUrl('resources/dashboard/message-volume', params), { headers: headers() })
+}
+export function getDashboardDeliveryRate(params = {}) {
+  return api().get(parseUrl('resources/dashboard/delivery-rate', params), { headers: headers() })
+}
+export function getDashboardQueue(params = {}) {
+  return api().get(parseUrl('resources/dashboard/queue', params), { headers: headers() })
+}
+export function getDashboardConversations(params = {}) {
+  return api().get(parseUrl('resources/dashboard/conversations', params), { headers: headers() })
+}
+export function getDashboardMessagesToday(params = {}) {
+  return api().get(parseUrl('resources/dashboard/messages-today', params), { headers: headers() })
+}
+export function getDashboardMessagesPerDay(params = {}) {
+  return api().get(parseUrl('resources/dashboard/messages-per-day', params), { headers: headers() })
+}

--- a/client/src/services/message.js
+++ b/client/src/services/message.js
@@ -10,4 +10,9 @@ function getMessages(queryParams) {
   return api().get(url, { headers })
 }
 
-export { getMessages }
+function resendMessage(id) {
+  const resendHeaders = { 'x-access-token': getToken() }
+  return api().post(`resources/messages/${id}/resend`, { headers: resendHeaders })
+}
+
+export { getMessages, resendMessage }

--- a/client/src/services/message.js
+++ b/client/src/services/message.js
@@ -2,17 +2,13 @@ import { getToken } from './auth'
 import api from './api'
 import parseUrl from './objectToQueryParameter'
 
-const token = getToken()
-const headers = { 'x-access-token': `${token}` }
-
 function getMessages(queryParams) {
   const url = parseUrl('resources/messages/', queryParams)
-  return api().get(url, { headers })
+  return api().get(url, { headers: { 'x-access-token': getToken() } })
 }
 
 function resendMessage(id) {
-  const resendHeaders = { 'x-access-token': getToken() }
-  return api().post(`resources/messages/${id}/resend`, { headers: resendHeaders })
+  return api().post(`resources/messages/${id}/resend`, { headers: { 'x-access-token': getToken() } })
 }
 
 export { getMessages, resendMessage }

--- a/src/app/controllers/DashboardController.js
+++ b/src/app/controllers/DashboardController.js
@@ -1,0 +1,326 @@
+class DashboardController {
+  constructor({
+    userRepository,
+    licenseeRepository,
+    contactRepository,
+    messageRepository,
+    roomRepository,
+    redisConnection,
+  } = {}) {
+    this.userRepository = userRepository
+    this.licenseeRepository = licenseeRepository
+    this.contactRepository = contactRepository
+    this.messageRepository = messageRepository
+    this.roomRepository = roomRepository
+    this.redisConnection = redisConnection
+
+    this.licensees = this.licensees.bind(this)
+    this.messageVolume = this.messageVolume.bind(this)
+    this.deliveryRate = this.deliveryRate.bind(this)
+    this.queue = this.queue.bind(this)
+    this.conversations = this.conversations.bind(this)
+    this.contacts = this.contacts.bind(this)
+    this.messagesToday = this.messagesToday.bind(this)
+    this.messagesPerDay = this.messagesPerDay.bind(this)
+  }
+
+  async _resolveUser(req) {
+    return await this.userRepository.findFirst({ _id: req.userId })
+  }
+
+  async _cached(key, fn) {
+    const cached = await this.redisConnection.get(key)
+    if (cached) return JSON.parse(cached)
+    const data = await fn()
+    await this.redisConnection.setex(key, 600, JSON.stringify(data))
+    return data
+  }
+
+  _parseDateRange(query) {
+    const now = new Date()
+    const startOfDay = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+    const endOfDay = new Date(startOfDay.getTime() + 24 * 60 * 60 * 1000)
+    return {
+      startDate: query.startDate ? new Date(query.startDate) : startOfDay,
+      endDate: query.endDate ? new Date(query.endDate) : endOfDay,
+    }
+  }
+
+  async licensees(req, res) {
+    try {
+      const user = await this._resolveUser(req)
+      if (!user) return res.status(404).json({ errors: { message: 'User not found' } })
+      if (!user.isSuper) return res.status(403).json({ errors: { message: 'Forbidden' } })
+
+      const cacheKey = 'dashboard:super:licensees'
+      const data = await this._cached(cacheKey, async () => {
+        const [total, active, demo, free, paid] = await Promise.all([
+          this.licenseeRepository.model().where({}).countDocuments(),
+          this.licenseeRepository.model().where({ active: true }).countDocuments(),
+          this.licenseeRepository.model().where({ licenseKind: 'demo' }).countDocuments(),
+          this.licenseeRepository.model().where({ licenseKind: 'free' }).countDocuments(),
+          this.licenseeRepository.model().where({ licenseKind: 'paid' }).countDocuments(),
+        ])
+        return { total, active, by_kind: { demo, free, paid } }
+      })
+
+      return res.status(200).json(data)
+    } catch (err) {
+      return res.status(500).json({ errors: { message: err.toString() } })
+    }
+  }
+
+  async messageVolume(req, res) {
+    try {
+      const user = await this._resolveUser(req)
+      if (!user) return res.status(404).json({ errors: { message: 'User not found' } })
+      if (!user.isSuper) return res.status(403).json({ errors: { message: 'Forbidden' } })
+
+      const { startDate, endDate } = this._parseDateRange(req.query)
+      const cacheKey = `dashboard:super:message-volume:${startDate.toISOString()}:${endDate.toISOString()}`
+
+      const data = await this._cached(cacheKey, async () => {
+        const perDayPipeline = [
+          { $match: { createdAt: { $gte: startDate, $lt: endDate } } },
+          { $group: { _id: { $dateToString: { format: '%Y-%m-%d', date: '$createdAt' } }, count: { $sum: 1 } } },
+          { $sort: { _id: 1 } },
+        ]
+        const perHourPipeline = [
+          { $match: { createdAt: { $gte: startDate, $lt: endDate } } },
+          { $group: { _id: { $dateToString: { format: '%Y-%m-%dT%H', date: '$createdAt' } }, count: { $sum: 1 } } },
+          { $sort: { _id: 1 } },
+        ]
+
+        const [perDay, perHour, sentCount, failedCount] = await Promise.all([
+          this.messageRepository.model().aggregate(perDayPipeline),
+          this.messageRepository.model().aggregate(perHourPipeline),
+          this.messageRepository
+            .model()
+            .where({ sended: true, createdAt: { $gte: startDate, $lt: endDate } })
+            .countDocuments(),
+          this.messageRepository
+            .model()
+            .where({ sended: false, createdAt: { $gte: startDate, $lt: endDate } })
+            .countDocuments(),
+        ])
+
+        const peakThroughput = perHour.length > 0 ? Math.max(...perHour.map((h) => h.count)) : 0
+        const hourSpan = (endDate - startDate) / 3_600_000
+        const avgTransferRate = parseFloat(((sentCount + failedCount) / hourSpan).toFixed(2))
+
+        return {
+          per_day: perDay,
+          per_hour: perHour,
+          peak_throughput: peakThroughput,
+          avg_transfer_rate: avgTransferRate,
+        }
+      })
+
+      return res.status(200).json(data)
+    } catch (err) {
+      return res.status(500).json({ errors: { message: err.toString() } })
+    }
+  }
+
+  async deliveryRate(req, res) {
+    try {
+      const user = await this._resolveUser(req)
+      if (!user) return res.status(404).json({ errors: { message: 'User not found' } })
+      if (!user.isSuper) return res.status(403).json({ errors: { message: 'Forbidden' } })
+
+      const { startDate, endDate } = this._parseDateRange(req.query)
+      const cacheKey = `dashboard:super:delivery-rate:${startDate.toISOString()}:${endDate.toISOString()}`
+
+      const data = await this._cached(cacheKey, async () => {
+        const [sentCount, failedCount] = await Promise.all([
+          this.messageRepository
+            .model()
+            .where({ sended: true, createdAt: { $gte: startDate, $lt: endDate } })
+            .countDocuments(),
+          this.messageRepository
+            .model()
+            .where({ sended: false, createdAt: { $gte: startDate, $lt: endDate } })
+            .countDocuments(),
+        ])
+
+        const total = sentCount + failedCount
+        const sentPct = total === 0 ? 0 : parseFloat(((sentCount / total) * 100).toFixed(2))
+        const failedPct = total === 0 ? 0 : parseFloat(((failedCount / total) * 100).toFixed(2))
+
+        return { sent_today: sentCount, failed_today: failedCount, sent_pct: sentPct, failed_pct: failedPct }
+      })
+
+      return res.status(200).json(data)
+    } catch (err) {
+      return res.status(500).json({ errors: { message: err.toString() } })
+    }
+  }
+
+  async queue(req, res) {
+    try {
+      const user = await this._resolveUser(req)
+      if (!user) return res.status(404).json({ errors: { message: 'User not found' } })
+      if (!user.isSuper) return res.status(403).json({ errors: { message: 'Forbidden' } })
+
+      const { startDate, endDate } = this._parseDateRange(req.query)
+      const cacheKey = `dashboard:super:queue:${startDate.toISOString()}:${endDate.toISOString()}`
+
+      const data = await this._cached(cacheKey, async () => {
+        const avgQueuePipeline = [
+          { $match: { sendedAt: { $exists: true }, createdAt: { $gte: startDate, $lt: endDate } } },
+          { $group: { _id: null, avg: { $avg: { $divide: [{ $subtract: ['$sendedAt', '$createdAt'] }, 1000] } } } },
+        ]
+
+        const [pendingMessages, avgResult] = await Promise.all([
+          this.messageRepository.model().where({ sended: false, destination: 'to-messenger' }).countDocuments(),
+          this.messageRepository.model().aggregate(avgQueuePipeline),
+        ])
+
+        const avgTimeInQueueSeconds = avgResult.length > 0 ? parseFloat((avgResult[0].avg ?? 0).toFixed(2)) : 0
+
+        return { pending_messages: pendingMessages, avg_time_in_queue_seconds: avgTimeInQueueSeconds }
+      })
+
+      return res.status(200).json(data)
+    } catch (err) {
+      return res.status(500).json({ errors: { message: err.toString() } })
+    }
+  }
+
+  async conversations(req, res) {
+    try {
+      const user = await this._resolveUser(req)
+      if (!user) return res.status(404).json({ errors: { message: 'User not found' } })
+      if (!user.isSuper) return res.status(403).json({ errors: { message: 'Forbidden' } })
+
+      const { startDate, endDate } = this._parseDateRange(req.query)
+      const cacheKey = `dashboard:super:conversations:${startDate.toISOString()}:${endDate.toISOString()}`
+
+      const data = await this._cached(cacheKey, async () => {
+        const avgMsgPerConvPipeline = [
+          { $match: { room: { $exists: true }, createdAt: { $gte: startDate, $lt: endDate } } },
+          { $group: { _id: '$room', count: { $sum: 1 } } },
+          { $group: { _id: null, avg: { $avg: '$count' } } },
+        ]
+        const avgDurationPipeline = [
+          { $match: { closedAt: { $gte: startDate, $lt: endDate } } },
+          { $group: { _id: null, avg: { $avg: { $divide: [{ $subtract: ['$closedAt', '$createdAt'] }, 1000] } } } },
+        ]
+
+        const [startedCount, endedCount, avgMsgResult, avgDurationResult] = await Promise.all([
+          this.roomRepository
+            .model()
+            .where({ createdAt: { $gte: startDate, $lt: endDate } })
+            .countDocuments(),
+          this.roomRepository
+            .model()
+            .where({ closedAt: { $gte: startDate, $lt: endDate } })
+            .countDocuments(),
+          this.messageRepository.model().aggregate(avgMsgPerConvPipeline),
+          this.roomRepository.model().aggregate(avgDurationPipeline),
+        ])
+
+        const avgMessagesPerConversation =
+          avgMsgResult.length > 0 ? parseFloat((avgMsgResult[0].avg ?? 0).toFixed(2)) : 0
+        const avgDurationSeconds =
+          avgDurationResult.length > 0 ? parseFloat((avgDurationResult[0].avg ?? 0).toFixed(2)) : 0
+
+        return {
+          started_today: startedCount,
+          ended_today: endedCount,
+          avg_messages_per_conversation: avgMessagesPerConversation,
+          avg_duration_seconds: avgDurationSeconds,
+        }
+      })
+
+      return res.status(200).json(data)
+    } catch (err) {
+      return res.status(500).json({ errors: { message: err.toString() } })
+    }
+  }
+
+  async contacts(req, res) {
+    try {
+      const user = await this._resolveUser(req)
+      if (!user) return res.status(404).json({ errors: { message: 'User not found' } })
+      if (user.isSuper) return res.status(403).json({ errors: { message: 'Forbidden' } })
+
+      const cacheKey = `dashboard:licensee:${user.licensee}:contacts`
+
+      const data = await this._cached(cacheKey, async () => {
+        const [total, inChatbot] = await Promise.all([
+          this.contactRepository.model().where({ licensee: user.licensee }).countDocuments(),
+          this.contactRepository.model().where({ licensee: user.licensee, talkingWithChatBot: true }).countDocuments(),
+        ])
+        return { total, in_chatbot: inChatbot }
+      })
+
+      return res.status(200).json(data)
+    } catch (err) {
+      return res.status(500).json({ errors: { message: err.toString() } })
+    }
+  }
+
+  async messagesToday(req, res) {
+    try {
+      const user = await this._resolveUser(req)
+      if (!user) return res.status(404).json({ errors: { message: 'User not found' } })
+      if (user.isSuper) return res.status(403).json({ errors: { message: 'Forbidden' } })
+
+      const { startDate, endDate } = this._parseDateRange(req.query)
+      const cacheKey = `dashboard:licensee:${user.licensee}:messages-today:${startDate.toISOString()}:${endDate.toISOString()}`
+
+      const data = await this._cached(cacheKey, async () => {
+        const [sentCount, failedCount] = await Promise.all([
+          this.messageRepository
+            .model()
+            .where({ licensee: user.licensee, sended: true, createdAt: { $gte: startDate, $lt: endDate } })
+            .countDocuments(),
+          this.messageRepository
+            .model()
+            .where({ licensee: user.licensee, sended: false, createdAt: { $gte: startDate, $lt: endDate } })
+            .countDocuments(),
+        ])
+
+        const total = sentCount + failedCount
+        const sentPct = total === 0 ? 0 : parseFloat(((sentCount / total) * 100).toFixed(2))
+        const failedPct = total === 0 ? 0 : parseFloat(((failedCount / total) * 100).toFixed(2))
+
+        return { sent_today: sentCount, failed_today: failedCount, sent_pct: sentPct, failed_pct: failedPct }
+      })
+
+      return res.status(200).json(data)
+    } catch (err) {
+      return res.status(500).json({ errors: { message: err.toString() } })
+    }
+  }
+
+  async messagesPerDay(req, res) {
+    try {
+      const user = await this._resolveUser(req)
+      if (!user) return res.status(404).json({ errors: { message: 'User not found' } })
+      if (user.isSuper) return res.status(403).json({ errors: { message: 'Forbidden' } })
+
+      const { startDate, endDate } = this._parseDateRange(req.query)
+      const cacheKey = `dashboard:licensee:${user.licensee}:messages-per-day:${startDate.toISOString()}:${endDate.toISOString()}`
+
+      const data = await this._cached(cacheKey, async () => {
+        const sevenDaysAgo = new Date(endDate.getTime() - 7 * 24 * 60 * 60 * 1000)
+        const perDayPipeline = [
+          { $match: { createdAt: { $gte: sevenDaysAgo, $lt: endDate }, licensee: user.licensee } },
+          { $group: { _id: { $dateToString: { format: '%Y-%m-%d', date: '$createdAt' } }, count: { $sum: 1 } } },
+          { $sort: { _id: 1 } },
+        ]
+
+        const perDay = await this.messageRepository.model().aggregate(perDayPipeline)
+        return { per_day: perDay }
+      })
+
+      return res.status(200).json(data)
+    } catch (err) {
+      return res.status(500).json({ errors: { message: err.toString() } })
+    }
+  }
+}
+
+export { DashboardController }

--- a/src/app/controllers/DashboardController.spec.js
+++ b/src/app/controllers/DashboardController.spec.js
@@ -1,0 +1,498 @@
+import { DashboardController } from './DashboardController.js'
+
+function buildResponse() {
+  return {
+    json: jest.fn(),
+    status: jest.fn().mockReturnThis(),
+  }
+}
+
+function buildModelAdapter({ countResult = 0, aggregateResult = [] } = {}) {
+  const queryChain = {
+    countDocuments: jest.fn().mockResolvedValue(countResult),
+  }
+  return {
+    where: jest.fn().mockReturnValue(queryChain),
+    aggregate: jest.fn().mockResolvedValue(aggregateResult),
+    _queryChain: queryChain,
+  }
+}
+
+function buildRedis({ cachedValue = null } = {}) {
+  return {
+    get: jest.fn().mockResolvedValue(cachedValue),
+    setex: jest.fn().mockResolvedValue('OK'),
+  }
+}
+
+function buildController({
+  user = null,
+  licenseeModelAdapter = null,
+  messageModelAdapter = null,
+  contactModelAdapter = null,
+  roomModelAdapter = null,
+  redisConnection = null,
+} = {}) {
+  const userRepository = {
+    findFirst: jest.fn().mockResolvedValue(user),
+  }
+  const licenseeRepository = {
+    model: jest.fn().mockReturnValue(licenseeModelAdapter ?? buildModelAdapter()),
+  }
+  const contactRepository = {
+    model: jest.fn().mockReturnValue(contactModelAdapter ?? buildModelAdapter()),
+  }
+  const messageRepository = {
+    model: jest.fn().mockReturnValue(messageModelAdapter ?? buildModelAdapter()),
+    findFirst: jest.fn().mockResolvedValue(null),
+    save: jest.fn(),
+  }
+  const roomRepository = {
+    model: jest.fn().mockReturnValue(roomModelAdapter ?? buildModelAdapter()),
+  }
+  const redis = redisConnection ?? buildRedis()
+
+  const controller = new DashboardController({
+    userRepository,
+    licenseeRepository,
+    contactRepository,
+    messageRepository,
+    roomRepository,
+    redisConnection: redis,
+  })
+
+  return {
+    controller,
+    userRepository,
+    licenseeRepository,
+    contactRepository,
+    messageRepository,
+    roomRepository,
+    redisConnection: redis,
+  }
+}
+
+const SUPER_USER = { _id: 'user-id', isSuper: true }
+const LICENSEE_USER = { _id: 'user-id', isSuper: false, licensee: 'licensee-id' }
+
+describe('DashboardController', () => {
+  describe('licensees', () => {
+    it('returns 403 when user is not super', async () => {
+      const { controller } = buildController({ user: LICENSEE_USER })
+      const req = { userId: 'user-id', query: {} }
+      const res = buildResponse()
+
+      await controller.licensees(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(403)
+    })
+
+    it('returns 404 when user not found', async () => {
+      const { controller } = buildController({ user: null })
+      const req = { userId: 'user-id', query: {} }
+      const res = buildResponse()
+
+      await controller.licensees(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(404)
+    })
+
+    it('serves from cache on cache hit', async () => {
+      const cached = { total: 5, active: 3, by_kind: { demo: 1, free: 2, paid: 2 } }
+      const redis = buildRedis({ cachedValue: JSON.stringify(cached) })
+      const { controller, licenseeRepository } = buildController({ user: SUPER_USER, redisConnection: redis })
+      const req = { userId: 'user-id', query: {} }
+      const res = buildResponse()
+
+      await controller.licensees(req, res)
+
+      expect(redis.get).toHaveBeenCalledWith('dashboard:super:licensees')
+      expect(licenseeRepository.model).not.toHaveBeenCalled()
+      expect(res.status).toHaveBeenCalledWith(200)
+      expect(res.json).toHaveBeenCalledWith(cached)
+    })
+
+    it('queries DB on cache miss and stores result in redis', async () => {
+      const redis = buildRedis({ cachedValue: null })
+      const modelAdapter = buildModelAdapter({ countResult: 10 })
+      const { controller } = buildController({
+        user: SUPER_USER,
+        licenseeModelAdapter: modelAdapter,
+        redisConnection: redis,
+      })
+      const req = { userId: 'user-id', query: {} }
+      const res = buildResponse()
+
+      await controller.licensees(req, res)
+
+      expect(redis.setex).toHaveBeenCalledWith('dashboard:super:licensees', 600, expect.any(String))
+      expect(res.status).toHaveBeenCalledWith(200)
+      const result = res.json.mock.calls[0][0]
+      expect(result).toHaveProperty('total')
+      expect(result).toHaveProperty('by_kind')
+    })
+
+    it('returns 500 on repository error', async () => {
+      const redis = buildRedis({ cachedValue: null })
+      const { controller, licenseeRepository } = buildController({ user: SUPER_USER, redisConnection: redis })
+      licenseeRepository.model.mockImplementation(() => {
+        throw new Error('DB error')
+      })
+      const req = { userId: 'user-id', query: {} }
+      const res = buildResponse()
+
+      await controller.licensees(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(500)
+    })
+  })
+
+  describe('messageVolume', () => {
+    it('returns 403 when user is not super', async () => {
+      const { controller } = buildController({ user: LICENSEE_USER })
+      const req = { userId: 'user-id', query: {} }
+      const res = buildResponse()
+
+      await controller.messageVolume(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(403)
+    })
+
+    it('serves from cache on cache hit', async () => {
+      const cached = { per_day: [], per_hour: [], peak_throughput: 0, avg_transfer_rate: 0 }
+      const startDate = new Date('2026-05-07T00:00:00.000Z')
+      const endDate = new Date('2026-05-07T01:00:00.000Z')
+      const redis = buildRedis({ cachedValue: JSON.stringify(cached) })
+      const { controller, messageRepository } = buildController({ user: SUPER_USER, redisConnection: redis })
+      const req = { userId: 'user-id', query: { startDate: startDate.toISOString(), endDate: endDate.toISOString() } }
+      const res = buildResponse()
+
+      await controller.messageVolume(req, res)
+
+      expect(messageRepository.model).not.toHaveBeenCalled()
+      expect(res.status).toHaveBeenCalledWith(200)
+      expect(res.json).toHaveBeenCalledWith(cached)
+    })
+
+    it('queries DB and returns volume data on cache miss', async () => {
+      const redis = buildRedis({ cachedValue: null })
+      const modelAdapter = buildModelAdapter({ countResult: 5, aggregateResult: [{ _id: '2026-05-07', count: 5 }] })
+      const { controller } = buildController({
+        user: SUPER_USER,
+        messageModelAdapter: modelAdapter,
+        redisConnection: redis,
+      })
+      const req = {
+        userId: 'user-id',
+        query: { startDate: '2026-05-07T00:00:00.000Z', endDate: '2026-05-07T24:00:00.000Z' },
+      }
+      const res = buildResponse()
+
+      await controller.messageVolume(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(200)
+      const result = res.json.mock.calls[0][0]
+      expect(result).toHaveProperty('per_day')
+      expect(result).toHaveProperty('per_hour')
+      expect(result).toHaveProperty('peak_throughput')
+      expect(result).toHaveProperty('avg_transfer_rate')
+    })
+  })
+
+  describe('deliveryRate', () => {
+    it('returns 403 when user is not super', async () => {
+      const { controller } = buildController({ user: LICENSEE_USER })
+      const req = { userId: 'user-id', query: {} }
+      const res = buildResponse()
+
+      await controller.deliveryRate(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(403)
+    })
+
+    it('returns correct percentages on cache miss', async () => {
+      const redis = buildRedis({ cachedValue: null })
+      const modelAdapter = buildModelAdapter({ countResult: 0 })
+      modelAdapter._queryChain.countDocuments.mockResolvedValueOnce(80).mockResolvedValueOnce(20)
+      const { controller } = buildController({
+        user: SUPER_USER,
+        messageModelAdapter: modelAdapter,
+        redisConnection: redis,
+      })
+      const req = { userId: 'user-id', query: {} }
+      const res = buildResponse()
+
+      await controller.deliveryRate(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(200)
+      const result = res.json.mock.calls[0][0]
+      expect(result.sent_today).toBe(80)
+      expect(result.failed_today).toBe(20)
+      expect(result.sent_pct).toBe(80)
+      expect(result.failed_pct).toBe(20)
+    })
+
+    it('returns zero percentages when no messages', async () => {
+      const redis = buildRedis({ cachedValue: null })
+      const modelAdapter = buildModelAdapter({ countResult: 0 })
+      const { controller } = buildController({
+        user: SUPER_USER,
+        messageModelAdapter: modelAdapter,
+        redisConnection: redis,
+      })
+      const req = { userId: 'user-id', query: {} }
+      const res = buildResponse()
+
+      await controller.deliveryRate(req, res)
+
+      const result = res.json.mock.calls[0][0]
+      expect(result.sent_pct).toBe(0)
+      expect(result.failed_pct).toBe(0)
+    })
+  })
+
+  describe('queue', () => {
+    it('returns 403 when user is not super', async () => {
+      const { controller } = buildController({ user: LICENSEE_USER })
+      const req = { userId: 'user-id', query: {} }
+      const res = buildResponse()
+
+      await controller.queue(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(403)
+    })
+
+    it('returns queue stats on cache miss', async () => {
+      const redis = buildRedis({ cachedValue: null })
+      const modelAdapter = buildModelAdapter({ countResult: 5, aggregateResult: [{ _id: null, avg: 30 }] })
+      const { controller } = buildController({
+        user: SUPER_USER,
+        messageModelAdapter: modelAdapter,
+        redisConnection: redis,
+      })
+      const req = { userId: 'user-id', query: {} }
+      const res = buildResponse()
+
+      await controller.queue(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(200)
+      const result = res.json.mock.calls[0][0]
+      expect(result).toHaveProperty('pending_messages')
+      expect(result).toHaveProperty('avg_time_in_queue_seconds')
+    })
+
+    it('returns 0 avg when no aggregate results', async () => {
+      const redis = buildRedis({ cachedValue: null })
+      const modelAdapter = buildModelAdapter({ countResult: 3, aggregateResult: [] })
+      const { controller } = buildController({
+        user: SUPER_USER,
+        messageModelAdapter: modelAdapter,
+        redisConnection: redis,
+      })
+      const req = { userId: 'user-id', query: {} }
+      const res = buildResponse()
+
+      await controller.queue(req, res)
+
+      const result = res.json.mock.calls[0][0]
+      expect(result.avg_time_in_queue_seconds).toBe(0)
+    })
+  })
+
+  describe('conversations', () => {
+    it('returns 403 when user is not super', async () => {
+      const { controller } = buildController({ user: LICENSEE_USER })
+      const req = { userId: 'user-id', query: {} }
+      const res = buildResponse()
+
+      await controller.conversations(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(403)
+    })
+
+    it('returns conversation stats on cache miss', async () => {
+      const redis = buildRedis({ cachedValue: null })
+      const roomModelAdapter = buildModelAdapter({ countResult: 5, aggregateResult: [{ _id: null, avg: 120 }] })
+      const messageModelAdapter = buildModelAdapter({ aggregateResult: [{ _id: null, avg: 4.5 }] })
+      const { controller } = buildController({
+        user: SUPER_USER,
+        roomModelAdapter,
+        messageModelAdapter,
+        redisConnection: redis,
+      })
+      const req = { userId: 'user-id', query: {} }
+      const res = buildResponse()
+
+      await controller.conversations(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(200)
+      const result = res.json.mock.calls[0][0]
+      expect(result).toHaveProperty('started_today')
+      expect(result).toHaveProperty('ended_today')
+      expect(result).toHaveProperty('avg_messages_per_conversation')
+      expect(result).toHaveProperty('avg_duration_seconds')
+    })
+
+    it('returns 0 averages when no aggregate results', async () => {
+      const redis = buildRedis({ cachedValue: null })
+      const roomModelAdapter = buildModelAdapter({ countResult: 0, aggregateResult: [] })
+      const messageModelAdapter = buildModelAdapter({ aggregateResult: [] })
+      const { controller } = buildController({
+        user: SUPER_USER,
+        roomModelAdapter,
+        messageModelAdapter,
+        redisConnection: redis,
+      })
+      const req = { userId: 'user-id', query: {} }
+      const res = buildResponse()
+
+      await controller.conversations(req, res)
+
+      const result = res.json.mock.calls[0][0]
+      expect(result.avg_messages_per_conversation).toBe(0)
+      expect(result.avg_duration_seconds).toBe(0)
+    })
+  })
+
+  describe('contacts', () => {
+    it('returns 403 when user is super', async () => {
+      const { controller } = buildController({ user: SUPER_USER })
+      const req = { userId: 'user-id', query: {} }
+      const res = buildResponse()
+
+      await controller.contacts(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(403)
+    })
+
+    it('returns 404 when user not found', async () => {
+      const { controller } = buildController({ user: null })
+      const req = { userId: 'user-id', query: {} }
+      const res = buildResponse()
+
+      await controller.contacts(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(404)
+    })
+
+    it('serves from cache on cache hit', async () => {
+      const cached = { total: 10, in_chatbot: 3 }
+      const redis = buildRedis({ cachedValue: JSON.stringify(cached) })
+      const { controller, contactRepository } = buildController({ user: LICENSEE_USER, redisConnection: redis })
+      const req = { userId: 'user-id', query: {} }
+      const res = buildResponse()
+
+      await controller.contacts(req, res)
+
+      expect(redis.get).toHaveBeenCalledWith(`dashboard:licensee:${LICENSEE_USER.licensee}:contacts`)
+      expect(contactRepository.model).not.toHaveBeenCalled()
+      expect(res.status).toHaveBeenCalledWith(200)
+      expect(res.json).toHaveBeenCalledWith(cached)
+    })
+
+    it('queries DB on cache miss', async () => {
+      const redis = buildRedis({ cachedValue: null })
+      const modelAdapter = buildModelAdapter({ countResult: 0 })
+      modelAdapter._queryChain.countDocuments.mockResolvedValueOnce(15).mockResolvedValueOnce(4)
+      const { controller } = buildController({
+        user: LICENSEE_USER,
+        contactModelAdapter: modelAdapter,
+        redisConnection: redis,
+      })
+      const req = { userId: 'user-id', query: {} }
+      const res = buildResponse()
+
+      await controller.contacts(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(200)
+      const result = res.json.mock.calls[0][0]
+      expect(result.total).toBe(15)
+      expect(result.in_chatbot).toBe(4)
+    })
+  })
+
+  describe('messagesToday', () => {
+    it('returns 403 when user is super', async () => {
+      const { controller } = buildController({ user: SUPER_USER })
+      const req = { userId: 'user-id', query: {} }
+      const res = buildResponse()
+
+      await controller.messagesToday(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(403)
+    })
+
+    it('returns licensee message counts on cache miss', async () => {
+      const redis = buildRedis({ cachedValue: null })
+      const modelAdapter = buildModelAdapter({ countResult: 0 })
+      modelAdapter._queryChain.countDocuments.mockResolvedValueOnce(50).mockResolvedValueOnce(5)
+      const { controller } = buildController({
+        user: LICENSEE_USER,
+        messageModelAdapter: modelAdapter,
+        redisConnection: redis,
+      })
+      const req = { userId: 'user-id', query: {} }
+      const res = buildResponse()
+
+      await controller.messagesToday(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(200)
+      const result = res.json.mock.calls[0][0]
+      expect(result.sent_today).toBe(50)
+      expect(result.failed_today).toBe(5)
+    })
+  })
+
+  describe('messagesPerDay', () => {
+    it('returns 403 when user is super', async () => {
+      const { controller } = buildController({ user: SUPER_USER })
+      const req = { userId: 'user-id', query: {} }
+      const res = buildResponse()
+
+      await controller.messagesPerDay(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(403)
+    })
+
+    it('returns per_day data on cache miss', async () => {
+      const redis = buildRedis({ cachedValue: null })
+      const modelAdapter = buildModelAdapter({ aggregateResult: [{ _id: '2026-05-07', count: 10 }] })
+      const { controller } = buildController({
+        user: LICENSEE_USER,
+        messageModelAdapter: modelAdapter,
+        redisConnection: redis,
+      })
+      const req = { userId: 'user-id', query: {} }
+      const res = buildResponse()
+
+      await controller.messagesPerDay(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(200)
+      const result = res.json.mock.calls[0][0]
+      expect(result).toHaveProperty('per_day')
+      expect(result.per_day).toHaveLength(1)
+      expect(result.per_day[0]).toEqual({ _id: '2026-05-07', count: 10 })
+    })
+  })
+
+  describe('_parseDateRange', () => {
+    it('defaults to today when no query params', () => {
+      const { controller } = buildController()
+      const now = new Date()
+      const { startDate, endDate } = controller._parseDateRange({})
+
+      expect(startDate.getDate()).toBe(now.getDate())
+      expect(endDate.getTime() - startDate.getTime()).toBe(24 * 60 * 60 * 1000)
+    })
+
+    it('parses ISO date strings from query', () => {
+      const { controller } = buildController()
+      const start = '2026-01-01T00:00:00.000Z'
+      const end = '2026-01-02T00:00:00.000Z'
+      const { startDate, endDate } = controller._parseDateRange({ startDate: start, endDate: end })
+
+      expect(startDate).toEqual(new Date(start))
+      expect(endDate).toEqual(new Date(end))
+    })
+  })
+})

--- a/src/app/controllers/MessagesController.js
+++ b/src/app/controllers/MessagesController.js
@@ -1,8 +1,12 @@
 class MessagesController {
-  constructor({ createMessagesQuery } = {}) {
+  constructor({ createMessagesQuery, userRepository, messageRepository, queueServer } = {}) {
     this.createMessagesQuery = createMessagesQuery
+    this.userRepository = userRepository
+    this.messageRepository = messageRepository
+    this.queueServer = queueServer
 
     this.index = this.index.bind(this)
+    this.resend = this.resend.bind(this)
   }
 
   async index(req, res) {
@@ -41,6 +45,37 @@ class MessagesController {
     const messages = await messagesQuery.all()
 
     res.status(200).send(messages)
+  }
+
+  async resend(req, res) {
+    try {
+      const [user, message] = await Promise.all([
+        this.userRepository.findFirst({ _id: req.userId }),
+        this.messageRepository.findFirst({ _id: req.params.id }),
+      ])
+
+      if (!message) return res.status(404).json({ errors: { message: 'Message not found' } })
+
+      if (!user) return res.status(404).json({ errors: { message: 'User not found' } })
+
+      if (!user.isSuper) {
+        if (message.licensee.toString() !== user.licensee.toString()) {
+          return res.status(403).json({ errors: { message: 'Forbidden' } })
+        }
+      }
+
+      message.sended = false
+      message.error = null
+      message.sendedAt = null
+
+      await this.messageRepository.save(message)
+
+      await this.queueServer.addJob('send-message-to-messenger', { messageId: message._id })
+
+      return res.status(200).json(message)
+    } catch (err) {
+      return res.status(500).json({ errors: { message: err.toString() } })
+    }
   }
 }
 

--- a/src/app/controllers/MessagesController.js
+++ b/src/app/controllers/MessagesController.js
@@ -64,6 +64,10 @@ class MessagesController {
         }
       }
 
+      if (message.sended) {
+        return res.status(422).json({ errors: { message: 'Message already sended' } })
+      }
+
       message.sended = false
       message.error = null
       message.sendedAt = null

--- a/src/app/controllers/MessagesController.spec.js
+++ b/src/app/controllers/MessagesController.spec.js
@@ -90,11 +90,11 @@ describe('MessagesController resend', () => {
   const LICENSEE_ID = 'licensee-id'
   const OTHER_LICENSEE_ID = 'other-licensee-id'
 
-  function buildMessage(licenseeId = LICENSEE_ID) {
+  function buildMessage(licenseeId = LICENSEE_ID, { sended = false } = {}) {
     return {
       _id: 'msg-id',
       licensee: { toString: () => licenseeId },
-      sended: true,
+      sended,
       error: 'some error',
       sendedAt: new Date(),
     }
@@ -141,6 +141,20 @@ describe('MessagesController resend', () => {
 
     expect(queueServer.addJob).not.toHaveBeenCalled()
     expect(res.status).toHaveBeenCalledWith(403)
+  })
+
+  it('returns 422 when message is already sended', async () => {
+    const superUser = { _id: 'user-id', isSuper: true }
+    const message = buildMessage(LICENSEE_ID, { sended: true })
+    const { controller, queueServer } = buildController({ user: superUser, message })
+    const req = { userId: 'user-id', params: { id: 'msg-id' } }
+    const res = buildResponse()
+
+    await controller.resend(req, res)
+
+    expect(queueServer.addJob).not.toHaveBeenCalled()
+    expect(res.status).toHaveBeenCalledWith(422)
+    expect(res.json).toHaveBeenCalledWith({ errors: { message: 'Message already sended' } })
   })
 
   it('returns 404 when message not found', async () => {

--- a/src/app/controllers/MessagesController.spec.js
+++ b/src/app/controllers/MessagesController.spec.js
@@ -2,12 +2,13 @@ import { MessagesController } from './MessagesController.js'
 
 function buildResponse() {
   return {
+    json: jest.fn(),
     send: jest.fn(),
     status: jest.fn().mockReturnThis(),
   }
 }
 
-function buildController() {
+function buildController({ user = null, message = null } = {}) {
   const messagesQueryInstance = {
     page: jest.fn(),
     limit: jest.fn(),
@@ -21,9 +22,20 @@ function buildController() {
   }
   const createMessagesQuery = jest.fn().mockReturnValue(messagesQueryInstance)
 
-  const controller = new MessagesController({ createMessagesQuery })
+  const userRepository = {
+    findFirst: jest.fn().mockResolvedValue(user),
+  }
+  const messageRepository = {
+    findFirst: jest.fn().mockResolvedValue(message),
+    save: jest.fn().mockResolvedValue(undefined),
+  }
+  const queueServer = {
+    addJob: jest.fn().mockResolvedValue(undefined),
+  }
 
-  return { controller, createMessagesQuery, messagesQueryInstance }
+  const controller = new MessagesController({ createMessagesQuery, userRepository, messageRepository, queueServer })
+
+  return { controller, createMessagesQuery, messagesQueryInstance, userRepository, messageRepository, queueServer }
 }
 
 describe('MessagesController delegation', () => {
@@ -71,5 +83,75 @@ describe('MessagesController delegation', () => {
 
     expect(messagesQueryInstance.filterByLicensee).toHaveBeenCalledWith('licensee-id')
     expect(messagesQueryInstance.filterByContact).toHaveBeenCalledWith('contact-id')
+  })
+})
+
+describe('MessagesController resend', () => {
+  const LICENSEE_ID = 'licensee-id'
+  const OTHER_LICENSEE_ID = 'other-licensee-id'
+
+  function buildMessage(licenseeId = LICENSEE_ID) {
+    return {
+      _id: 'msg-id',
+      licensee: { toString: () => licenseeId },
+      sended: true,
+      error: 'some error',
+      sendedAt: new Date(),
+    }
+  }
+
+  it('resets message fields, enqueues, and returns 200 for super user', async () => {
+    const superUser = { _id: 'user-id', isSuper: true }
+    const message = buildMessage()
+    const { controller, messageRepository, queueServer } = buildController({ user: superUser, message })
+    const req = { userId: 'user-id', params: { id: 'msg-id' } }
+    const res = buildResponse()
+
+    await controller.resend(req, res)
+
+    expect(message.sended).toBe(false)
+    expect(message.error).toBeNull()
+    expect(message.sendedAt).toBeNull()
+    expect(messageRepository.save).toHaveBeenCalledWith(message)
+    expect(queueServer.addJob).toHaveBeenCalledWith('send-message-to-messenger', { messageId: message._id })
+    expect(res.status).toHaveBeenCalledWith(200)
+  })
+
+  it('resets message and returns 200 for licensee user owning the message', async () => {
+    const licenseeUser = { _id: 'user-id', isSuper: false, licensee: { toString: () => LICENSEE_ID } }
+    const message = buildMessage(LICENSEE_ID)
+    const { controller, queueServer } = buildController({ user: licenseeUser, message })
+    const req = { userId: 'user-id', params: { id: 'msg-id' } }
+    const res = buildResponse()
+
+    await controller.resend(req, res)
+
+    expect(queueServer.addJob).toHaveBeenCalledWith('send-message-to-messenger', { messageId: message._id })
+    expect(res.status).toHaveBeenCalledWith(200)
+  })
+
+  it('returns 403 when licensee user attempts cross-licensee resend', async () => {
+    const licenseeUser = { _id: 'user-id', isSuper: false, licensee: { toString: () => OTHER_LICENSEE_ID } }
+    const message = buildMessage(LICENSEE_ID)
+    const { controller, queueServer } = buildController({ user: licenseeUser, message })
+    const req = { userId: 'user-id', params: { id: 'msg-id' } }
+    const res = buildResponse()
+
+    await controller.resend(req, res)
+
+    expect(queueServer.addJob).not.toHaveBeenCalled()
+    expect(res.status).toHaveBeenCalledWith(403)
+  })
+
+  it('returns 404 when message not found', async () => {
+    const superUser = { _id: 'user-id', isSuper: true }
+    const { controller, queueServer } = buildController({ user: superUser, message: null })
+    const req = { userId: 'user-id', params: { id: 'nonexistent-id' } }
+    const res = buildResponse()
+
+    await controller.resend(req, res)
+
+    expect(queueServer.addJob).not.toHaveBeenCalled()
+    expect(res.status).toHaveBeenCalledWith(404)
   })
 })

--- a/src/app/models/Room.js
+++ b/src/app/models/Room.js
@@ -9,6 +9,7 @@ const roomSchema = new Schema(
     roomId: String,
     token: String,
     closed: { type: Boolean, default: false },
+    closedAt: { type: Date },
     contact: {
       type: ObjectId,
       ref: 'Contact',

--- a/src/app/plugins/chatbots/Landbot.js
+++ b/src/app/plugins/chatbots/Landbot.js
@@ -10,6 +10,7 @@ const closeRoom = async (contact, roomRepository) => {
   const room = await roomRepository.findFirst({ contact: contact._id, closed: false })
   if (room) {
     room.closed = true
+    room.closedAt = new Date()
     await roomRepository.save(room)
   }
 }

--- a/src/app/plugins/chats/Chatwoot.js
+++ b/src/app/plugins/chats/Chatwoot.js
@@ -334,6 +334,7 @@ class Chatwoot extends ChatsBase {
 
     const room = await this.roomRepository.findFirst({ roomId: message.room.roomId })
     room.closed = true
+    room.closedAt = new Date()
     await this.roomRepository.save(room)
 
     if (licensee.messageOnCloseChat) {
@@ -467,6 +468,7 @@ class Chatwoot extends ChatsBase {
       if (response.data.error === 'Resource could not be found') {
         const roomSaved = await this.roomRepository.findFirst({ roomId: room.roomId })
         roomSaved.closed = true
+        roomSaved.closedAt = new Date()
         await this.roomRepository.save(roomSaved)
 
         await this.contactRepository.update(contact._id, {

--- a/src/app/plugins/chats/Rocketchat.js
+++ b/src/app/plugins/chats/Rocketchat.js
@@ -170,6 +170,7 @@ class Rocketchat extends ChatsBase {
         : JSON.stringify(response.data)
       if (messageToSend.error.includes('room-closed')) {
         room.closed = true
+        room.closedAt = new Date()
         await this.roomRepository.save(room)
         messageToSend.room = null
       }
@@ -195,6 +196,7 @@ class Rocketchat extends ChatsBase {
     const messages = []
 
     room.closed = true
+    room.closedAt = new Date()
     await this.roomRepository.save(room)
 
     if (licensee.messageOnCloseChat) {

--- a/src/app/routes/resources-routes.js
+++ b/src/app/routes/resources-routes.js
@@ -6,7 +6,9 @@ import { ContactsController } from '../controllers/ContactsController.js'
 import { TriggersController } from '../controllers/TriggersController.js'
 import { MessagesController } from '../controllers/MessagesController.js'
 import { TemplatesController } from '../controllers/TemplatesController.js'
+import { DashboardController } from '../controllers/DashboardController.js'
 import { queueServer } from '../../config/queue.js'
+import { redisConnection } from '../../config/redis.js'
 import { LicenseesQuery } from '../queries/LicenseesQuery.js'
 import { ContactsQuery } from '../queries/ContactsQuery.js'
 import { TriggersQuery } from '../queries/TriggersQuery.js'
@@ -38,6 +40,7 @@ const {
   triggerRepository,
   templateRepository,
   messageRepository,
+  roomRepository,
   createMessengerPlugin,
   createPagarMe,
   createPedidos10,
@@ -79,6 +82,17 @@ const triggersController = new TriggersController({
 })
 const messagesController = new MessagesController({
   createMessagesQuery: () => new MessagesQuery({ messageRepository }),
+  userRepository,
+  messageRepository,
+  queueServer,
+})
+const dashboardController = new DashboardController({
+  userRepository,
+  licenseeRepository,
+  contactRepository,
+  messageRepository,
+  roomRepository,
+  redisConnection,
 })
 const templatesController = new TemplatesController({
   templateRepository,
@@ -133,5 +147,15 @@ router.post('/licensees/:id/sign-order-webhook', licenseesController.signOrderWe
 router.post('/licensees/:id/integration/pagarme', licenseesController.sendToPagarMe)
 
 router.get('/messages', messagesController.index)
+router.post('/messages/:id/resend', messagesController.resend)
+
+router.get('/dashboard/licensees', dashboardController.licensees)
+router.get('/dashboard/message-volume', dashboardController.messageVolume)
+router.get('/dashboard/delivery-rate', dashboardController.deliveryRate)
+router.get('/dashboard/queue', dashboardController.queue)
+router.get('/dashboard/conversations', dashboardController.conversations)
+router.get('/dashboard/contacts', dashboardController.contacts)
+router.get('/dashboard/messages-today', dashboardController.messagesToday)
+router.get('/dashboard/messages-per-day', dashboardController.messagesPerDay)
 
 export default router


### PR DESCRIPTION
## Summary

- Adds a 3-phase development plan for role-aware dashboard widgets
- Super users see platform-wide metrics; licensee users see scoped data
- Includes resend flow for failed messages via Bull queue

## Plan structure

| Phase | Task | Description |
|-------|------|-------------|
| 1 | `task-01-room-schema` | Add `closedAt: Date` to Room schema + update 5 close sites in Rocketchat, Chatwoot, Landbot plugins |
| 2 | `task-02-backend` | `DashboardController` (GET /resources/dashboard/stats) + resend endpoint (POST /resources/messages/:id/resend) |
| 3 | `task-03-frontend` | Dashboard page with role-aware widgets + failed-messages Bootstrap modal with per-row resend buttons |

## Super user widgets
- Licensees: total / active / by plan kind
- Message Volume: per day (7d), per hour (today), peak throughput, avg transfer rate
- Delivery Rate: sent + failed counts + percentages (failed is clickable → resend modal)
- Queue: pending messages, avg time in queue
- Conversations: started, ended, avg msgs/conversation, avg duration

## Licensee user widgets
- Contacts: total + in chatbot
- Messages Today: sent + failed
- Messages per Day: last 7 days table

## Test plan
- [ ] Review plan task files for completeness and accuracy
- [ ] Confirm phase dependencies are correct before execution begins
- [ ] Verify resend payload shape against `SendMessageToMessenger.js` before Phase 2 starts