### PR TITLE
plan(baileys-groups-directory): Baileys Group Messaging & Directory Sync

### DIFF
--- a/.plans/README.md
+++ b/.plans/README.md
@@ -25,6 +25,7 @@ Git-native Markdown plans for multi-step work.
 | 1 | [JS → TypeScript](./js-to-ts/overview.md) | `js-to-ts/` | not-started | Incremental migration of all source files (backend + client) to TypeScript using `allowJs: true` throughout |
 | 2 | [Remove PDV](./remove-pdv/overview.md) | `remove-pdv/` | not-started | Delete cart, payment (PagarMe), and order integration (Pedidos10) domain — strip PDV fields from Licensee and Contact |
 | 3 | [Security Hardening](./security-hardening/overview.md) | `security-hardening/` | not-started | Fix 10 security issues from OWASP audit: Helmet, CORS, rate limiting, Bull Board auth, error leakage, JWT fix, RBAC, logging PII, API token header, v1 input validation |
+| 4 | [Baileys Group Messaging & Directory Sync](./baileys-groups-directory/overview.md) | `baileys-groups-directory/` | not-started | Extend the existing Baileys plugin to import WhatsApp contacts/groups into Contacts and send outbound messages to group JIDs |
 
 ---
 

--- a/.plans/baileys-groups-directory/overview.md
+++ b/.plans/baileys-groups-directory/overview.md
@@ -9,13 +9,13 @@
 
 ## Objective
 
-Extend the existing Baileys integration so a connected WhatsApp account can sync its groups, plus any directly available WhatsApp contact directory metadata, into the app's existing `Contact` model without reading chat history, and so outbound `to-messenger` messages can be sent directly to WhatsApp groups.
+Extend the existing Baileys integration so a connected WhatsApp account can discover which WhatsApp groups it belongs to, sync those groups into the app's existing `Contact` model without reading chat history, and send outbound `to-messenger` messages directly to those groups.
 
 ## Scope
 
 ### In Scope
 - Reuse the existing Baileys session/auth flow to open an authenticated socket for on-demand directory sync
-- Import WhatsApp groups, and any directly available WhatsApp contact directory metadata, into existing `Contact` records using `@c.us` / `@g.us` types
+- Import WhatsApp groups into existing `Contact` records using `type: '@g.us'`
 - Add an authenticated admin endpoint to trigger the sync and return import/update counts
 - Support outbound Baileys sends to group JIDs stored on imported contacts
 - Add admin UI controls to trigger sync and inspect imported groups through the existing Contacts surface
@@ -26,12 +26,13 @@ Extend the existing Baileys integration so a connected WhatsApp account can sync
 - Group creation, join/leave, participant management, or admin moderation actions — not requested
 - Media/template feature expansion beyond the current Baileys plugin scope — only group-target delivery is required
 - Reading, importing, or persisting WhatsApp chat/message history — explicitly excluded for this plan
+- Searching, importing, or syncing the full WhatsApp contact list — not required for this plan
 - Full bidirectional WhatsApp address-book editing — the repo needs read/import behavior, not contact mutation on WhatsApp
 - Reworking inbound group-routing behavior into chatbot/chat platforms — this plan focuses on sync/read and outbound group send
 
 ## Kill Criteria
 
-- If live validation on the repo's resolved `@whiskeysockets/baileys` `7.0.0-rc11` cannot produce a usable contact list without enabling or consuming chat history, stop and re-scope the feature to groups-only plus existing/manual contacts
+- If live validation on the repo's resolved `@whiskeysockets/baileys` `7.0.0-rc11` cannot produce a usable list of groups without enabling or consuming chat history, stop and escalate the Baileys limitation before implementation continues
 - If a connected Baileys session cannot deliver a simple text message to a known `@g.us` JID in local smoke validation, stop and capture the vendor/library limitation before further implementation
 - If on-demand directory sync cannot complete within a bounded 30-second request window for a typical linked account and no asynchronous fallback is acceptable, escalate before shipping
 
@@ -80,13 +81,13 @@ Base branch: `main`
 
 ## Risks
 
-- Baileys does not document a simple fetch-all contacts API; contact availability appears to come from contact/store events rather than a guaranteed directory endpoint — mitigate with a no-history capability check and preserve a groups-first fallback
+- Baileys group membership discovery must work without consuming message history — mitigate with `groupFetchAllParticipating()` validation before building the rest of the flow
 - The current outbound send path assumes a person JID resolved via `onWhatsApp()` — mitigate with type-aware routing that sends `@g.us` contacts directly by stored `waId`
 - Imported groups will reuse the legacy `Contact` model — mitigate with idempotent matching on `licensee + waId` and minimal mutation of unrelated contact fields
 
 ## Success Criteria
 
-- [ ] A connected Baileys licensee can trigger an admin sync that imports/updates WhatsApp groups and, when available without history reads, WhatsApp contact directory records
+- [ ] A connected Baileys licensee can trigger an admin sync that imports/updates WhatsApp groups
 - [ ] Imported groups are stored as `Contact` records with stable `waId` and `type: '@g.us'`
 - [ ] Existing contacts APIs/UI can distinguish contacts from groups without creating a new model or table
 - [ ] A `to-messenger` message targeting an imported group contact is delivered through Baileys using the group JID

--- a/.plans/baileys-groups-directory/overview.md
+++ b/.plans/baileys-groups-directory/overview.md
@@ -9,27 +9,29 @@
 
 ## Objective
 
-Extend the existing Baileys integration so a connected WhatsApp account can sync its contacts and groups into the app's existing `Contact` model, and so outbound `to-messenger` messages can be sent directly to WhatsApp groups.
+Extend the existing Baileys integration so a connected WhatsApp account can sync its groups, plus any directly available WhatsApp contact directory metadata, into the app's existing `Contact` model without reading chat history, and so outbound `to-messenger` messages can be sent directly to WhatsApp groups.
 
 ## Scope
 
 ### In Scope
 - Reuse the existing Baileys session/auth flow to open an authenticated socket for on-demand directory sync
-- Import WhatsApp contacts and groups into existing `Contact` records using `@c.us` / `@g.us` types
+- Import WhatsApp groups, and any directly available WhatsApp contact directory metadata, into existing `Contact` records using `@c.us` / `@g.us` types
 - Add an authenticated admin endpoint to trigger the sync and return import/update counts
 - Support outbound Baileys sends to group JIDs stored on imported contacts
 - Add admin UI controls to trigger sync and inspect imported groups through the existing Contacts surface
 - Add automated tests and update the existing Baileys KB/API documentation
+- Preserve the no-history constraint: do not enable, read, persist, or import chat/message history as part of sync
 
 ### Out of Scope
 - Group creation, join/leave, participant management, or admin moderation actions — not requested
 - Media/template feature expansion beyond the current Baileys plugin scope — only group-target delivery is required
+- Reading, importing, or persisting WhatsApp chat/message history — explicitly excluded for this plan
 - Full bidirectional WhatsApp address-book editing — the repo needs read/import behavior, not contact mutation on WhatsApp
 - Reworking inbound group-routing behavior into chatbot/chat platforms — this plan focuses on sync/read and outbound group send
 
 ## Kill Criteria
 
-- If live validation on the repo's resolved `@whiskeysockets/baileys` `7.0.0-rc11` cannot produce a usable contact list from `messaging-history.set` or related contact events for a linked device, stop and re-scope the feature to groups-only
+- If live validation on the repo's resolved `@whiskeysockets/baileys` `7.0.0-rc11` cannot produce a usable contact list without enabling or consuming chat history, stop and re-scope the feature to groups-only plus existing/manual contacts
 - If a connected Baileys session cannot deliver a simple text message to a known `@g.us` JID in local smoke validation, stop and capture the vendor/library limitation before further implementation
 - If on-demand directory sync cannot complete within a bounded 30-second request window for a typical linked account and no asynchronous fallback is acceptable, escalate before shipping
 
@@ -78,16 +80,17 @@ Base branch: `main`
 
 ## Risks
 
-- Baileys contact retrieval is event/history-driven rather than a documented single `getAllContacts()` call — mitigate with an explicit on-demand sync flow and live validation against the linked device
+- Baileys does not document a simple fetch-all contacts API; contact availability appears to come from contact/store events rather than a guaranteed directory endpoint — mitigate with a no-history capability check and preserve a groups-first fallback
 - The current outbound send path assumes a person JID resolved via `onWhatsApp()` — mitigate with type-aware routing that sends `@g.us` contacts directly by stored `waId`
 - Imported groups will reuse the legacy `Contact` model — mitigate with idempotent matching on `licensee + waId` and minimal mutation of unrelated contact fields
 
 ## Success Criteria
 
-- [ ] A connected Baileys licensee can trigger an admin sync that imports/updates both WhatsApp contacts and groups
+- [ ] A connected Baileys licensee can trigger an admin sync that imports/updates WhatsApp groups and, when available without history reads, WhatsApp contact directory records
 - [ ] Imported groups are stored as `Contact` records with stable `waId` and `type: '@g.us'`
 - [ ] Existing contacts APIs/UI can distinguish contacts from groups without creating a new model or table
 - [ ] A `to-messenger` message targeting an imported group contact is delivered through Baileys using the group JID
+- [ ] No chat/message history is read or persisted as part of the sync flow
 - [ ] Existing Baileys QR/status behavior continues to work
 - [ ] All tests pass
 - [ ] Required KB / documentation updates are complete or explicitly marked not needed

