### PR TITLE
plan(baileys-socket-monitor): Persistent Baileys Socket Monitor

### DIFF
--- a/.plans/README.md
+++ b/.plans/README.md
@@ -26,6 +26,7 @@ Git-native Markdown plans for multi-step work.
 | 2 | [Remove PDV](./remove-pdv/overview.md) | `remove-pdv/` | not-started | Delete cart, payment (PagarMe), and order integration (Pedidos10) domain — strip PDV fields from Licensee and Contact |
 | 3 | [Security Hardening](./security-hardening/overview.md) | `security-hardening/` | not-started | Fix 10 security issues from OWASP audit: Helmet, CORS, rate limiting, Bull Board auth, error leakage, JWT fix, RBAC, logging PII, API token header, v1 input validation |
 | 4 | [MongoDB → PostgreSQL](./mongo-to-postgres/overview.md) | `mongo-to-postgres/` | not-started | Migrate all persistent data from MongoDB/Mongoose to PostgreSQL/Prisma using dual-write strategy; prerequisite: remove-pdv complete |
+| 5 | [Baileys Socket Monitor](./baileys-socket-monitor/overview.md) | `baileys-socket-monitor/` | not-started | Replace webhook-only inbound flow with a persistent Baileys socket per licensee; captures messages.upsert and messages.update natively |
 
 ---
 

--- a/.plans/baileys-socket-monitor/overview.md
+++ b/.plans/baileys-socket-monitor/overview.md
@@ -1,0 +1,110 @@
+# Plan: Baileys Socket Monitor
+
+**Status**: not-started
+**Created**: 2026-05-29
+**Last Updated**: 2026-05-29
+**Estimated Demo Date**: 2026-06-13
+**Assigned Dev**: Alan Costa Facchini
+**Assigned QA**: unassigned
+
+## Objective
+
+Replace the external-webhook-only inbound flow with a persistent Baileys WebSocket per licensee that listens to `messages.upsert` (inbound messages) and `messages.update` (delivery receipts), feeding events directly into the existing BullMQ pipeline.
+
+## Scope
+
+### In Scope
+- `BaileysSocketManager` service — per-licensee persistent socket registry with reconnect logic
+- `messages.upsert` → `IngestMessengerMessage` pipeline for inbound messages (`fromMe: false`)
+- `messages.update` → delivery receipt status updates (`sendedAt`, `deliveredAt`, `readAt`)
+- `StartBaileysSocket` use case wiring `IngestMessengerMessage` as the message callback
+- `BootBaileysSocketSessions` use case to start all active Baileys sessions at app boot
+- `server.js` startup hook gated by `ENABLE_BAILEYS_SOCKET=true`
+- `GetBaileysQr.js` integration — trigger persistent socket after successful QR pairing
+- `parseMessageStatus` implementation in `Baileys.js` (currently a stub returning null)
+- Unit tests for all new code
+- KB update to `baileys-whatsapp-guide.md`
+
+### Out of Scope
+- Replacing the existing HTTP webhook endpoint (`POST /v1/messenger/message`) — webhook remains as a fallback and for non-Baileys messengers
+- Routing outbound sends through the persistent socket (existing `sendMessage` ephemeral flow unchanged)
+- Image, audio, video, or sticker message parsing — text only, matching existing `parseMessage` scope
+- Worker process (`worker.js`) — persistent socket runs in the web process only
+- Contact address-book sync — only group and individual message events, no directory import
+- Multi-instance / Redis socket coordination — single-dyno assumption; multi-dyno coordination is out of scope
+
+## Kill Criteria
+
+- If `@whiskeysockets/baileys` v7+ drops the `ev.on('messages.upsert')` API shape, stop and re-evaluate
+- If Heroku memory limits are breached by maintaining N persistent sockets (one per licensee), stop and redesign using a pooled approach
+- If the reconnect loop produces credential churn that invalidates sessions in production, halt and investigate before continuing
+
+## Phases
+
+| Phase | Name | Tasks | Dependencies | Description |
+|-------|------|-------|--------------|-------------|
+| 1 | Core Infrastructure | task-01, task-02 | None | Socket lifecycle service + receipt parsing — parallel, no shared files |
+| 2 | Use Case Wiring | task-03 | Phase 1 | `StartBaileysSocket` use case wiring ingest + receipt callbacks into the socket manager |
+| 3 | Boot & Integration | task-04 | Phase 2 | App startup hook, QR post-pairing trigger, env flag, KB update |
+
+## Task Summary
+
+| Task Path | Title | Phase | Status | Depends On |
+|-----------|-------|-------|--------|------------|
+| phase-1/task-01-socket-manager | BaileysSocketManager service | 1 | not-started | — |
+| phase-1/task-02-receipt-parsing | parseMessageStatus implementation | 1 | not-started | — |
+| phase-2/task-03-start-socket-usecase | StartBaileysSocket use case | 2 | not-started | phase-1/task-01-socket-manager, phase-1/task-02-receipt-parsing |
+| phase-3/task-04-boot-and-qr-integration | App boot wiring + QR integration | 3 | not-started | phase-2/task-03-start-socket-usecase |
+
+## Branch Convention
+
+Pattern: `plan/baileys-socket-monitor/{task-path}`
+
+Example branches:
+- `plan/baileys-socket-monitor/phase-1/task-01-socket-manager`
+- `plan/baileys-socket-monitor/phase-1/task-02-receipt-parsing`
+- `plan/baileys-socket-monitor/phase-2/task-03-start-socket-usecase`
+- `plan/baileys-socket-monitor/phase-3/task-04-boot-and-qr-integration`
+
+Base branch: `main`
+
+## Key Files
+
+| File/Directory | Relevance |
+|----------------|-----------|
+| `src/app/services/BaileysSocketManager.js` | NEW — core persistent socket lifecycle service |
+| `src/app/plugins/messengers/Baileys.js` | Modify `parseMessageStatus` stub; socket manager reuses `buildAuthState` / `saveSession` |
+| `src/app/usecases/licensees/StartBaileysSocket.js` | NEW — use case wiring ingest + receipt callbacks |
+| `src/app/usecases/licensees/BootBaileysSocketSessions.js` | NEW — use case to start all active sessions at boot |
+| `src/app/usecases/webhooks/IngestMessengerMessage.js` | Read-only — inbound handler called from socket manager |
+| `src/app/runtime/dependencies.js` | Add `socketManager`, `startBaileysSocket`, `bootBaileysSocketSessions` |
+| `src/app/usecases/licensees/GetBaileysQr.js` | Trigger persistent socket after successful QR pairing |
+| `server.js` | Boot hook: call `bootBaileysSocketSessions` after DB connect |
+| `docs/kb/features/baileys-whatsapp-guide.md` | Document the persistent socket feature and env flag |
+
+## Risks
+
+- **Reconnect storm** — If all licensees disconnect simultaneously (Heroku restart), they reconnect at once and could spike WhatsApp rate limits. Mitigation: add jittered delay in reconnect backoff.
+- **Credential invalidation during reconnect** — Baileys writes creds on every `creds.update`. If the socket is reconnecting while a send is in progress, concurrent writes could corrupt the session. Mitigation: reuse the same `saveSession` logic (already serialized by Mongoose upsert), and ensure `sendMessage` still creates its own short-lived socket without touching the persistent socket's credentials.
+- **Memory leak on long-running sockets** — If event listeners accumulate across reconnects. Mitigation: call `socket.ev.removeAllListeners()` before closing on reconnect, and the `stop()` method must fully clean up the socket reference.
+- **Test isolation** — Socket manager is a singleton; tests must reset state between runs. Mitigation: export a factory or a `reset()` method for test use.
+
+## Success Criteria
+
+- [ ] A text message sent from a real WhatsApp account to a Baileys-connected licensee appears as a `Message` record in the DB without hitting the HTTP webhook
+- [ ] Delivery receipt (`delivered`) updates `message.deliveredAt` on the corresponding Message record
+- [ ] Read receipt updates `message.readAt`
+- [ ] App boot with `ENABLE_BAILEYS_SOCKET=true` starts persistent sockets for all licensees with active sessions
+- [ ] After a QR scan, the persistent socket starts automatically without requiring an app restart
+- [ ] Existing webhook flow still works (no regression for non-Baileys messengers)
+- [ ] Existing outbound `sendMessage` flow is unaffected
+- [ ] All unit tests pass with `npx jest`
+- [ ] `npx eslint .` produces no new errors
+- [ ] KB doc `baileys-whatsapp-guide.md` updated with persistent socket section
+
+## References
+
+- **JIRA Epic**: N/A
+- **Weekly Plan Brief**: N/A
+- **Related Plans**: [Baileys WhatsApp Plugin](../baileys-plugin/overview.md), [Baileys Group Messaging & Directory Sync](../baileys-groups-directory/overview.md)
+- **Rock Alignment**: N/A