--- a/.plans/baileys-groups-directory/overview.md
+++ b/.plans/baileys-groups-directory/overview.md
@@ -1,0 +1,101 @@
+# Plan: Baileys Group Messaging & Directory Sync
+
+**Status**: not-started
+**Created**: 2026-05-16
+**Last Updated**: 2026-05-16
+**Estimated Demo Date**: 2026-05-23
+**Assigned Dev**: Alan Costa Facchini
+**Assigned QA**: unassigned
+
+## Objective
+
+Extend the existing Baileys integration so a connected WhatsApp account can sync its contacts and groups into the app's existing `Contact` model, and so outbound `to-messenger` messages can be sent directly to WhatsApp groups.
+
+## Scope
+
+### In Scope
+- Reuse the existing Baileys session/auth flow to open an authenticated socket for on-demand directory sync
+- Import WhatsApp contacts and groups into existing `Contact` records using `@c.us` / `@g.us` types
+- Add an authenticated admin endpoint to trigger the sync and return import/update counts
+- Support outbound Baileys sends to group JIDs stored on imported contacts
+- Add admin UI controls to trigger sync and inspect imported groups through the existing Contacts surface
+- Add automated tests and update the existing Baileys KB/API documentation
+
+### Out of Scope
+- Group creation, join/leave, participant management, or admin moderation actions — not requested
+- Media/template feature expansion beyond the current Baileys plugin scope — only group-target delivery is required
+- Full bidirectional WhatsApp address-book editing — the repo needs read/import behavior, not contact mutation on WhatsApp
+- Reworking inbound group-routing behavior into chatbot/chat platforms — this plan focuses on sync/read and outbound group send
+
+## Kill Criteria
+
+- If live validation on the repo's resolved `@whiskeysockets/baileys` `7.0.0-rc11` cannot produce a usable contact list from `messaging-history.set` or related contact events for a linked device, stop and re-scope the feature to groups-only
+- If a connected Baileys session cannot deliver a simple text message to a known `@g.us` JID in local smoke validation, stop and capture the vendor/library limitation before further implementation
+- If on-demand directory sync cannot complete within a bounded 30-second request window for a typical linked account and no asynchronous fallback is acceptable, escalate before shipping
+
+## Phases
+
+| Phase | Name | Tasks | Dependencies | Description |
+|-------|------|-------|--------------|-------------|
+| 1 | Core Messenger Extension | task-01 | None | Extend the Baileys plugin with reusable socket helpers, directory fetch primitives, and group-aware send behavior |
+| 2 | Sync API | task-02 | Phase 1 | Import synced contacts/groups into `Contact` records and expose an admin sync endpoint |
+| 3 | Admin Surface | task-03 | Phase 2 | Add Licensee/Contacts UI affordances so admins can trigger sync and inspect imported groups |
+| 4 | Docs & Verification | task-04 | Phase 2, Phase 3 | Update KB/API docs and capture the live verification matrix for the new flow |
+
+## Task Summary
+
+| Task Path | Title | Phase | Status | Depends On |
+|-----------|-------|-------|--------|------------|
+| task-01-plugin-core | Baileys Group/Directory Core | 1 | not-started | — |
+| task-02-directory-sync-api | Directory Sync API | 2 | not-started | task-01-plugin-core |
+| task-03-admin-sync-surface | Admin Sync Surface | 3 | not-started | task-02-directory-sync-api |
+| task-04-docs-and-verification | Docs and Live Verification | 4 | not-started | task-02-directory-sync-api, task-03-admin-sync-surface |
+
+## Branch Convention
+
+Pattern: `plan/baileys-groups-directory/{task-path}`
+
+Example branches:
+- `plan/baileys-groups-directory/task-01-plugin-core`
+- `plan/baileys-groups-directory/task-02-directory-sync-api`
+
+Base branch: `main`
+
+## Key Files
+
+| File/Directory | Relevance |
+|----------------|-----------|
+| `src/app/plugins/messengers/Baileys.js` | Current Baileys socket/session/send implementation; group send and directory sync start here |
+| `src/app/plugins/messengers/Baileys.spec.js` | Existing harness for plugin behavior and mocking socket events |
+| `src/app/controllers/LicenseesController.js` | Current Baileys QR/status actions live here; sync endpoint should follow the same pattern |
+| `src/app/usecases/licensees/` | Existing Baileys QR/status use cases provide the shape for a new sync use case |
+| `src/app/routes/resources-routes.js` | Admin resource API route registration |
+| `src/app/models/Contact.js` | Existing contact model already stores `type`, `number`, and `waId` needed for imported groups |
+| `src/app/helpers/NormalizePhone.js` | Current `@c.us` / `@g.us` normalization behavior that imported entities must preserve |
+| `src/app/queries/ContactsQuery.js` | Existing `type` filter can surface contacts vs groups without a new backend query layer |
+| `client/src/pages/Licensees/scenes/Form/panels/WhatsAppPanel.js` | Current Baileys QR/status admin surface |
+| `client/src/pages/Contacts/scenes/Index/index.js` | Existing Contacts UI where imported groups can be inspected |
+
+## Risks
+
+- Baileys contact retrieval is event/history-driven rather than a documented single `getAllContacts()` call — mitigate with an explicit on-demand sync flow and live validation against the linked device
+- The current outbound send path assumes a person JID resolved via `onWhatsApp()` — mitigate with type-aware routing that sends `@g.us` contacts directly by stored `waId`
+- Imported groups will reuse the legacy `Contact` model — mitigate with idempotent matching on `licensee + waId` and minimal mutation of unrelated contact fields
+
+## Success Criteria
+
+- [ ] A connected Baileys licensee can trigger an admin sync that imports/updates both WhatsApp contacts and groups
+- [ ] Imported groups are stored as `Contact` records with stable `waId` and `type: '@g.us'`
+- [ ] Existing contacts APIs/UI can distinguish contacts from groups without creating a new model or table
+- [ ] A `to-messenger` message targeting an imported group contact is delivered through Baileys using the group JID
+- [ ] Existing Baileys QR/status behavior continues to work
+- [ ] All tests pass
+- [ ] Required KB / documentation updates are complete or explicitly marked not needed
+- [ ] No regressions in existing functionality
+
+## References
+
+- **JIRA Epic**: N/A
+- **Weekly Plan Brief**: N/A
+- **Related Plans**: [Baileys WhatsApp Plugin](../baileys-plugin/overview.md)
+- **Rock Alignment**: N/A

--- a/.plans/baileys-groups-directory/overview.md
+++ b/.plans/baileys-groups-directory/overview.md
@@ -9,14 +9,16 @@
 
 ## Objective
 
-Extend the existing Baileys integration so a connected WhatsApp account can discover which WhatsApp groups it belongs to, sync those groups into the app's existing `Contact` model without reading chat history, and send outbound `to-messenger` messages directly to those groups.
+Extend the existing Baileys integration so a connected WhatsApp account can discover which WhatsApp groups it belongs to, sync those groups into the app's existing `Contact` model without reading chat history, mark synced records explicitly as groups, and send outbound `to-messenger` messages directly to those groups.
 
 ## Scope
 
 ### In Scope
 - Reuse the existing Baileys session/auth flow to open an authenticated socket for on-demand directory sync
 - Import WhatsApp groups into existing `Contact` records using `type: '@g.us'`
+- Add a dedicated contact field to persist whether a contact record represents a group
 - Add an authenticated admin endpoint to trigger the sync and return import/update counts
+- Improve the contacts index endpoint with group-only filtering and `updatedAt` date filtering
 - Support outbound Baileys sends to group JIDs stored on imported contacts
 - Add admin UI controls to trigger sync and inspect imported groups through the existing Contacts surface
 - Add automated tests and update the existing Baileys KB/API documentation
@@ -41,7 +43,7 @@ Extend the existing Baileys integration so a connected WhatsApp account can disc
 | Phase | Name | Tasks | Dependencies | Description |
 |-------|------|-------|--------------|-------------|
 | 1 | Core Messenger Extension | task-01 | None | Extend the Baileys plugin with reusable socket helpers, directory fetch primitives, and group-aware send behavior |
-| 2 | Sync API | task-02 | Phase 1 | Import synced contacts/groups into `Contact` records and expose an admin sync endpoint |
+| 2 | Contact Model & Sync API | task-02 | Phase 1 | Add the contact group field, extend contacts index filtering, and expose the admin group sync endpoint |
 | 3 | Admin Surface | task-03 | Phase 2 | Add Licensee/Contacts UI affordances so admins can trigger sync and inspect imported groups |
 | 4 | Docs & Verification | task-04 | Phase 2, Phase 3 | Update KB/API docs and capture the live verification matrix for the new flow |
 
@@ -50,7 +52,7 @@ Extend the existing Baileys integration so a connected WhatsApp account can disc
 | Task Path | Title | Phase | Status | Depends On |
 |-----------|-------|-------|--------|------------|
 | task-01-plugin-core | Baileys Group/Directory Core | 1 | not-started | — |
-| task-02-directory-sync-api | Directory Sync API | 2 | not-started | task-01-plugin-core |
+| task-02-directory-sync-api | Contact Group Field, Filters, and Sync API | 2 | not-started | task-01-plugin-core |
 | task-03-admin-sync-surface | Admin Sync Surface | 3 | not-started | task-02-directory-sync-api |
 | task-04-docs-and-verification | Docs and Live Verification | 4 | not-started | task-02-directory-sync-api, task-03-admin-sync-surface |
 
@@ -73,9 +75,10 @@ Base branch: `main`
 | `src/app/controllers/LicenseesController.js` | Current Baileys QR/status actions live here; sync endpoint should follow the same pattern |
 | `src/app/usecases/licensees/` | Existing Baileys QR/status use cases provide the shape for a new sync use case |
 | `src/app/routes/resources-routes.js` | Admin resource API route registration |
-| `src/app/models/Contact.js` | Existing contact model already stores `type`, `number`, and `waId` needed for imported groups |
+| `src/app/models/Contact.js` | Contact model needs the explicit group marker field used by synced WhatsApp groups |
 | `src/app/helpers/NormalizePhone.js` | Current `@c.us` / `@g.us` normalization behavior that imported entities must preserve |
-| `src/app/queries/ContactsQuery.js` | Existing `type` filter can surface contacts vs groups without a new backend query layer |
+| `src/app/queries/ContactsQuery.js` | Contacts index query layer needs new `updatedAt` and group-only filters |
+| `src/app/controllers/ContactsController.js` | Contacts index endpoint must accept and forward the new filter params |
 | `client/src/pages/Licensees/scenes/Form/panels/WhatsAppPanel.js` | Current Baileys QR/status admin surface |
 | `client/src/pages/Contacts/scenes/Index/index.js` | Existing Contacts UI where imported groups can be inspected |
 
@@ -88,7 +91,8 @@ Base branch: `main`
 ## Success Criteria
 
 - [ ] A connected Baileys licensee can trigger an admin sync that imports/updates WhatsApp groups
-- [ ] Imported groups are stored as `Contact` records with stable `waId` and `type: '@g.us'`
+- [ ] Imported groups are stored as `Contact` records with stable `waId`, `type: '@g.us'`, and an explicit persisted group flag
+- [ ] The contacts index endpoint supports filtering by `updatedAt` date and group-only records
 - [ ] Existing contacts APIs/UI can distinguish contacts from groups without creating a new model or table
 - [ ] A `to-messenger` message targeting an imported group contact is delivered through Baileys using the group JID
 - [ ] No chat/message history is read or persisted as part of the sync flow

--- a/.plans/baileys-groups-directory/task-01-plugin-core/status.md
+++ b/.plans/baileys-groups-directory/task-01-plugin-core/status.md
@@ -1,0 +1,25 @@
+# Status: Baileys Group/Directory Core
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-16
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-16 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/baileys-groups-directory/task-01-plugin-core/task.md
+++ b/.plans/baileys-groups-directory/task-01-plugin-core/task.md
@@ -1,0 +1,118 @@
+# Task: Baileys Group/Directory Core
+
+**Plan**: Baileys Group Messaging & Directory Sync
+**Phase**: 1
+**Task ID (phase-local)**: task-01
+**Task Path**: task-01-plugin-core
+**Depends On**: None
+**JIRA**: N/A
+
+## Objective
+
+Extend the Baileys messenger plugin so it can fetch group/contact directory data from a connected WhatsApp account and send outbound messages directly to imported group JIDs.
+
+## Context
+
+The repo already has a working Baileys session flow for QR pairing, status checks, inbound message parsing, and person-to-person sends. The missing capability is a reusable authenticated socket path that can serve three needs without duplicating connection logic:
+
+- directory sync primitives for groups and contacts
+- type-aware outbound sends for `@g.us` contacts
+- shared session handling that still preserves the current QR/status behavior
+
+Relevant files and docs:
+- [docs/kb/features/baileys-whatsapp-guide.md](../../../docs/kb/features/baileys-whatsapp-guide.md)
+- [docs/kb/architecture/project-overview.md](../../../docs/kb/architecture/project-overview.md)
+- `src/app/plugins/messengers/Baileys.js`
+- `src/app/plugins/messengers/Baileys.spec.js`
+- Baileys History Sync docs: `https://baileys.wiki/docs/socket/history-sync/`
+- Baileys Receiving Updates docs: `https://baileys.wiki/docs/socket/receiving-updates/`
+- Baileys API docs for `groupFetchAllParticipating()`: `https://baileys.wiki/docs/api/functions/makeWASocket/`
+
+Important implementation constraint:
+- groups are directly supported by Baileys via `groupFetchAllParticipating()` and `sendMessage(groupJid, ...)`
+- contact import is less direct and must rely on history/contact events (`messaging-history.set`, `contacts.upsert`, `contacts.update`) or store binding
+
+## Before You Start
+
+- [ ] Switch to the planning/base branch and pull the latest plan state: `git switch main && git pull --rebase origin main`
+- [ ] Verify `Depends On` is satisfied
+- [ ] Check this task's `status.md` — if already `in-progress` or `complete`, stop and investigate
+- [ ] Read referenced architecture docs:
+  - `docs/kb/features/baileys-whatsapp-guide.md`
+  - `docs/kb/architecture/project-overview.md`
+- [ ] Review the current plugin/test shape in `src/app/plugins/messengers/Baileys.js` and `src/app/plugins/messengers/Baileys.spec.js`
+- [ ] Mark this task `in-progress` in `status.md` before proceeding
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/app/plugins/messengers/Baileys.js` | modify | Add reusable socket helpers, directory fetch, and group-aware send logic |
+| `src/app/plugins/messengers/Baileys.spec.js` | modify | Cover directory sync primitives and `@g.us` outbound sends |
+| `src/app/plugins/messengers/baileys/` | create | Optional helper module(s) if the socket/session logic needs extraction to keep `Baileys.js` readable |
+
+### Do NOT Modify
+
+- `src/app/controllers/LicenseesController.js` — owned by `task-02-directory-sync-api`
+- `src/app/routes/resources-routes.js` — owned by `task-02-directory-sync-api`
+- `src/app/usecases/licensees/` — owned by `task-02-directory-sync-api`
+- `client/src/pages/Licensees/scenes/Form/panels/WhatsAppPanel.js` — owned by `task-03-admin-sync-surface`
+- `client/src/pages/Contacts/scenes/Index/index.js` — owned by `task-03-admin-sync-surface`
+- `docs/kb/features/baileys-whatsapp-guide.md` — owned by `task-04-docs-and-verification`
+- `API_DOCUMENTATION.md` — owned by `task-04-docs-and-verification`
+
+## Implementation Steps
+
+### Step 1: Consolidate authenticated socket/session helpers
+
+Refactor the current `Baileys.js` connection bootstrap so QR generation, outbound send, and directory sync can share the same session-loading, `creds.update`, connection lifecycle, and cleanup behavior without copy/paste branching.
+
+### Step 2: Add directory retrieval primitives
+
+Implement a plugin method that returns a normalized sync payload for:
+- groups from `groupFetchAllParticipating()`
+- contacts collected from `messaging-history.set` and/or contact update events within a bounded wait window
+
+Define a stable internal result shape for task 2 to consume, for example:
+
+```json
+{
+  "contacts": [{ "waId": "5511999999999", "name": "Jane", "number": "5511999999999", "type": "@c.us" }],
+  "groups": [{ "waId": "1203630...@g.us", "name": "Sales Team", "number": "1203630...-...", "type": "@g.us" }]
+}
+```
+
+### Step 3: Make outbound sends group-aware
+
+Update `sendMessage()` so:
+- `@c.us` contacts still resolve/validate person JIDs appropriately
+- `@g.us` contacts bypass `onWhatsApp()` lookup and send directly to the stored group JID
+- failure paths still persist `message.error` and preserve the existing queue behavior
+
+## Testing
+
+- [ ] Add/adjust plugin specs for group directory retrieval behavior
+- [ ] Add/adjust plugin specs proving `sendMessage()` delivers to a stored `@g.us` JID without resolving it as a person number
+- [ ] `npx jest src/app/plugins/messengers/Baileys.spec.js`
+- [ ] Existing tests still pass
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] No planned KB/doc updates in this task; `task-04-docs-and-verification` owns the user-facing docs
+- [ ] If the implementation requires a non-obvious Baileys history-sync workaround, run `document-solution`
+- [ ] If KB files change unexpectedly, run `check-kb-index`
+
+## Completion Criteria
+
+- [ ] `Baileys.js` exposes a reusable directory-fetch path that task 2 can call
+- [ ] Group sends use the stored group JID instead of person-number resolution
+- [ ] Plugin tests cover group sync and group send behavior
+- [ ] Documentation / KB updates completed or explicitly marked not needed
+- [ ] Changes committed to `plan/baileys-groups-directory/task-01-plugin-core` branch
+- [ ] Status updated in `status.md`
+
+## Conflict Avoidance Notes
+
+- `task-02-directory-sync-api` will consume the normalized sync payload created here. Keep that payload shape explicit and stable to avoid controller/use-case churn.
+- Do not modify Licensee controller/routes in this task. If a small API hook feels necessary, document it in the task branch notes and leave implementation to task 2.

--- a/.plans/baileys-groups-directory/task-01-plugin-core/task.md
+++ b/.plans/baileys-groups-directory/task-01-plugin-core/task.md
@@ -9,13 +9,13 @@
 
 ## Objective
 
-Extend the Baileys messenger plugin so it can fetch group data, plus any directly available contact directory metadata, from a connected WhatsApp account without reading chat history, and send outbound messages directly to imported group JIDs.
+Extend the Baileys messenger plugin so it can fetch group membership data from a connected WhatsApp account without reading chat history, and send outbound messages directly to imported group JIDs.
 
 ## Context
 
 The repo already has a working Baileys session flow for QR pairing, status checks, inbound message parsing, and person-to-person sends. The missing capability is a reusable authenticated socket path that can serve three needs without duplicating connection logic:
 
-- directory sync primitives for groups and contacts
+- directory sync primitives for groups
 - type-aware outbound sends for `@g.us` contacts
 - shared session handling that still preserves the current QR/status behavior
 
@@ -30,7 +30,7 @@ Relevant files and docs:
 Important implementation constraint:
 - groups are directly supported by Baileys via `groupFetchAllParticipating()` and `sendMessage(groupJid, ...)`
 - this task must not enable or consume chat/message history as a source of contacts
-- contact import is less direct and appears to rely on contact/store events (`contacts.upsert`, `contacts.update`, bound store state) rather than a documented fetch-all directory endpoint
+- contact import is not a requirement for this plan; if the code happens to expose contact metadata directly, treat that as a non-blocking note rather than a deliverable
 
 ## Before You Start
 
@@ -71,18 +71,14 @@ Refactor the current `Baileys.js` connection bootstrap so QR generation, outboun
 
 Implement a plugin method that returns a normalized sync payload for:
 - groups from `groupFetchAllParticipating()`
-- contacts collected only from directly available contact/store metadata within a bounded wait window, without reading or importing chat/message history
 
 Define a stable internal result shape for task 2 to consume, for example:
 
 ```json
 {
-  "contacts": [{ "waId": "5511999999999", "name": "Jane", "number": "5511999999999", "type": "@c.us" }],
   "groups": [{ "waId": "1203630...@g.us", "name": "Sales Team", "number": "1203630...-...", "type": "@g.us" }]
 }
 ```
-
-If Baileys cannot expose a usable contacts list under the no-history constraint, return an empty `contacts` collection and a machine-readable limitation that task 2/task 4 can surface and document.
 
 ### Step 3: Make outbound sends group-aware
 
@@ -102,7 +98,7 @@ Update `sendMessage()` so:
 ## Documentation / KB Updates
 
 - [ ] No planned KB/doc updates in this task; `task-04-docs-and-verification` owns the user-facing docs
-- [ ] If the implementation requires a non-obvious Baileys contact/store workaround, run `document-solution`
+- [ ] If the implementation requires a non-obvious Baileys group metadata workaround, run `document-solution`
 - [ ] If KB files change unexpectedly, run `check-kb-index`
 
 ## Completion Criteria
@@ -110,7 +106,7 @@ Update `sendMessage()` so:
 - [ ] `Baileys.js` exposes a reusable directory-fetch path that task 2 can call
 - [ ] The directory-fetch path does not enable or consume chat/message history
 - [ ] Group sends use the stored group JID instead of person-number resolution
-- [ ] Plugin tests cover group sync and group send behavior
+- [ ] Plugin tests cover group discovery and group send behavior
 - [ ] Documentation / KB updates completed or explicitly marked not needed
 - [ ] Changes committed to `plan/baileys-groups-directory/task-01-plugin-core` branch
 - [ ] Status updated in `status.md`

--- a/.plans/baileys-groups-directory/task-01-plugin-core/task.md
+++ b/.plans/baileys-groups-directory/task-01-plugin-core/task.md
@@ -9,7 +9,7 @@
 
 ## Objective
 
-Extend the Baileys messenger plugin so it can fetch group/contact directory data from a connected WhatsApp account and send outbound messages directly to imported group JIDs.
+Extend the Baileys messenger plugin so it can fetch group data, plus any directly available contact directory metadata, from a connected WhatsApp account without reading chat history, and send outbound messages directly to imported group JIDs.
 
 ## Context
 
@@ -24,13 +24,13 @@ Relevant files and docs:
 - [docs/kb/architecture/project-overview.md](../../../docs/kb/architecture/project-overview.md)
 - `src/app/plugins/messengers/Baileys.js`
 - `src/app/plugins/messengers/Baileys.spec.js`
-- Baileys History Sync docs: `https://baileys.wiki/docs/socket/history-sync/`
 - Baileys Receiving Updates docs: `https://baileys.wiki/docs/socket/receiving-updates/`
 - Baileys API docs for `groupFetchAllParticipating()`: `https://baileys.wiki/docs/api/functions/makeWASocket/`
 
 Important implementation constraint:
 - groups are directly supported by Baileys via `groupFetchAllParticipating()` and `sendMessage(groupJid, ...)`