--- a/.plans/baileys-socket-monitor/phase-1/task-01-socket-manager/status.md
+++ b/.plans/baileys-socket-monitor/phase-1/task-01-socket-manager/status.md
@@ -1,0 +1,25 @@
+# Status: BaileysSocketManager service
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-29
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-29 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/baileys-socket-monitor/phase-1/task-01-socket-manager/task.md
+++ b/.plans/baileys-socket-monitor/phase-1/task-01-socket-manager/task.md
@@ -1,0 +1,143 @@
+# Task: BaileysSocketManager service
+
+**Plan**: Baileys Socket Monitor
+**Phase**: 1
+**Task ID (phase-local)**: task-01
+**Task Path**: phase-1/task-01-socket-manager
+**Depends On**: None
+**JIRA**: N/A
+
+## Objective
+
+Create `src/app/services/BaileysSocketManager.js` — a per-licensee persistent Baileys WebSocket registry that opens a socket, keeps it alive with reconnect logic, and fires caller-supplied callbacks for inbound messages and delivery receipt events.
+
+## Context
+
+The current `Baileys.js` plugin opens a socket on-demand and closes it after each operation (send, QR, fetchGroups). There is no long-lived socket, so incoming `messages.upsert` and `messages.update` events are never captured natively.
+
+`BaileysSocketManager` is the low-level service responsible only for socket lifecycle. It does NOT know about the app's message pipeline — it accepts callbacks (`onMessage`, `onReceiptUpdate`) at start time so callers can inject their own routing logic without coupling this service to use cases.
+
+Key patterns to follow from `Baileys.js`:
+- `_openSocket(session, state, rawKeys, BufferJSON)` — socket bootstrap including `creds.update` persistence. Reuse the auth state build pattern.
+- `buildAuthState(session, initAuthCreds, BufferJSON)` — deserialize MongoDB-stored creds/keys back to Buffers.
+- `saveSession(session, creds, keys, BufferJSON)` — persist updated credentials.
+- These methods are on the `Baileys` class (which extends `MessengersBase`). `BaileysSocketManager` is a standalone service — it should accept a `whatsappSessionRepository` and a `Baileys` plugin factory (or the auth helpers directly) rather than extending the plugin class.
+
+Reconnect logic: Baileys fires `connection.update` with `connection === 'close'` and `lastDisconnect.error` containing a `DisconnectReason` code. The standard reconnect approach:
+- `DisconnectReason.loggedOut` (401) — do NOT reconnect; clear credentials, emit a `onLogout` callback.
+- Any other close reason — reconnect after a jittered backoff (start with 2s, cap at 30s).
+
+The socket registry is a `Map<string, { socket, licensee }>` keyed by `licenseeId.toString()`.
+
+Read `docs/kb/architecture/job-queue-system.md` for context on how the job pipeline works (the `onMessage` callback will eventually enqueue a `messenger-message` job).
+
+## Before You Start
+
+- [ ] Switch to main and pull: `git switch main && git pull --rebase origin main`
+- [ ] Create task branch: `git switch -c plan/baileys-socket-monitor/phase-1/task-01-socket-manager`
+- [ ] Verify this task's `status.md` shows `not-started`
+- [ ] Read `src/app/plugins/messengers/Baileys.js` (full file — especially `_openSocket`, `buildAuthState`, `saveSession`, `_waitForConnection`)
+- [ ] Read `docs/kb/architecture/job-queue-system.md`
+- [ ] Mark this task `in-progress` in `status.md`
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/app/services/BaileysSocketManager.js` | create | Core service |
+| `src/app/services/BaileysSocketManager.spec.js` | create | Unit tests |
+
+### Do NOT Modify
+
+- `src/app/plugins/messengers/Baileys.js` — owned by phase-1/task-02-receipt-parsing
+- `src/app/runtime/dependencies.js` — owned by phase-2/task-03-start-socket-usecase
+- `src/app/usecases/licensees/GetBaileysQr.js` — owned by phase-3/task-04-boot-and-qr-integration
+- `server.js` — owned by phase-3/task-04-boot-and-qr-integration
+
+## Implementation Steps
+
+### Step 1: Create `BaileysSocketManager`
+
+```js
+// src/app/services/BaileysSocketManager.js
+class BaileysSocketManager {
+  constructor({ whatsappSessionRepository } = {}) {
+    this._whatsappSessionRepository = whatsappSessionRepository
+    this._sockets = new Map() // licenseeId (string) → { socket, licensee }
+  }
+
+  isConnected(licenseeId) { ... }
+
+  async start(licensee, { onMessage, onReceiptUpdate, onLogout } = {}) { ... }
+
+  stop(licenseeId) { ... }
+
+  _scheduleReconnect(licensee, callbacks, delayMs) { ... }
+}
+```
+
+### Step 2: Implement `start(licensee, callbacks)`
+
+1. Load/create the `WhatsappSession` for this licensee (same as `Baileys.prototype.loadOrCreateSession`).
+2. Import `@whiskeysockets/baileys` dynamically: `initAuthCreds`, `BufferJSON`, `fetchLatestBaileysVersion`, `makeWASocket`, `Browsers`, `DisconnectReason`.
+3. Build auth state via `buildAuthState` logic (inline or via a shared helper — do NOT call into the Baileys plugin class).
+4. Call `makeWASocket({ version, auth: state, printQRInTerminal: false, browser: Browsers.ubuntu('Chrome') })`.
+5. Register `creds.update` → persist session.
+6. Register `connection.update`:
+   - `connection === 'open'` → store socket in `_sockets`, log info.
+   - `connection === 'close'` → remove from `_sockets`; if `DisconnectReason.loggedOut`, clear creds and call `onLogout?.()`, otherwise `_scheduleReconnect`.
+7. Register `messages.upsert`:
+   - Only process `type === 'notify'` events.
+   - For each `msg` where `!msg.key.fromMe`: call `onMessage?.(msg)`.
+8. Register `messages.update`:
+   - For each update: call `onReceiptUpdate?.(update)`.
+
+### Step 3: Implement `stop(licenseeId)`
+
+Call `socket.end()` and delete from `_sockets`. Guard against double-stop (socket may already be closed).
+
+### Step 4: Implement reconnect with jitter
+
+```js
+_scheduleReconnect(licensee, callbacks, delayMs = 2000) {
+  const jitter = Math.random() * 1000
+  const nextDelay = Math.min(delayMs * 2, 30000)
+  setTimeout(() => {
+    this.start(licensee, { ...callbacks, reconnectDelay: nextDelay })
+  }, delayMs + jitter)
+}
+```
+
+Pass `reconnectDelay` through so `start` feeds it back to `_scheduleReconnect` on subsequent failures.
+
+### Step 5: Auth state helpers
+
+Inline the `buildAuthState` and `saveSession` logic from `Baileys.js` (copy, don't import from the plugin class — the service has no plugin dependency). This is a deliberate duplication to keep the service self-contained; if a shared utility is later extracted, that is a separate refactor.
+
+## Testing
+
+- [ ] `start()` — when `messages.upsert` fires with `type: 'notify'` and `fromMe: false`, `onMessage` callback is called with the message
+- [ ] `start()` — when `messages.upsert` fires with `fromMe: true` (self-sent), `onMessage` is NOT called
+- [ ] `start()` — when `messages.update` fires, `onReceiptUpdate` is called
+- [ ] `connection.update` with `connection: 'close'` and non-logout error triggers `_scheduleReconnect`
+- [ ] `connection.update` with `DisconnectReason.loggedOut` clears credentials and calls `onLogout`
+- [ ] `stop()` calls `socket.end()` and removes from registry
+- [ ] `isConnected()` returns `true` only when socket is in registry
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] No KB doc updates required at this task — the persistent socket feature is documented as a whole in phase-3/task-04-boot-and-qr-integration
+
+## Completion Criteria
+
+- [ ] `BaileysSocketManager` created with `start`, `stop`, `isConnected`, reconnect logic
+- [ ] All unit tests pass with `npx jest src/app/services/BaileysSocketManager.spec.js`
+- [ ] `npx eslint src/app/services/` passes
+- [ ] Changes committed to `plan/baileys-socket-monitor/phase-1/task-01-socket-manager` branch
+- [ ] Status updated to `complete` in `status.md`
+
+## Conflict Avoidance Notes
+
+- task-02 (receipt-parsing) modifies `Baileys.js`. This task does not touch that file.
+- Auth state logic is intentionally duplicated here rather than shared to avoid creating a cross-task file dependency in this phase.

--- a/.plans/baileys-socket-monitor/phase-1/task-02-receipt-parsing/status.md
+++ b/.plans/baileys-socket-monitor/phase-1/task-02-receipt-parsing/status.md
@@ -1,0 +1,25 @@
+# Status: parseMessageStatus implementation
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-29
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-29 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/baileys-socket-monitor/phase-1/task-02-receipt-parsing/task.md
+++ b/.plans/baileys-socket-monitor/phase-1/task-02-receipt-parsing/task.md
@@ -1,0 +1,145 @@
+# Task: parseMessageStatus implementation
+
+**Plan**: Baileys Socket Monitor
+**Phase**: 1
+**Task ID (phase-local)**: task-02
+**Task Path**: phase-1/task-02-receipt-parsing
+**Depends On**: None
+**JIRA**: N/A
+
+## Objective
+
+Implement the `parseMessageStatus` stub in `Baileys.js` so that `messages.update` socket events can update `sendedAt`, `deliveredAt`, and `readAt` on existing `Message` records via the existing `Base.js` receipt path.
+
+## Context
+
+`Baileys.js:30-34` has a stub:
+```js
+parseMessageStatus(_body) {
+  // Baileys delivery receipts are not received via HTTP webhook body in the same shape.
+  // For now, no status parsing is needed from incoming HTTP payloads.
+  this.messageStatus = null
+}
+```
+
+`Base.js:74-91` already handles `messageStatus` correctly when it's not null:
+```js
+if (this.messageStatus) {
+  const message = await this.messageRepository.findFirst({ licensee, messageWaId: this.messageStatus.id })
+  if (message) {
+    if (this.messageStatus.status === 'sent') message.sendedAt = new Date()
+    if (this.messageStatus.status === 'delivered') message.deliveredAt = new Date()
+    if (this.messageStatus.status === 'read') message.readAt = new Date()
+    await this.messageRepository.save(message)
+  }
+  return []
+}
+```
+
+The `messages.update` event from Baileys delivers an array of updates with this shape (one entry per update):
+```js
+{
+  key: { id: string, fromMe: boolean, remoteJid: string },
+  update: { status: number }  // Baileys MessageStatus enum
+}
+```
+
+Baileys `MessageStatus` enum values (from `@whiskeysockets/baileys`):
+- `1` → `SERVER_ACK` → map to `'sent'`
+- `2` → `DELIVERY_ACK` → map to `'delivered'`
+- `3` → `READ` → map to `'read'`
+- `4` → `PLAYED` → map to `'read'` (audio played counts as read)
+
+Only `fromMe: true` updates are relevant for receipt tracking (we're tracking our own outbound messages).
+
+The `BaileysSocketManager` (task-01) calls `onReceiptUpdate(update)` for each update in `messages.update`. The `StartBaileysSocket` use case (task-03) will wire this callback to call `messengerPlugin.responseToMessages(update)`, which in turn calls `parseMessageStatus(update)`. This task makes that path work.
+
+The `body` passed to `parseMessageStatus` from the socket manager will be a single update entry (not the full array), shaped as above.
+
+## Before You Start
+
+- [ ] Switch to main and pull: `git switch main && git pull --rebase origin main`
+- [ ] Create task branch: `git switch -c plan/baileys-socket-monitor/phase-1/task-02-receipt-parsing`
+- [ ] Verify this task's `status.md` shows `not-started`
+- [ ] Read `src/app/plugins/messengers/Baileys.js` in full
+- [ ] Read `src/app/plugins/messengers/Base.js:74-91` (receipt handling path)
+- [ ] Read existing `Baileys.spec.js` to understand test patterns
+- [ ] Mark this task `in-progress` in `status.md`
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/app/plugins/messengers/Baileys.js` | modify | Implement `parseMessageStatus` |
+| `src/app/plugins/messengers/Baileys.spec.js` | modify | Add receipt parsing tests |
+
+### Do NOT Modify
+
+- `src/app/services/BaileysSocketManager.js` — owned by phase-1/task-01-socket-manager
+- `src/app/plugins/messengers/Base.js` — shared, read-only
+- `src/app/runtime/dependencies.js` — owned by phase-2/task-03-start-socket-usecase
+
+## Implementation Steps
+
+### Step 1: Replace the `parseMessageStatus` stub in `Baileys.js`
+
+Replace the stub with an implementation that maps the Baileys update shape to the `messageStatus` object expected by `Base.js`:
+
+```js
+parseMessageStatus(body) {
+  if (!body?.key?.id || !body?.key?.fromMe || body.update?.status == null) {
+    this.messageStatus = null
+    return
+  }
+
+  const statusMap = {
+    1: 'sent',       // SERVER_ACK
+    2: 'delivered',  // DELIVERY_ACK
+    3: 'read',       // READ
+    4: 'read',       // PLAYED (audio)
+  }
+
+  const mapped = statusMap[body.update.status]
+  if (!mapped) {
+    this.messageStatus = null
+    return
+  }
+
+  this.messageStatus = {
+    id: body.key.id,
+    status: mapped,
+  }
+}
+```
+
+### Step 2: Remove the stale comment
+
+Remove the comment inside the stub that says "Baileys delivery receipts are not received via HTTP webhook body in the same shape." — that is no longer accurate once the socket delivers them natively.
+
+## Testing
+
+- [ ] `parseMessageStatus` with `status: 1` (SERVER_ACK) sets `messageStatus.status = 'sent'`
+- [ ] `parseMessageStatus` with `status: 2` (DELIVERY_ACK) sets `messageStatus.status = 'delivered'`
+- [ ] `parseMessageStatus` with `status: 3` (READ) sets `messageStatus.status = 'read'`
+- [ ] `parseMessageStatus` with `status: 4` (PLAYED) sets `messageStatus.status = 'read'`
+- [ ] `parseMessageStatus` with `fromMe: false` sets `messageStatus = null` (not a receipt for our messages)
+- [ ] `parseMessageStatus` with null/missing body sets `messageStatus = null`
+- [ ] `parseMessageStatus` with unknown status code sets `messageStatus = null`
+- [ ] All existing `Baileys.spec.js` tests still pass
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] No KB doc updates required at this task — the feature is documented as a whole in phase-3/task-04-boot-and-qr-integration
+
+## Completion Criteria
+
+- [ ] `parseMessageStatus` implemented as described
+- [ ] All new and existing tests pass: `npx jest src/app/plugins/messengers/Baileys.spec.js`
+- [ ] `npx eslint src/app/plugins/messengers/` passes
+- [ ] Changes committed to `plan/baileys-socket-monitor/phase-1/task-02-receipt-parsing` branch
+- [ ] Status updated to `complete` in `status.md`
+
+## Conflict Avoidance Notes
+
+- task-01 (socket-manager) creates a new file only — no conflict with `Baileys.js`.