-- contact import is less direct and must rely on history/contact events (`messaging-history.set`, `contacts.upsert`, `contacts.update`) or store binding
+- this task must not enable or consume chat/message history as a source of contacts
+- contact import is less direct and appears to rely on contact/store events (`contacts.upsert`, `contacts.update`, bound store state) rather than a documented fetch-all directory endpoint
 
 ## Before You Start
 
@@ -71,7 +71,7 @@ Refactor the current `Baileys.js` connection bootstrap so QR generation, outboun
 
 Implement a plugin method that returns a normalized sync payload for:
 - groups from `groupFetchAllParticipating()`
-- contacts collected from `messaging-history.set` and/or contact update events within a bounded wait window
+- contacts collected only from directly available contact/store metadata within a bounded wait window, without reading or importing chat/message history
 
 Define a stable internal result shape for task 2 to consume, for example:
 
@@ -81,6 +81,8 @@ Define a stable internal result shape for task 2 to consume, for example:
   "groups": [{ "waId": "1203630...@g.us", "name": "Sales Team", "number": "1203630...-...", "type": "@g.us" }]
 }
 ```
+
+If Baileys cannot expose a usable contacts list under the no-history constraint, return an empty `contacts` collection and a machine-readable limitation that task 2/task 4 can surface and document.
 
 ### Step 3: Make outbound sends group-aware
 
@@ -100,12 +102,13 @@ Update `sendMessage()` so:
 ## Documentation / KB Updates
 
 - [ ] No planned KB/doc updates in this task; `task-04-docs-and-verification` owns the user-facing docs
-- [ ] If the implementation requires a non-obvious Baileys history-sync workaround, run `document-solution`
+- [ ] If the implementation requires a non-obvious Baileys contact/store workaround, run `document-solution`
 - [ ] If KB files change unexpectedly, run `check-kb-index`
 
 ## Completion Criteria
 
 - [ ] `Baileys.js` exposes a reusable directory-fetch path that task 2 can call
+- [ ] The directory-fetch path does not enable or consume chat/message history
 - [ ] Group sends use the stored group JID instead of person-number resolution
 - [ ] Plugin tests cover group sync and group send behavior
 - [ ] Documentation / KB updates completed or explicitly marked not needed

--- a/.plans/baileys-groups-directory/task-02-directory-sync-api/status.md
+++ b/.plans/baileys-groups-directory/task-02-directory-sync-api/status.md
@@ -1,4 +1,4 @@
-# Status: Directory Sync API
+# Status: Contact Group Field, Filters, and Sync API
 
 **Current Status**: not-started
 **Last Updated**: 2026-05-16

--- a/.plans/baileys-groups-directory/task-02-directory-sync-api/status.md
+++ b/.plans/baileys-groups-directory/task-02-directory-sync-api/status.md
@@ -1,0 +1,25 @@
+# Status: Directory Sync API
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-16
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-16 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/baileys-groups-directory/task-02-directory-sync-api/task.md
+++ b/.plans/baileys-groups-directory/task-02-directory-sync-api/task.md
@@ -9,11 +9,15 @@
 
 ## Objective
 
-Add an authenticated admin endpoint that triggers Baileys directory sync, imports contacts/groups into existing `Contact` records, and returns a deterministic sync summary to the client.
+Add an authenticated admin endpoint that triggers Baileys directory sync, imports groups and any no-history contact directory metadata into existing `Contact` records, and returns a deterministic sync summary to the client.
 
 ## Context
 
 The repo already stores WhatsApp-facing identities in `Contact` records with `number`, `type`, `waId`, and `licensee`. That makes the import path lighter than creating a new `WhatsappContact` model.
+
+Hard scope constraint:
+- this sync must not read, import, or persist chat/message history
+- groups must be imported as `Contact` records so they can be direct message destinations
 
 Relevant files and docs:
 - [docs/kb/features/baileys-whatsapp-guide.md](../../../docs/kb/features/baileys-whatsapp-guide.md)
@@ -85,7 +89,7 @@ Add a dedicated use case that:
 - loads the licensee
 - verifies `whatsappDefault === 'baileys'`
 - calls the plugin directory-sync method from task 1
-- transforms returned contacts/groups into `Contact` payloads
+- transforms returned groups, and any available no-history contacts, into `Contact` payloads
 
 ### Step 2: Make imports idempotent
 
@@ -94,6 +98,10 @@ Import/update records with this priority:
 2. fallback to `licensee + number + type`
 
 Only mutate WhatsApp-identity fields that task 1 owns confidently (`name`, `number`, `type`, `waId`, `talkingWithChatBot`, `licensee`). Preserve unrelated user-maintained fields such as address/payment metadata.
+
+Treat groups as first-class import targets:
+- every imported group must become or update a `Contact` record with `type: '@g.us'`
+- individual contacts may be imported only when Baileys exposes them without requiring history reads
 
 ### Step 3: Expose the resource endpoint
 
@@ -117,7 +125,8 @@ Wire the use case through `LicenseesController` and `resources-routes.js`, keepi
 ## Completion Criteria
 
 - [ ] An authenticated admin endpoint can trigger Baileys sync for a licensee
-- [ ] Contacts and groups are imported idempotently into `Contact` records
+- [ ] Groups are imported idempotently into `Contact` records and can be used as direct message destinations
+- [ ] Contacts are imported only from no-history directory metadata exposed by Baileys
 - [ ] The endpoint returns stable sync counts suitable for the UI
 - [ ] Automated tests cover use case, controller, and route behavior
 - [ ] Documentation / KB updates completed or explicitly marked not needed

--- a/.plans/baileys-groups-directory/task-02-directory-sync-api/task.md
+++ b/.plans/baileys-groups-directory/task-02-directory-sync-api/task.md
@@ -1,0 +1,130 @@
+# Task: Directory Sync API
+
+**Plan**: Baileys Group Messaging & Directory Sync
+**Phase**: 2
+**Task ID (phase-local)**: task-02
+**Task Path**: task-02-directory-sync-api
+**Depends On**: task-01-plugin-core
+**JIRA**: N/A
+
+## Objective
+
+Add an authenticated admin endpoint that triggers Baileys directory sync, imports contacts/groups into existing `Contact` records, and returns a deterministic sync summary to the client.
+
+## Context
+
+The repo already stores WhatsApp-facing identities in `Contact` records with `number`, `type`, `waId`, and `licensee`. That makes the import path lighter than creating a new `WhatsappContact` model.
+
+Relevant files and docs:
+- [docs/kb/features/baileys-whatsapp-guide.md](../../../docs/kb/features/baileys-whatsapp-guide.md)
+- [docs/kb/architecture/project-overview.md](../../../docs/kb/architecture/project-overview.md)
+- `src/app/controllers/LicenseesController.js`
+- `src/app/controllers/LicenseesController.spec.js`
+- `src/app/routes/resources-routes.js`
+- `src/app/routes/resources-routes.spec.js`
+- `src/app/models/Contact.js`
+- `src/app/repositories/contact.js`
+- `src/app/queries/ContactsQuery.js`
+- `src/app/usecases/licensees/GetBaileysQr.js`
+- `src/app/usecases/licensees/GetBaileysStatus.js`
+
+Recommended endpoint shape:
+- `POST /resources/licensees/:id/baileys-sync`
+
+Recommended response shape:
+
+```json
+{
+  "importedContacts": 0,
+  "updatedContacts": 0,
+  "importedGroups": 0,
+  "updatedGroups": 0,
+  "skipped": 0
+}
+```
+
+## Before You Start
+
+- [ ] Switch to the planning/base branch and pull the latest plan state: `git switch main && git pull --rebase origin main`
+- [ ] Verify every prerequisite task in `Depends On` is complete
+- [ ] Check this task's `status.md` — if already `in-progress` or `complete`, stop and investigate
+- [ ] Read referenced architecture docs:
+  - `docs/kb/features/baileys-whatsapp-guide.md`
+  - `docs/kb/architecture/project-overview.md`
+- [ ] Re-read the normalized payload contract produced by `task-01-plugin-core`
+- [ ] Mark this task `in-progress` in `status.md` before proceeding
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/app/usecases/licensees/SyncBaileysDirectory.js` | create | Main orchestration/use case |
+| `src/app/usecases/licensees/SyncBaileysDirectory.spec.js` | create | Unit coverage for import summary and matching logic |
+| `src/app/controllers/LicenseesController.js` | modify | Add controller action and wire new use case |
+| `src/app/controllers/LicenseesController.spec.js` | modify | Cover delegation/error handling for sync |
+| `src/app/routes/resources-routes.js` | modify | Register the new authenticated route |
+| `src/app/routes/resources-routes.spec.js` | modify | Cover route wiring/auth expectations |
+| `src/app/repositories/contact.js` | modify | Optional helper extraction if idempotent matching/upsert becomes repetitive |
+| `src/app/repositories/contact.spec.js` | modify | Only if repository behavior changes |
+
+### Do NOT Modify
+
+- `src/app/plugins/messengers/Baileys.js` — owned by `task-01-plugin-core`
+- `src/app/plugins/messengers/Baileys.spec.js` — owned by `task-01-plugin-core`
+- `client/src/services/licensee.js` — owned by `task-03-admin-sync-surface`
+- `client/src/pages/Licensees/scenes/Form/panels/WhatsAppPanel.js` — owned by `task-03-admin-sync-surface`
+- `client/src/pages/Contacts/scenes/Index/index.js` — owned by `task-03-admin-sync-surface`
+- `docs/kb/features/baileys-whatsapp-guide.md` — owned by `task-04-docs-and-verification`
+- `API_DOCUMENTATION.md` — owned by `task-04-docs-and-verification`
+
+## Implementation Steps
+
+### Step 1: Create the sync use case
+
+Add a dedicated use case that:
+- loads the licensee
+- verifies `whatsappDefault === 'baileys'`
+- calls the plugin directory-sync method from task 1
+- transforms returned contacts/groups into `Contact` payloads
+
+### Step 2: Make imports idempotent
+
+Import/update records with this priority:
+1. match on `licensee + waId`
+2. fallback to `licensee + number + type`
+
+Only mutate WhatsApp-identity fields that task 1 owns confidently (`name`, `number`, `type`, `waId`, `talkingWithChatBot`, `licensee`). Preserve unrelated user-maintained fields such as address/payment metadata.
+
+### Step 3: Expose the resource endpoint
+
+Wire the use case through `LicenseesController` and `resources-routes.js`, keeping the same auth pattern as existing `/baileys-status` and `/baileys-qr` routes.
+
+## Testing
+
+- [ ] `npx jest src/app/usecases/licensees/SyncBaileysDirectory.spec.js`
+- [ ] `npx jest src/app/controllers/LicenseesController.spec.js`
+- [ ] `npx jest src/app/routes/resources-routes.spec.js`
+- [ ] `npx jest src/app/repositories/contact.spec.js` if repository helpers change
+- [ ] Existing tests still pass
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] No planned KB/doc updates in this task; `task-04-docs-and-verification` owns the final API/KB write-up
+- [ ] If the import semantics differ materially from the task assumptions, document the adaptation in `status.md`
+- [ ] If KB files change unexpectedly, run `check-kb-index`
+
+## Completion Criteria
+
+- [ ] An authenticated admin endpoint can trigger Baileys sync for a licensee
+- [ ] Contacts and groups are imported idempotently into `Contact` records
+- [ ] The endpoint returns stable sync counts suitable for the UI
+- [ ] Automated tests cover use case, controller, and route behavior
+- [ ] Documentation / KB updates completed or explicitly marked not needed
+- [ ] Changes committed to `plan/baileys-groups-directory/task-02-directory-sync-api` branch
+- [ ] Status updated in `status.md`
+
+## Conflict Avoidance Notes
+
+- `task-03-admin-sync-surface` will consume the response shape defined here. Do not rename response keys casually once the client work starts.
+- If the sync path needs additional client-facing fields, add them additively rather than replacing the summary keys above.

--- a/.plans/baileys-groups-directory/task-02-directory-sync-api/task.md
+++ b/.plans/baileys-groups-directory/task-02-directory-sync-api/task.md
@@ -9,7 +9,7 @@
 
 ## Objective
 
-Add an authenticated admin endpoint that triggers Baileys directory sync, imports groups and any no-history contact directory metadata into existing `Contact` records, and returns a deterministic sync summary to the client.
+Add an authenticated admin endpoint that triggers Baileys group sync, imports those groups into existing `Contact` records, and returns a deterministic sync summary to the client.
 
 ## Context
 
@@ -18,6 +18,7 @@ The repo already stores WhatsApp-facing identities in `Contact` records with `nu
 Hard scope constraint:
 - this sync must not read, import, or persist chat/message history
 - groups must be imported as `Contact` records so they can be direct message destinations
+- contact discovery is optional and not required for this task
 
 Relevant files and docs:
 - [docs/kb/features/baileys-whatsapp-guide.md](../../../docs/kb/features/baileys-whatsapp-guide.md)
@@ -89,7 +90,7 @@ Add a dedicated use case that:
 - loads the licensee
 - verifies `whatsappDefault === 'baileys'`
 - calls the plugin directory-sync method from task 1
-- transforms returned groups, and any available no-history contacts, into `Contact` payloads
+- transforms returned groups into `Contact` payloads
 
 ### Step 2: Make imports idempotent
 
@@ -101,7 +102,6 @@ Only mutate WhatsApp-identity fields that task 1 owns confidently (`name`, `numb
 
 Treat groups as first-class import targets:
 - every imported group must become or update a `Contact` record with `type: '@g.us'`
-- individual contacts may be imported only when Baileys exposes them without requiring history reads
 
 ### Step 3: Expose the resource endpoint
 
@@ -126,7 +126,6 @@ Wire the use case through `LicenseesController` and `resources-routes.js`, keepi
 
 - [ ] An authenticated admin endpoint can trigger Baileys sync for a licensee
 - [ ] Groups are imported idempotently into `Contact` records and can be used as direct message destinations
-- [ ] Contacts are imported only from no-history directory metadata exposed by Baileys
 - [ ] The endpoint returns stable sync counts suitable for the UI
 - [ ] Automated tests cover use case, controller, and route behavior
 - [ ] Documentation / KB updates completed or explicitly marked not needed