--- a/.plans/baileys-socket-monitor/phase-2/task-03-start-socket-usecase/status.md
+++ b/.plans/baileys-socket-monitor/phase-2/task-03-start-socket-usecase/status.md
@@ -1,0 +1,25 @@
+# Status: StartBaileysSocket use case
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-29
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-29 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/baileys-socket-monitor/phase-2/task-03-start-socket-usecase/task.md
+++ b/.plans/baileys-socket-monitor/phase-2/task-03-start-socket-usecase/task.md
@@ -1,0 +1,151 @@
+# Task: StartBaileysSocket use case
+
+**Plan**: Baileys Socket Monitor
+**Phase**: 2
+**Task ID (phase-local)**: task-03
+**Task Path**: phase-2/task-03-start-socket-usecase
+**Depends On**: phase-1/task-01-socket-manager, phase-1/task-02-receipt-parsing
+**JIRA**: N/A
+
+## Objective
+
+Create the `StartBaileysSocket` use case that wires `BaileysSocketManager.start()` to the app's message pipeline, and add it plus the socket manager to the runtime dependency graph.
+
+## Context
+
+After phase 1 we have:
+- `BaileysSocketManager` — knows how to manage socket lifecycle and fires `onMessage(msg)` and `onReceiptUpdate(update)` callbacks.
+- `Baileys.parseMessageStatus` — can now parse a `messages.update` entry into the `messageStatus` shape consumed by `Base.responseToMessages`.
+
+This task is the glue layer:
+
+**`onMessage(msg)` callback** → calls `IngestMessengerMessage.execute({ body: msg, licenseeId })`. This routes the inbound message through the existing `Body` → `messenger-message` BullMQ job → `transformMessengerBody` → `Baileys.responseToMessages` pipeline with no changes to those layers.
+
+**`onReceiptUpdate(update)` callback** → calls `messengerPlugin.responseToMessages(update)`. Since `parseMessageStatus` (task-02) now returns a non-null `messageStatus` for valid receipt updates, `Base.responseToMessages` takes the early-return receipt path and updates `sendedAt`/`deliveredAt`/`readAt` on the Message record.
+
+`onLogout` callback → log a warning that the licensee's session was invalidated. No further action at this layer (the socket manager already cleared credentials).
+
+See `src/app/usecases/webhooks/IngestMessengerMessage.js` for the ingest use case signature and `src/app/runtime/dependencies.js` for how use cases and factories are assembled.
+
+## Before You Start
+
+- [ ] Switch to main and pull: `git switch main && git pull --rebase origin main`
+- [ ] Create task branch: `git switch -c plan/baileys-socket-monitor/phase-2/task-03-start-socket-usecase`
+- [ ] Verify `phase-1/task-01-socket-manager/status.md` shows `complete`
+- [ ] Verify `phase-1/task-02-receipt-parsing/status.md` shows `complete`
+- [ ] Verify this task's `status.md` shows `not-started`
+- [ ] Read `src/app/usecases/webhooks/IngestMessengerMessage.js`
+- [ ] Read `src/app/runtime/dependencies.js` (full file — understand how use cases are wired)
+- [ ] Read `src/app/services/BaileysSocketManager.js` (created in task-01)
+- [ ] Mark this task `in-progress` in `status.md`
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/app/usecases/licensees/StartBaileysSocket.js` | create | Use case |
+| `src/app/usecases/licensees/StartBaileysSocket.spec.js` | create | Unit tests |
+| `src/app/runtime/dependencies.js` | modify | Wire `socketManager`, `startBaileysSocket` |
+
+### Do NOT Modify
+
+- `src/app/services/BaileysSocketManager.js` — owned by phase-1/task-01-socket-manager (complete)
+- `src/app/plugins/messengers/Baileys.js` — owned by phase-1/task-02-receipt-parsing (complete)
+- `src/app/usecases/webhooks/IngestMessengerMessage.js` — read-only
+- `server.js` — owned by phase-3/task-04-boot-and-qr-integration
+- `src/app/usecases/licensees/GetBaileysQr.js` — owned by phase-3/task-04-boot-and-qr-integration
+
+## Implementation Steps
+
+### Step 1: Create `StartBaileysSocket` use case
+
+```js
+// src/app/usecases/licensees/StartBaileysSocket.js
+class StartBaileysSocket {
+  constructor({ socketManager, createMessengerPlugin, ingestMessengerMessage } = {}) {
+    this.socketManager = socketManager
+    this.createMessengerPlugin = createMessengerPlugin
+    this.ingestMessengerMessage = ingestMessengerMessage
+  }
+
+  async execute(licensee) {
+    const plugin = this.createMessengerPlugin(licensee)
+
+    await this.socketManager.start(licensee, {
+      onMessage: async (msg) => {
+        await this.ingestMessengerMessage.execute({
+          body: msg,
+          licenseeId: licensee._id,
+        })
+      },
+      onReceiptUpdate: async (update) => {
+        await plugin.responseToMessages(update)
+      },
+      onLogout: () => {
+        logger.warn(`Baileys: sessão do licensee ${licensee._id} foi desconectada (logout).`)
+      },
+    })
+  }
+}
+
+export { StartBaileysSocket }
+```
+
+Import `logger` from `../../helpers/logger.js`.
+
+### Step 2: Add `socketManager` singleton to `dependencies.js`
+
+In `src/app/runtime/dependencies.js`:
+
+1. Import `BaileysSocketManager` and `StartBaileysSocket`.
+2. Inside `buildRuntimeDependencies`, create the singleton:
+   ```js
+   const socketManager = new BaileysSocketManager({ whatsappSessionRepository })
+   ```
+3. Create the factory / instance:
+   ```js
+   const startBaileysSocket = (licensee) =>
+     new StartBaileysSocket({
+       socketManager,
+       createMessengerPlugin,
+       ingestMessengerMessage: new IngestMessengerMessage({
+         messengerRepository: bodyRepository,
+         jobQueue: queueServer,
+       }),
+     }).execute(licensee)
+   ```
+4. Add `socketManager` and `startBaileysSocket` to the returned dependency object.
+
+> `queueServer` is already imported in `queue.js` — `dependencies.js` should import it from `../../config/queue.js` (already available via the existing pattern if it isn't already imported). Verify before adding a new import.
+
+### Step 3: Ensure `IngestMessengerMessage` is importable in `dependencies.js`
+
+Check if it is already imported. If not, add:
+```js
+import { IngestMessengerMessage } from '../usecases/webhooks/IngestMessengerMessage.js'
+```
+
+## Testing
+
+- [ ] `StartBaileysSocket.execute(licensee)` calls `socketManager.start` with correct callbacks
+- [ ] `onMessage` callback calls `ingestMessengerMessage.execute` with `{ body: msg, licenseeId }`
+- [ ] `onReceiptUpdate` callback calls `plugin.responseToMessages` with the update
+- [ ] `onLogout` logs a warning (mock `logger` and assert)
+- [ ] All existing tests in `src/app/usecases/` still pass
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] No KB doc updates required at this task — the feature is documented as a whole in phase-3/task-04-boot-and-qr-integration
+
+## Completion Criteria
+
+- [ ] `StartBaileysSocket` created and wired in `dependencies.js`
+- [ ] All unit tests pass: `npx jest src/app/usecases/licensees/StartBaileysSocket.spec.js`
+- [ ] `npx eslint src/app/usecases/licensees/ src/app/runtime/` passes
+- [ ] Changes committed to `plan/baileys-socket-monitor/phase-2/task-03-start-socket-usecase` branch
+- [ ] Status updated to `complete` in `status.md`
+
+## Conflict Avoidance Notes
+
+None — this phase has only one task.

--- a/.plans/baileys-socket-monitor/phase-3/task-04-boot-and-qr-integration/status.md
+++ b/.plans/baileys-socket-monitor/phase-3/task-04-boot-and-qr-integration/status.md
@@ -1,0 +1,25 @@
+# Status: App boot wiring + QR integration
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-29
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-29 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/baileys-socket-monitor/phase-3/task-04-boot-and-qr-integration/task.md
+++ b/.plans/baileys-socket-monitor/phase-3/task-04-boot-and-qr-integration/task.md
@@ -1,0 +1,217 @@
+# Task: App boot wiring + QR integration
+
+**Plan**: Baileys Socket Monitor
+**Phase**: 3
+**Task ID (phase-local)**: task-04
+**Task Path**: phase-3/task-04-boot-and-qr-integration
+**Depends On**: phase-2/task-03-start-socket-usecase
+**JIRA**: N/A
+
+## Objective
+
+Wire the persistent socket system into the app lifecycle: start all active Baileys sessions at server boot (gated by `ENABLE_BAILEYS_SOCKET=true`), trigger a socket start after a successful QR pairing, and update the KB doc.
+
+## Context
+
+After phase 2 we have a working `startBaileysSocket(licensee)` function in the runtime dependency graph.
+
+This task connects it to two trigger points:
+
+**1. App boot (`server.js`)**: After the DB connection is established, load all licensees with `whatsappDefault === 'baileys'` and a non-empty session (active credentials), then call `startBaileysSocket` for each. Fire-and-forget (don't block `server.listen`). Gate the entire boot routine behind `ENABLE_BAILEYS_SOCKET=true` to allow gradual rollout.
+
+**2. Post-QR pairing (`GetBaileysQr.js`)**: `getQrCode()` in `Baileys.js` currently resolves with `null` when the QR is scanned and the connection opens. After this task, `GetBaileysQr.execute()` calls `startBaileysSocket(licensee)` when `getQrCode()` returns `null` (already connected) or after the QR is resolved (connection opened). This ensures a persistent socket is started without requiring a restart.
+
+Boot use case (`BootBaileysSocketSessions`): Encapsulates the "find all active Baileys licensees → start sockets" logic so it is testable independently from the server entry point.
+
+An "active session" is a licensee where:
+- `whatsappDefault === 'baileys'`
+- A `WhatsappSession` record exists with non-empty `creds`
+
+The boot routine should log each start attempt and swallow per-licensee errors (a bad session should not prevent other licensees from starting).
+
+## Before You Start
+
+- [ ] Switch to main and pull: `git switch main && git pull --rebase origin main`
+- [ ] Create task branch: `git switch -c plan/baileys-socket-monitor/phase-3/task-04-boot-and-qr-integration`
+- [ ] Verify `phase-2/task-03-start-socket-usecase/status.md` shows `complete`
+- [ ] Verify this task's `status.md` shows `not-started`
+- [ ] Read `server.js` (top-level)
+- [ ] Read `src/config/http.js` and `src/config/mongo.js` to understand the boot sequence
+- [ ] Read `src/app/usecases/licensees/GetBaileysQr.js`
+- [ ] Read `src/app/runtime/dependencies.js` (understand what's now available after task-03)
+- [ ] Mark this task `in-progress` in `status.md`
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/app/usecases/licensees/BootBaileysSocketSessions.js` | create | Boot use case |
+| `src/app/usecases/licensees/BootBaileysSocketSessions.spec.js` | create | Unit tests |
+| `src/app/usecases/licensees/GetBaileysQr.js` | modify | Trigger socket after QR pairing |
+| `src/app/usecases/licensees/GetBaileysQr.spec.js` | modify | Add socket trigger test |
+| `src/app/runtime/dependencies.js` | modify | Wire `bootBaileysSocketSessions` |
+| `server.js` | modify | Call boot routine after DB connects |
+| `docs/kb/features/baileys-whatsapp-guide.md` | modify | Document persistent socket section |
+
+### Do NOT Modify
+
+- `src/app/services/BaileysSocketManager.js` — complete (phase 1)
+- `src/app/plugins/messengers/Baileys.js` — complete (phase 1)
+- `src/app/usecases/licensees/StartBaileysSocket.js` — complete (phase 2)
+
+## Implementation Steps
+
+### Step 1: Create `BootBaileysSocketSessions` use case
+
+```js
+// src/app/usecases/licensees/BootBaileysSocketSessions.js
+class BootBaileysSocketSessions {
+  constructor({ licenseeRepository, whatsappSessionRepository, startBaileysSocket } = {}) {
+    this.licenseeRepository = licenseeRepository
+    this.whatsappSessionRepository = whatsappSessionRepository
+    this.startBaileysSocket = startBaileysSocket
+  }
+
+  async execute() {
+    const licensees = await this.licenseeRepository.find({ whatsappDefault: 'baileys' })
+
+    for (const licensee of licensees) {
+      try {
+        const session = await this.whatsappSessionRepository.findFirst({ licensee: licensee._id })
+        if (!session?.creds || Object.keys(session.creds).length === 0) {
+          logger.info(`Baileys boot: licensee ${licensee._id} sem sessão ativa, ignorando.`)
+          continue
+        }
+        logger.info(`Baileys boot: iniciando socket para licensee ${licensee._id}`)
+        await this.startBaileysSocket(licensee)
+      } catch (err) {
+        logger.error(`Baileys boot: falha ao iniciar socket para licensee ${licensee._id}: ${err.message ?? err}`)
+      }
+    }
+  }
+}
+
+export { BootBaileysSocketSessions }
+```
+
+### Step 2: Wire `bootBaileysSocketSessions` in `dependencies.js`
+
+1. Import `BootBaileysSocketSessions`.
+2. Inside `buildRuntimeDependencies`, after `startBaileysSocket`:
+   ```js
+   const bootBaileysSocketSessions = () =>
+     new BootBaileysSocketSessions({
+       licenseeRepository,
+       whatsappSessionRepository,
+       startBaileysSocket,
+     }).execute()
+   ```
+3. Add to the returned object.
+
+### Step 3: Add boot hook to `server.js`
+
+After `server.listen(PORT)`, add a fire-and-forget boot call gated by the env flag:
+
+```js
+if (process.env.ENABLE_BAILEYS_SOCKET === 'true') {
+  import('./src/app/runtime/dependencies.js').then(({ createRuntimeDependencies }) => {
+    const { bootBaileysSocketSessions } = createRuntimeDependencies()
+    bootBaileysSocketSessions().catch((err) => {
+      console.error('Baileys boot: erro ao iniciar sockets', err)
+    })
+  })
+}
+```
+
+Use a dynamic import to avoid the `createRuntimeDependencies` call from affecting non-Baileys server starts.
+
+### Step 4: Update `GetBaileysQr.js`
+
+Add `startBaileysSocket` as a constructor dependency and call it after QR resolution:
+
+```js
+class GetBaileysQr {
+  constructor({ licenseeRepository, createMessengerPlugin, startBaileysSocket } = {}) {
+    this.licenseeRepository = licenseeRepository
+    this.createMessengerPlugin = createMessengerPlugin
+    this.startBaileysSocket = startBaileysSocket
+  }
+
+  async execute(id) {
+    const licensee = await this.licenseeRepository.findFirst({ _id: id })
+
+    if (licensee.whatsappDefault !== 'baileys') {
+      return { message: 'Licensee não usa Baileys' }
+    }
+
+    const plugin = this.createMessengerPlugin(licensee)
+    const qr = await plugin.getQrCode()
+
+    if (!qr) {
+      // Already connected — ensure persistent socket is running
+      if (process.env.ENABLE_BAILEYS_SOCKET === 'true') {
+        this.startBaileysSocket?.(licensee).catch(() => {})
+      }
+      return { message: 'Já conectado' }
+    }
+
+    // QR returned — the QR flow will trigger a connection.update → 'open' event.
+    // Start socket after pairing succeeds (fire-and-forget; the Baileys socket manager
+    // handles duplicate start calls gracefully via the registry check).
+    if (process.env.ENABLE_BAILEYS_SOCKET === 'true') {
+      this.startBaileysSocket?.(licensee).catch(() => {})
+    }
+
+    return { qr }
+  }
+}
+```
+
+Wire `startBaileysSocket` in `createGetBaileysQr` factory or wherever `GetBaileysQr` is instantiated (check the controller or routes that call it).
+
+> **Note**: Duplicate `start()` calls are safe if `BaileysSocketManager` checks `isConnected()` at the top of `start()` and returns early if the socket is already in the registry. Verify task-01 implements this guard; if not, add it.
+
+### Step 5: Update `baileys-whatsapp-guide.md`
+
+Add a new section **"Step 6 — Persistent Socket Monitor"** covering:
+- What `ENABLE_BAILEYS_SOCKET=true` enables
+- What events are captured (`messages.upsert` inbound, `messages.update` receipts)
+- Boot behavior (all active sessions start at server start)
+- Post-QR behavior (socket starts automatically after pairing)
+- How inbound messages reach the DB (same `Body → messenger-message` job pipeline)
+- How delivery receipts update `Message.sendedAt / deliveredAt / readAt`
+- Note that the HTTP webhook endpoint (`POST /v1/messenger/message`) still works as a fallback
+- Manual verification checklist (see Success Criteria in overview.md)
+
+## Testing
+
+- [ ] `BootBaileysSocketSessions.execute()` — calls `startBaileysSocket` for each licensee with non-empty session creds
+- [ ] `BootBaileysSocketSessions.execute()` — skips licensees with empty/missing creds
+- [ ] `BootBaileysSocketSessions.execute()` — logs error and continues if `startBaileysSocket` throws for one licensee
+- [ ] `GetBaileysQr.execute()` — calls `startBaileysSocket` when `ENABLE_BAILEYS_SOCKET === 'true'` and QR is generated
+- [ ] `GetBaileysQr.execute()` — calls `startBaileysSocket` when `ENABLE_BAILEYS_SOCKET === 'true'` and already connected
+- [ ] `GetBaileysQr.execute()` — does NOT call `startBaileysSocket` when `ENABLE_BAILEYS_SOCKET` is not set
+- [ ] All existing `GetBaileysQr.spec.js` tests still pass
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] Update `docs/kb/features/baileys-whatsapp-guide.md` with Step 6 (persistent socket section)
+- [ ] Run `check-kb-index` after KB changes
+
+## Completion Criteria
+
+- [ ] `BootBaileysSocketSessions` created and wired
+- [ ] `GetBaileysQr` triggers socket start after pairing
+- [ ] `server.js` boots all active sessions when `ENABLE_BAILEYS_SOCKET=true`
+- [ ] All unit tests pass: `npx jest`
+- [ ] `npx eslint .` produces no new errors
+- [ ] `baileys-whatsapp-guide.md` updated with persistent socket section
+- [ ] `check-kb-index` run after KB update
+- [ ] Changes committed to `plan/baileys-socket-monitor/phase-3/task-04-boot-and-qr-integration` branch
+- [ ] Status updated to `complete` in `status.md`
+- [ ] All items in the plan's Success Criteria checked off
+
+## Conflict Avoidance Notes
+
+None — this phase has only one task.


### PR DESCRIPTION
## Plan: Baileys Socket Monitor

Replace the external-webhook-only inbound flow with a persistent Baileys WebSocket per licensee that listens to `messages.upsert` (inbound) and `messages.update` (delivery receipts), feeding events directly into the existing BullMQ pipeline.

**Type**: Type 2 (Technical)
**Phases**: 3  **Tasks**: 4
**Assigned Dev**: Alan Costa Facchini

## Task breakdown

| Phase | Task | Description | Parallel? |
|-------|------|-------------|-----------|
| 1 | task-01-socket-manager | `BaileysSocketManager` — persistent socket lifecycle with reconnect | ✅ with task-02 |
| 1 | task-02-receipt-parsing | Implement `parseMessageStatus` stub in `Baileys.js` | ✅ with task-01 |
| 2 | task-03-start-socket-usecase | `StartBaileysSocket` use case + runtime dep wiring | after Phase 1 |
| 3 | task-04-boot-and-qr-integration | App boot hook, QR integration, `ENABLE_BAILEYS_SOCKET` flag, KB update | after Phase 2 |

> Merge this PR before running `/execute-plan baileys-socket-monitor` or any `/execute-task`.