--- a/.plans/baileys-groups-directory/task-02-directory-sync-api/task.md
+++ b/.plans/baileys-groups-directory/task-02-directory-sync-api/task.md
@@ -1,4 +1,4 @@
-# Task: Directory Sync API
+# Task: Contact Group Field, Filters, and Sync API
 
 **Plan**: Baileys Group Messaging & Directory Sync
 **Phase**: 2
@@ -9,7 +9,7 @@
 
 ## Objective
 
-Add an authenticated admin endpoint that triggers Baileys group sync, imports those groups into existing `Contact` records, and returns a deterministic sync summary to the client.
+Add the explicit contact group field, extend the contacts index endpoint with `updatedAt` and group-only filters, and expose an authenticated admin endpoint that syncs Baileys groups into `Contact` records.
 
 ## Context
 
@@ -20,21 +20,33 @@ Hard scope constraint:
 - groups must be imported as `Contact` records so they can be direct message destinations
 - contact discovery is optional and not required for this task
 
+Additional requirement from the user:
+- add an explicit field on `Contact` to persist whether the record is a group
+- improve the contacts index endpoint so callers can filter by `updatedAt` and retrieve only group contacts
+
 Relevant files and docs:
 - [docs/kb/features/baileys-whatsapp-guide.md](../../../docs/kb/features/baileys-whatsapp-guide.md)
 - [docs/kb/architecture/project-overview.md](../../../docs/kb/architecture/project-overview.md)
 - `src/app/controllers/LicenseesController.js`
 - `src/app/controllers/LicenseesController.spec.js`
+- `src/app/controllers/ContactsController.js`
+- `src/app/controllers/ContactsController.spec.js`
 - `src/app/routes/resources-routes.js`
 - `src/app/routes/resources-routes.spec.js`
 - `src/app/models/Contact.js`
 - `src/app/repositories/contact.js`
 - `src/app/queries/ContactsQuery.js`
+- `src/app/queries/ContactsQuery.spec.js`
 - `src/app/usecases/licensees/GetBaileysQr.js`
 - `src/app/usecases/licensees/GetBaileysStatus.js`
 
 Recommended endpoint shape:
 - `POST /resources/licensees/:id/baileys-sync`
+
+Recommended contacts index params:
+- `isGroup=true|false`
+- `updatedAtStart=<ISO date>`
+- `updatedAtEnd=<ISO date>`
 
 Recommended response shape:
 
@@ -67,6 +79,11 @@ Recommended response shape:
 | `src/app/usecases/licensees/SyncBaileysDirectory.spec.js` | create | Unit coverage for import summary and matching logic |
 | `src/app/controllers/LicenseesController.js` | modify | Add controller action and wire new use case |
 | `src/app/controllers/LicenseesController.spec.js` | modify | Cover delegation/error handling for sync |
+| `src/app/models/Contact.js` | modify | Add explicit persisted group field |
+| `src/app/controllers/ContactsController.js` | modify | Accept and forward group/date filters in index |
+| `src/app/controllers/ContactsController.spec.js` | modify | Cover new index filter delegation |
+| `src/app/queries/ContactsQuery.js` | modify | Add `isGroup` and `updatedAt` filter support |
+| `src/app/queries/ContactsQuery.spec.js` | modify | Cover new query behavior |
 | `src/app/routes/resources-routes.js` | modify | Register the new authenticated route |
 | `src/app/routes/resources-routes.spec.js` | modify | Cover route wiring/auth expectations |
 | `src/app/repositories/contact.js` | modify | Optional helper extraction if idempotent matching/upsert becomes repetitive |
@@ -92,18 +109,27 @@ Add a dedicated use case that:
 - calls the plugin directory-sync method from task 1
 - transforms returned groups into `Contact` payloads
 
-### Step 2: Make imports idempotent
+### Step 2: Add the contact group marker and contacts index filters
+
+Add a persisted boolean field such as `isGroup` on `Contact`, and make sure group sync writes it consistently for `@g.us` records.
+
+Extend contacts index filtering so the API can:
+- return only group contacts
+- filter by `updatedAt` date range using the repo's existing query-builder style
+
+### Step 3: Make imports idempotent
 
 Import/update records with this priority:
 1. match on `licensee + waId`
 2. fallback to `licensee + number + type`
 
-Only mutate WhatsApp-identity fields that task 1 owns confidently (`name`, `number`, `type`, `waId`, `talkingWithChatBot`, `licensee`). Preserve unrelated user-maintained fields such as address/payment metadata.
+Only mutate WhatsApp-identity fields that task 1 owns confidently (`name`, `number`, `type`, `waId`, `talkingWithChatBot`, `licensee`, `isGroup`). Preserve unrelated user-maintained fields such as address/payment metadata.
 
 Treat groups as first-class import targets:
 - every imported group must become or update a `Contact` record with `type: '@g.us'`
+- every imported group must persist the explicit group marker field
 
-### Step 3: Expose the resource endpoint
+### Step 4: Expose the resource endpoint
 
 Wire the use case through `LicenseesController` and `resources-routes.js`, keeping the same auth pattern as existing `/baileys-status` and `/baileys-qr` routes.
 
@@ -111,6 +137,8 @@ Wire the use case through `LicenseesController` and `resources-routes.js`, keepi
 
 - [ ] `npx jest src/app/usecases/licensees/SyncBaileysDirectory.spec.js`
 - [ ] `npx jest src/app/controllers/LicenseesController.spec.js`
+- [ ] `npx jest src/app/controllers/ContactsController.spec.js`
+- [ ] `npx jest src/app/queries/ContactsQuery.spec.js`
 - [ ] `npx jest src/app/routes/resources-routes.spec.js`
 - [ ] `npx jest src/app/repositories/contact.spec.js` if repository helpers change
 - [ ] Existing tests still pass
@@ -125,6 +153,8 @@ Wire the use case through `LicenseesController` and `resources-routes.js`, keepi
 ## Completion Criteria
 
 - [ ] An authenticated admin endpoint can trigger Baileys sync for a licensee
+- [ ] `Contact` has an explicit persisted group field and group sync populates it
+- [ ] The contacts index endpoint supports `updatedAt` filtering and group-only retrieval
 - [ ] Groups are imported idempotently into `Contact` records and can be used as direct message destinations
 - [ ] The endpoint returns stable sync counts suitable for the UI
 - [ ] Automated tests cover use case, controller, and route behavior
@@ -135,4 +165,5 @@ Wire the use case through `LicenseesController` and `resources-routes.js`, keepi
 ## Conflict Avoidance Notes
 
 - `task-03-admin-sync-surface` will consume the response shape defined here. Do not rename response keys casually once the client work starts.
+- `task-03-admin-sync-surface` should consume the new contacts index filter params instead of reimplementing group filtering purely in the client.
 - If the sync path needs additional client-facing fields, add them additively rather than replacing the summary keys above.

--- a/.plans/baileys-groups-directory/task-03-admin-sync-surface/status.md
+++ b/.plans/baileys-groups-directory/task-03-admin-sync-surface/status.md
@@ -1,0 +1,25 @@
+# Status: Admin Sync Surface
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-16
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-16 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/baileys-groups-directory/task-03-admin-sync-surface/task.md
+++ b/.plans/baileys-groups-directory/task-03-admin-sync-surface/task.md
@@ -28,6 +28,7 @@ Expected UX:
 - after sync, show counts returned by the backend
 - make it easy to filter/read `@g.us` records on the Contacts page
 - do not add new contact-search UI as part of this task
+- prefer the backend `isGroup` filter instead of client-side-only filtering
 
 ## Before You Start
 
@@ -77,6 +78,8 @@ Update `WhatsAppPanel` to:
 Use the existing Contacts page rather than adding a brand-new screen. Add a minimal filter/toggle so admins can switch among:
 - all contacts
 - WhatsApp groups (`@g.us`)
+
+If date filtering is surfaced in the UI during this task, use the backend `updatedAt` filter rather than local client filtering. If the UI does not need that control yet, leave the API support backend-only and document that choice in `status.md`.
 
 ## Testing
 

--- a/.plans/baileys-groups-directory/task-03-admin-sync-surface/task.md
+++ b/.plans/baileys-groups-directory/task-03-admin-sync-surface/task.md
@@ -1,0 +1,107 @@
+# Task: Admin Sync Surface
+
+**Plan**: Baileys Group Messaging & Directory Sync
+**Phase**: 3
+**Task ID (phase-local)**: task-03
+**Task Path**: task-03-admin-sync-surface
+**Depends On**: task-02-directory-sync-api
+**JIRA**: N/A
+
+## Objective
+
+Add admin UI affordances so a Baileys-connected licensee can trigger directory sync, see the result immediately, and inspect imported groups through the existing Contacts view.
+
+## Context
+
+The existing admin surface already supports Baileys QR generation and connection status in the Licensee form. The Contacts page already renders `contact.type`, but it does not yet expose a fast UI filter for distinguishing imported groups from regular contacts.
+
+Relevant files and docs:
+- `client/src/services/licensee.js`
+- `client/src/pages/Licensees/scenes/Form/panels/WhatsAppPanel.js`
+- `client/src/pages/Licensees/scenes/Form/panels/WhatsAppPanel.spec.js`
+- `client/src/pages/Contacts/scenes/Index/index.js`
+- `client/src/pages/Contacts/scenes/Index/index.spec.js`
+- `client/src/services/contact.js`
+
+Expected UX:
+- when Baileys is connected, show a sync action in the WhatsApp panel
+- after sync, show counts returned by the backend
+- make it easy to filter/read `@g.us` records on the Contacts page
+
+## Before You Start
+
+- [ ] Switch to the planning/base branch and pull the latest plan state: `git switch main && git pull --rebase origin main`
+- [ ] Verify every prerequisite task in `Depends On` is complete
+- [ ] Check this task's `status.md` — if already `in-progress` or `complete`, stop and investigate
+- [ ] Read referenced architecture docs:
+  - `docs/kb/features/baileys-whatsapp-guide.md`
+  - `docs/kb/architecture/project-overview.md`
+- [ ] Review the response contract from `task-02-directory-sync-api`
+- [ ] Mark this task `in-progress` in `status.md` before proceeding
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `client/src/services/licensee.js` | modify | Add client helper for the new sync endpoint |
+| `client/src/pages/Licensees/scenes/Form/panels/WhatsAppPanel.js` | modify | Add sync action/result state to the Baileys admin panel |
+| `client/src/pages/Licensees/scenes/Form/panels/WhatsAppPanel.spec.js` | modify | Cover sync action and result rendering |
+| `client/src/pages/Contacts/scenes/Index/index.js` | modify | Add easy contact/group filtering or another minimal read affordance |
+| `client/src/pages/Contacts/scenes/Index/index.spec.js` | modify | Cover the new filter/read behavior |
+
+### Do NOT Modify
+
+- `src/app/plugins/messengers/Baileys.js` — owned by `task-01-plugin-core`
+- `src/app/usecases/licensees/SyncBaileysDirectory.js` — owned by `task-02-directory-sync-api`
+- `src/app/controllers/LicenseesController.js` — owned by `task-02-directory-sync-api`
+- `src/app/routes/resources-routes.js` — owned by `task-02-directory-sync-api`
+- `docs/kb/features/baileys-whatsapp-guide.md` — owned by `task-04-docs-and-verification`
+- `API_DOCUMENTATION.md` — owned by `task-04-docs-and-verification`
+
+## Implementation Steps
+
+### Step 1: Add the client service call
+
+Extend `client/src/services/licensee.js` with a method for `POST /resources/licensees/:id/baileys-sync`.
+
+### Step 2: Surface sync in the WhatsApp panel
+
+Update `WhatsAppPanel` to:
+- show the sync action only when Baileys is connected and the licensee is persisted
+- render loading, success, and failure states cleanly
+- display the returned counts in a compact, readable way
+
+### Step 3: Make imported groups easy to inspect
+
+Use the existing Contacts page rather than adding a brand-new screen. Add a minimal filter/toggle so admins can switch among:
+- all contacts
+- WhatsApp contacts (`@c.us`)
+- WhatsApp groups (`@g.us`)
+
+## Testing
+
+- [ ] `npx jest client/src/pages/Licensees/scenes/Form/panels/WhatsAppPanel.spec.js`
+- [ ] `npx jest client/src/pages/Contacts/scenes/Index/index.spec.js`
+- [ ] Existing tests still pass
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] No planned KB/doc updates in this task; `task-04-docs-and-verification` owns the final guide/API changes
+- [ ] If the shipped UX diverges from this task, capture the reasoning in `status.md`
+- [ ] If KB files change unexpectedly, run `check-kb-index`
+
+## Completion Criteria
+
+- [ ] Admins can trigger Baileys sync from the Licensee WhatsApp panel
+- [ ] Sync success/failure/result counts are visible in the UI
+- [ ] Contacts UI can clearly surface imported groups
+- [ ] Automated tests cover the new panel/filter behavior
+- [ ] Documentation / KB updates completed or explicitly marked not needed
+- [ ] Changes committed to `plan/baileys-groups-directory/task-03-admin-sync-surface` branch
+- [ ] Status updated in `status.md`
+
+## Conflict Avoidance Notes
+
+- Keep the client dependent on the summary payload from task 2 only. Do not re-encode backend transformation rules in the UI.
+- Prefer additive UI changes in existing screens over creating a new standalone Baileys directory page.

--- a/.plans/baileys-groups-directory/task-03-admin-sync-surface/task.md
+++ b/.plans/baileys-groups-directory/task-03-admin-sync-surface/task.md
@@ -9,7 +9,7 @@
 
 ## Objective
 
-Add admin UI affordances so a Baileys-connected licensee can trigger directory sync, see the result immediately, and inspect imported groups through the existing Contacts view.
+Add admin UI affordances so a Baileys-connected licensee can trigger group sync, see the result immediately, and inspect imported groups through the existing Contacts view.
 
 ## Context
 
@@ -27,6 +27,7 @@ Expected UX:
 - when Baileys is connected, show a sync action in the WhatsApp panel
 - after sync, show counts returned by the backend
 - make it easy to filter/read `@g.us` records on the Contacts page
+- do not add new contact-search UI as part of this task
 
 ## Before You Start
 
@@ -75,7 +76,6 @@ Update `WhatsAppPanel` to:
 
 Use the existing Contacts page rather than adding a brand-new screen. Add a minimal filter/toggle so admins can switch among:
 - all contacts
-- WhatsApp contacts (`@c.us`)
 - WhatsApp groups (`@g.us`)
 
 ## Testing

--- a/.plans/baileys-groups-directory/task-04-docs-and-verification/status.md
+++ b/.plans/baileys-groups-directory/task-04-docs-and-verification/status.md
@@ -1,0 +1,25 @@
+# Status: Docs and Live Verification
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-16
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-16 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/baileys-groups-directory/task-04-docs-and-verification/task.md
+++ b/.plans/baileys-groups-directory/task-04-docs-and-verification/task.md
@@ -16,6 +16,7 @@ Update the Baileys documentation for the new sync/group-send flow and capture th
 This repo already has a Baileys KB guide, and it currently documents QR pairing and the existing send/receive flow. After tasks 1-3 land, the guide and API docs will be stale unless they cover:
 
 - the new sync endpoint
+- the new `Contact` group field and contacts index filters
 - how imported groups appear in the existing Contacts model/UI
 - how group sends work through the existing message-creation flow
 - the explicit no-history constraint for this feature
@@ -58,6 +59,8 @@ Relevant files and docs:
 Extend `docs/kb/features/baileys-whatsapp-guide.md` with:
 - how to trigger the new sync
 - what gets imported into `Contact`
+- how the explicit group field is populated
+- how to query only group contacts and filter by `updatedAt`
 - how to inspect groups afterward
 - how to send to an imported group through the existing message flow
 - the known limitation/caveat that this feature does not depend on contact discovery
@@ -72,6 +75,8 @@ Validate with a real linked Baileys session:
 - QR/status still work
 - sync returns counts
 - imported `@g.us` groups appear in the Contacts screen
+- contacts index API can return only group contacts
+- contacts index API can filter contacts by `updatedAt`
 - a text message can be sent to an imported group
 - no chat/message history is read or persisted by the sync implementation
 

--- a/.plans/baileys-groups-directory/task-04-docs-and-verification/task.md
+++ b/.plans/baileys-groups-directory/task-04-docs-and-verification/task.md
@@ -18,7 +18,8 @@ This repo already has a Baileys KB guide, and it currently documents QR pairing 
 - the new sync endpoint
 - how imported groups appear in the existing Contacts model/UI
 - how group sends work through the existing message-creation flow
-- the caveat that Baileys contact data comes from history/contact events rather than a single documented fetch-all method
+- the explicit no-history constraint for this feature
+- the caveat that Baileys contact data does not appear to come from a single documented fetch-all method
 
 Relevant files and docs:
 - [docs/kb/features/baileys-whatsapp-guide.md](../../../docs/kb/features/baileys-whatsapp-guide.md)
@@ -59,7 +60,7 @@ Extend `docs/kb/features/baileys-whatsapp-guide.md` with:
 - what gets imported into `Contact`
 - how to inspect groups/contacts afterward
 - how to send to an imported group through the existing message flow
-- the known limitation/caveat around contact completeness
+- the known limitation/caveat around contact completeness under the no-history constraint
 
 ### Step 2: Update API documentation
 
@@ -72,6 +73,7 @@ Validate with a real linked Baileys session:
 - sync returns counts
 - imported `@c.us` and `@g.us` contacts appear in the Contacts screen
 - a text message can be sent to an imported group
+- no chat/message history is read or persisted by the sync implementation
 
 Capture any caveats directly in the KB doc instead of leaving them only in chat or commit history.
 

--- a/.plans/baileys-groups-directory/task-04-docs-and-verification/task.md
+++ b/.plans/baileys-groups-directory/task-04-docs-and-verification/task.md
@@ -1,0 +1,102 @@
+# Task: Docs and Live Verification
+
+**Plan**: Baileys Group Messaging & Directory Sync
+**Phase**: 4
+**Task ID (phase-local)**: task-04
+**Task Path**: task-04-docs-and-verification
+**Depends On**: [task-02-directory-sync-api, task-03-admin-sync-surface]
+**JIRA**: N/A
+
+## Objective
+
+Update the Baileys documentation for the new sync/group-send flow and capture the live verification matrix needed because contact sync depends on a real linked WhatsApp account.
+
+## Context
+
+This repo already has a Baileys KB guide, and it currently documents QR pairing and the existing send/receive flow. After tasks 1-3 land, the guide and API docs will be stale unless they cover:
+
+- the new sync endpoint
+- how imported groups appear in the existing Contacts model/UI
+- how group sends work through the existing message-creation flow
+- the caveat that Baileys contact data comes from history/contact events rather than a single documented fetch-all method
+
+Relevant files and docs:
+- [docs/kb/features/baileys-whatsapp-guide.md](../../../docs/kb/features/baileys-whatsapp-guide.md)
+- [docs/kb/README.md](../../../docs/kb/README.md)
+- `API_DOCUMENTATION.md`
+
+## Before You Start
+
+- [ ] Switch to the planning/base branch and pull the latest plan state: `git switch main && git pull --rebase origin main`
+- [ ] Verify every prerequisite task in `Depends On` is complete
+- [ ] Check this task's `status.md` — if already `in-progress` or `complete`, stop and investigate
+- [ ] Read referenced architecture docs:
+  - `docs/kb/features/baileys-whatsapp-guide.md`
+  - `docs/kb/architecture/project-overview.md`
+- [ ] Re-read the final endpoint/UX behavior from tasks 2 and 3 before editing docs
+- [ ] Mark this task `in-progress` in `status.md` before proceeding
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `docs/kb/features/baileys-whatsapp-guide.md` | modify | Document sync flow, imported groups, and group send behavior |
+| `API_DOCUMENTATION.md` | modify | Document the new admin sync endpoint and response |
+
+### Do NOT Modify
+
+- `src/app/plugins/messengers/Baileys.js` — owned by `task-01-plugin-core`
+- `src/app/usecases/licensees/SyncBaileysDirectory.js` — owned by `task-02-directory-sync-api`
+- `client/src/pages/Licensees/scenes/Form/panels/WhatsAppPanel.js` — owned by `task-03-admin-sync-surface`
+- `client/src/pages/Contacts/scenes/Index/index.js` — owned by `task-03-admin-sync-surface`
+
+## Implementation Steps
+
+### Step 1: Update the KB guide
+
+Extend `docs/kb/features/baileys-whatsapp-guide.md` with:
+- how to trigger the new sync
+- what gets imported into `Contact`
+- how to inspect groups/contacts afterward
+- how to send to an imported group through the existing message flow
+- the known limitation/caveat around contact completeness
+
+### Step 2: Update API documentation
+
+Document the new admin endpoint, auth requirements, sample response, and expected error cases.
+
+### Step 3: Run the live/manual verification matrix
+
+Validate with a real linked Baileys session:
+- QR/status still work
+- sync returns counts
+- imported `@c.us` and `@g.us` contacts appear in the Contacts screen
+- a text message can be sent to an imported group
+
+Capture any caveats directly in the KB doc instead of leaving them only in chat or commit history.
+
+## Testing
+
+- [ ] Re-run the targeted automated suites from tasks 1-3 or verify they are still green
+- [ ] Manual: complete the live verification matrix above with a linked test WhatsApp account
+- [ ] Existing tests still pass
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] Update existing docs / KB files affected by this task
+- [ ] If the final behavior required a reusable workaround not already captured, run `document-solution`
+- [ ] If KB files change, run `check-kb-index`
+
+## Completion Criteria
+
+- [ ] KB guide documents sync, group inspection, and group send flow
+- [ ] `API_DOCUMENTATION.md` documents the new admin endpoint
+- [ ] Manual verification results are reflected in docs, including any limitations
+- [ ] Documentation / KB updates completed or explicitly marked not needed
+- [ ] Changes committed to `plan/baileys-groups-directory/task-04-docs-and-verification` branch
+- [ ] Status updated in `status.md`
+
+## Conflict Avoidance Notes
+
+- This task should describe the behavior that actually shipped. Do not edit docs speculatively before re-reading the final code from tasks 1-3.

--- a/.plans/baileys-groups-directory/task-04-docs-and-verification/task.md
+++ b/.plans/baileys-groups-directory/task-04-docs-and-verification/task.md
@@ -19,7 +19,7 @@ This repo already has a Baileys KB guide, and it currently documents QR pairing 
 - how imported groups appear in the existing Contacts model/UI
 - how group sends work through the existing message-creation flow
 - the explicit no-history constraint for this feature
-- the caveat that Baileys contact data does not appear to come from a single documented fetch-all method
+- the fact that contact discovery is not required for this feature
 
 Relevant files and docs:
 - [docs/kb/features/baileys-whatsapp-guide.md](../../../docs/kb/features/baileys-whatsapp-guide.md)
@@ -58,9 +58,9 @@ Relevant files and docs:
 Extend `docs/kb/features/baileys-whatsapp-guide.md` with:
 - how to trigger the new sync
 - what gets imported into `Contact`
-- how to inspect groups/contacts afterward
+- how to inspect groups afterward
 - how to send to an imported group through the existing message flow
-- the known limitation/caveat around contact completeness under the no-history constraint
+- the known limitation/caveat that this feature does not depend on contact discovery
 
 ### Step 2: Update API documentation
 
@@ -71,7 +71,7 @@ Document the new admin endpoint, auth requirements, sample response, and expecte
 Validate with a real linked Baileys session:
 - QR/status still work
 - sync returns counts
-- imported `@c.us` and `@g.us` contacts appear in the Contacts screen
+- imported `@g.us` groups appear in the Contacts screen
 - a text message can be sent to an imported group
 - no chat/message history is read or persisted by the sync implementation
 

--- a/docs/kb/ai-patterns/mistake-log.md
+++ b/docs/kb/ai-patterns/mistake-log.md
@@ -83,3 +83,11 @@ not yet represented by the task list.
 **Area**: Create-plan scoping, requirements translation
 **Prevention**: During plan review, scan the overview and early task files for accidental dependencies on prohibited flows such as chat history, background imports, or additional models.
 **Count**: 1
+
+## [2026-05-16] Prefer the primary user outcome over optional directory features in plans
+
+**Wrong**: Kept WhatsApp contact discovery as part of the planned deliverable after the user clarified that the real requirement is only knowing which groups the account belongs to and messaging those groups.
+**Correct**: When the user distinguishes between required and optional capabilities, center the plan on the required outcome and move optional capabilities out of scope or into explicit non-blocking follow-up notes.
+**Area**: Create-plan scoping, requirements prioritization
+**Prevention**: Before finalizing a plan, restate the one indispensable user outcome and remove any secondary capability that is not needed to deliver it.
+**Count**: 1

--- a/docs/kb/ai-patterns/mistake-log.md
+++ b/docs/kb/ai-patterns/mistake-log.md
@@ -1,6 +1,6 @@
 # Mistake Log
 
-**Last Updated**: 2026-04-23
+**Last Updated**: 2026-05-16
 **Context**: Read at session start to avoid repeating known error patterns.
 
 When the AI is corrected, `log-mistake` appends an entry here.
@@ -90,4 +90,12 @@ not yet represented by the task list.
 **Correct**: When the user distinguishes between required and optional capabilities, center the plan on the required outcome and move optional capabilities out of scope or into explicit non-blocking follow-up notes.
 **Area**: Create-plan scoping, requirements prioritization
 **Prevention**: Before finalizing a plan, restate the one indispensable user outcome and remove any secondary capability that is not needed to deliver it.
+**Count**: 1
+
+## [2026-05-16] When the user adds schema or index-filter requirements, reflect them explicitly in the plan
+
+**Wrong**: Narrowed the Baileys plan to group discovery/send but did not immediately add the user-requested `Contact` group field and contacts index filter work to the plan structure.
+**Correct**: When the user adds concrete schema or endpoint requirements, update the plan's scope, key files, task ownership, and success criteria so those technical changes are visible as first-class deliverables.
+**Area**: Create-plan scoping, API/data-model requirements
+**Prevention**: After any plan correction, scan for implied model, query, controller, and spec changes rather than only updating the headline objective.
 **Count**: 1

--- a/docs/kb/ai-patterns/mistake-log.md
+++ b/docs/kb/ai-patterns/mistake-log.md
@@ -75,3 +75,11 @@ not yet represented by the task list.
 **Area**: Validation workflow, ESLint, test-spec migrations
 **Prevention**: When a wave changes many files or rewrites test setup, always rerun the canonical lint command for the affected directories after the final edit pass, even if a narrower pre-commit scan looked clean earlier.
 **Count**: 1
+
+## [2026-05-16] Keep explicit no-history constraints visible in new plans
+
+**Wrong**: Wrote the Baileys group/contact plan in a way that still relied on history-derived contact reads after the user clarified that reading chat history is out of scope.
+**Correct**: When a requirement excludes a data source or workflow, mark that exclusion explicitly in scope, out-of-scope, kill criteria, and task instructions, and treat any history-dependent capability as a validation risk or fallback.
+**Area**: Create-plan scoping, requirements translation
+**Prevention**: During plan review, scan the overview and early task files for accidental dependencies on prohibited flows such as chat history, background imports, or additional models.
+**Count**: 1


### PR DESCRIPTION
## Plan: Baileys Group Messaging & Directory Sync

Extend the existing Baileys plugin so a connected WhatsApp account can sync contacts/groups into Contacts and send outbound messages to group JIDs.

**Type**: Type 1 Product
**Phases**: 4  **Tasks**: 4
**Assigned Dev**: Alan Costa Facchini

> Merge this PR before running `/execute-plan baileys-groups-directory` or any `/execute-task`.