### PR TITLE
fix(auth): prevent 401 on first page load after login

### DIFF
--- a/client/src/services/contact.js
+++ b/client/src/services/contact.js
@@ -2,24 +2,23 @@ import { getToken } from './auth'
 import api from './api'
 import parseUrl from './objectToQueryParameter'
 
-const token = getToken()
-const headers = { 'x-access-token': `${token}` }
+const headers = () => ({ 'x-access-token': getToken() })
 
 function createContact(values) {
-  return api().post('resources/contacts/', { body: values, headers })
+  return api().post('resources/contacts/', { body: values, headers: headers() })
 }
 
 function getContacts(queryParams) {
   const url = parseUrl('resources/contacts/', queryParams)
-  return api().get(url, { headers })
+  return api().get(url, { headers: headers() })
 }
 
 function getContact(id) {
-  return api().get(`resources/contacts/${id}`, { headers })
+  return api().get(`resources/contacts/${id}`, { headers: headers() })
 }
 
 function updateContact(contact) {
-  return api().post(`resources/contacts/${contact.id}`, { headers, body: contact })
+  return api().post(`resources/contacts/${contact.id}`, { headers: headers(), body: contact })
 }
 
 export { createContact, getContacts, getContact, updateContact }

--- a/client/src/services/contact.spec.js
+++ b/client/src/services/contact.spec.js
@@ -1,0 +1,68 @@
+import * as auth from './auth'
+import * as apiModule from './api'
+import { createContact, getContacts, getContact, updateContact } from './contact'
+
+vi.mock('./auth')
+vi.mock('./api')
+
+describe('contact service', () => {
+  let mockGet, mockPost
+
+  beforeEach(() => {
+    mockGet = vi.fn().mockResolvedValue({ data: [] })
+    mockPost = vi.fn().mockResolvedValue({ data: {} })
+    apiModule.default.mockReturnValue({ get: mockGet, post: mockPost })
+    auth.getToken.mockReturnValue('test-token')
+  })
+
+  it('reads the token at call time, not at module initialization', async () => {
+    auth.getToken.mockReturnValue('token-after-login')
+    await getContacts({})
+    expect(mockGet).toHaveBeenCalledWith(
+      expect.any(String),
+      { headers: { 'x-access-token': 'token-after-login' } }
+    )
+  })
+
+  describe('getContacts', () => {
+    it('sends GET to resources/contacts/ with auth header and query params', async () => {
+      await getContacts({ page: 1 })
+      expect(mockGet).toHaveBeenCalledWith(
+        'resources/contacts/?page=1',
+        { headers: { 'x-access-token': 'test-token' } }
+      )
+    })
+  })
+
+  describe('getContact', () => {
+    it('sends GET to resources/contacts/:id with auth header', async () => {
+      await getContact('abc123')
+      expect(mockGet).toHaveBeenCalledWith(
+        'resources/contacts/abc123',
+        { headers: { 'x-access-token': 'test-token' } }
+      )
+    })
+  })
+
+  describe('createContact', () => {
+    it('sends POST to resources/contacts/ with auth header and body', async () => {
+      const values = { name: 'Alice', number: '5511999999999' }
+      await createContact(values)
+      expect(mockPost).toHaveBeenCalledWith(
+        'resources/contacts/',
+        { body: values, headers: { 'x-access-token': 'test-token' } }
+      )
+    })
+  })
+
+  describe('updateContact', () => {
+    it('sends POST to resources/contacts/:id with auth header and body', async () => {
+      const contact = { id: 'abc123', name: 'Alice Updated' }
+      await updateContact(contact)
+      expect(mockPost).toHaveBeenCalledWith(
+        'resources/contacts/abc123',
+        { headers: { 'x-access-token': 'test-token' }, body: contact }
+      )
+    })
+  })
+})

--- a/client/src/services/licensee.js
+++ b/client/src/services/licensee.js
@@ -2,52 +2,51 @@ import { getToken } from './auth'
 import api from './api'
 import parseUrl from './objectToQueryParameter'
 
-const token = getToken()
-const headers = { 'x-access-token': `${token}` }
+const headers = () => ({ 'x-access-token': getToken() })
 
 function createLicensee(values) {
-  return api().post('resources/licensees/', { body: values, headers })
+  return api().post('resources/licensees/', { body: values, headers: headers() })
 }
 
 function getLicensees(queryParams) {
   const url = parseUrl('resources/licensees/', queryParams)
-  return api().get(url, { headers })
+  return api().get(url, { headers: headers() })
 }
 
 function getLicensee(id) {
-  return api().get(`resources/licensees/${id}`, { headers })
+  return api().get(`resources/licensees/${id}`, { headers: headers() })
 }
 
 function updateLicensee(licensee) {
-  return api().post(`resources/licensees/${licensee.id}`, { headers, body: licensee })
+  return api().post(`resources/licensees/${licensee.id}`, { headers: headers(), body: licensee })
 }
 
 function setLicenseeWebhook(licensee) {
-  return api().post(`resources/licensees/${licensee.id}/dialogwebhook`, { headers, body: licensee })
+  return api().post(`resources/licensees/${licensee.id}/dialogwebhook`, { headers: headers(), body: licensee })
 }
 
 function getBaileysQr(licensee) {
-  return api().post(`resources/licensees/${licensee.id}/baileys-qr`, { headers })
+  return api().post(`resources/licensees/${licensee.id}/baileys-qr`, { headers: headers() })
 }
 
 function getBaileysStatus(licensee) {
-  return api().get(`resources/licensees/${licensee.id}/baileys-status`, { headers })
+  return api().get(`resources/licensees/${licensee.id}/baileys-status`, { headers: headers() })
 }
 
 function sendLicenseePagarMe(licensee) {
-  return api().post(`resources/licensees/${licensee.id}/integration/pagarme`, { headers, body: licensee })
+  return api().post(`resources/licensees/${licensee.id}/integration/pagarme`, { headers: headers(), body: licensee })
 }
 
 function importLicenseeTemplate(licensee) {
-  return api().post(`resources/templates/${licensee.id}/importation/`, { headers })
+  return api().post(`resources/templates/${licensee.id}/importation/`, { headers: headers() })
 }
 
 function signOrderWebhook(licensee) {
-  return api().post(`resources/licensees/${licensee.id}/sign-order-webhook`, { headers, body: licensee })
+  return api().post(`resources/licensees/${licensee.id}/sign-order-webhook`, { headers: headers(), body: licensee })
 }
 
 function syncBaileysDirectory(licensee) {
-  return api().post(`resources/licensees/${licensee.id}/baileys-sync`, { headers })
+  return api().post(`resources/licensees/${licensee.id}/baileys-sync`, { headers: headers() })
 }
 
 export {

--- a/client/src/services/licensee.spec.js
+++ b/client/src/services/licensee.spec.js
@@ -1,0 +1,150 @@
+import * as auth from './auth'
+import * as apiModule from './api'
+import {
+  createLicensee,
+  getLicensees,
+  getLicensee,
+  updateLicensee,
+  setLicenseeWebhook,
+  getBaileysQr,
+  getBaileysStatus,
+  importLicenseeTemplate,
+  sendLicenseePagarMe,
+  signOrderWebhook,
+  syncBaileysDirectory,
+} from './licensee'
+
+vi.mock('./auth')
+vi.mock('./api')
+
+describe('licensee service', () => {
+  let mockGet, mockPost
+  const licensee = { id: 'lic-id', name: 'Acme' }
+
+  beforeEach(() => {
+    mockGet = vi.fn().mockResolvedValue({ data: {} })
+    mockPost = vi.fn().mockResolvedValue({ data: {} })
+    apiModule.default.mockReturnValue({ get: mockGet, post: mockPost })
+    auth.getToken.mockReturnValue('test-token')
+  })
+
+  it('reads the token at call time, not at module initialization', async () => {
+    auth.getToken.mockReturnValue('token-after-login')
+    await getLicensees({})
+    expect(mockGet).toHaveBeenCalledWith(
+      expect.any(String),
+      { headers: { 'x-access-token': 'token-after-login' } }
+    )
+  })
+
+  describe('getLicensees', () => {
+    it('sends GET to resources/licensees/ with auth header and query params', async () => {
+      await getLicensees({ page: 1 })
+      expect(mockGet).toHaveBeenCalledWith(
+        'resources/licensees/?page=1',
+        { headers: { 'x-access-token': 'test-token' } }
+      )
+    })
+  })
+
+  describe('getLicensee', () => {
+    it('sends GET to resources/licensees/:id with auth header', async () => {
+      await getLicensee('lic-id')
+      expect(mockGet).toHaveBeenCalledWith(
+        'resources/licensees/lic-id',
+        { headers: { 'x-access-token': 'test-token' } }
+      )
+    })
+  })
+
+  describe('createLicensee', () => {
+    it('sends POST to resources/licensees/ with auth header and body', async () => {
+      const values = { name: 'New Licensee' }
+      await createLicensee(values)
+      expect(mockPost).toHaveBeenCalledWith(
+        'resources/licensees/',
+        { body: values, headers: { 'x-access-token': 'test-token' } }
+      )
+    })
+  })
+
+  describe('updateLicensee', () => {
+    it('sends POST to resources/licensees/:id with auth header and body', async () => {
+      await updateLicensee(licensee)
+      expect(mockPost).toHaveBeenCalledWith(
+        'resources/licensees/lic-id',
+        { headers: { 'x-access-token': 'test-token' }, body: licensee }
+      )
+    })
+  })
+
+  describe('setLicenseeWebhook', () => {
+    it('sends POST to resources/licensees/:id/dialogwebhook with auth header and body', async () => {
+      await setLicenseeWebhook(licensee)
+      expect(mockPost).toHaveBeenCalledWith(
+        'resources/licensees/lic-id/dialogwebhook',
+        { headers: { 'x-access-token': 'test-token' }, body: licensee }
+      )
+    })
+  })
+
+  describe('getBaileysQr', () => {
+    it('sends POST to resources/licensees/:id/baileys-qr with auth header', async () => {
+      await getBaileysQr(licensee)
+      expect(mockPost).toHaveBeenCalledWith(
+        'resources/licensees/lic-id/baileys-qr',
+        { headers: { 'x-access-token': 'test-token' } }
+      )
+    })
+  })
+
+  describe('getBaileysStatus', () => {
+    it('sends GET to resources/licensees/:id/baileys-status with auth header', async () => {
+      await getBaileysStatus(licensee)
+      expect(mockGet).toHaveBeenCalledWith(
+        'resources/licensees/lic-id/baileys-status',
+        { headers: { 'x-access-token': 'test-token' } }
+      )
+    })
+  })
+
+  describe('sendLicenseePagarMe', () => {
+    it('sends POST to resources/licensees/:id/integration/pagarme with auth header and body', async () => {
+      await sendLicenseePagarMe(licensee)
+      expect(mockPost).toHaveBeenCalledWith(
+        'resources/licensees/lic-id/integration/pagarme',
+        { headers: { 'x-access-token': 'test-token' }, body: licensee }
+      )
+    })
+  })
+
+  describe('importLicenseeTemplate', () => {
+    it('sends POST to resources/templates/:id/importation/ with auth header', async () => {
+      await importLicenseeTemplate(licensee)
+      expect(mockPost).toHaveBeenCalledWith(
+        'resources/templates/lic-id/importation/',
+        { headers: { 'x-access-token': 'test-token' } }
+      )
+    })
+  })
+
+  describe('signOrderWebhook', () => {
+    it('sends POST to resources/licensees/:id/sign-order-webhook with auth header and body', async () => {
+      await signOrderWebhook(licensee)
+      expect(mockPost).toHaveBeenCalledWith(
+        'resources/licensees/lic-id/sign-order-webhook',
+        { headers: { 'x-access-token': 'test-token' }, body: licensee }
+      )
+    })
+  })
+
+  describe('syncBaileysDirectory', () => {
+    it('sends POST to resources/licensees/:id/baileys-sync with auth header', async () => {
+      await syncBaileysDirectory(licensee)
+      expect(mockPost).toHaveBeenCalledWith(
+        'resources/licensees/lic-id/baileys-sync',
+        { headers: { 'x-access-token': 'test-token' } }
+      )
+    })
+  })
+})

--- a/client/src/services/template.js
+++ b/client/src/services/template.js
@@ -2,28 +2,27 @@ import { getToken } from './auth'
 import api from './api'
 import parseUrl from './objectToQueryParameter'
 
-const token = getToken()
-const headers = { 'x-access-token': `${token}` }
+const headers = () => ({ 'x-access-token': getToken() })
 
 function createTemplate(values) {
-  return api().post('resources/templates/', { body: values, headers })
+  return api().post('resources/templates/', { body: values, headers: headers() })
 }
 
 function getTemplates(queryParams) {
   const url = parseUrl('resources/templates/', queryParams)
-  return api().get(url, { headers })
+  return api().get(url, { headers: headers() })
 }
 
 function getTemplate(id) {
-  return api().get(`resources/templates/${id}`, { headers })
+  return api().get(`resources/templates/${id}`, { headers: headers() })
 }
 
 function updateTemplate(trigger) {
-  return api().post(`resources/templates/${trigger.id}`, { headers, body: trigger })
+  return api().post(`resources/templates/${trigger.id}`, { headers: headers(), body: trigger })
 }
 
 function importTemplates(triggerId, values) {
-  return api().post(`resources/templates/${triggerId}/importation/`, { headers, body: values })
+  return api().post(`resources/templates/${triggerId}/importation/`, { headers: headers(), body: values })
 }
 
 export { createTemplate, getTemplates, getTemplate, updateTemplate, importTemplates }

--- a/client/src/services/template.spec.js
+++ b/client/src/services/template.spec.js
@@ -1,0 +1,79 @@
+import * as auth from './auth'
+import * as apiModule from './api'
+import { createTemplate, getTemplates, getTemplate, updateTemplate, importTemplates } from './template'
+
+vi.mock('./auth')
+vi.mock('./api')
+
+describe('template service', () => {
+  let mockGet, mockPost
+
+  beforeEach(() => {
+    mockGet = vi.fn().mockResolvedValue({ data: [] })
+    mockPost = vi.fn().mockResolvedValue({ data: {} })
+    apiModule.default.mockReturnValue({ get: mockGet, post: mockPost })
+    auth.getToken.mockReturnValue('test-token')
+  })
+
+  it('reads the token at call time, not at module initialization', async () => {
+    auth.getToken.mockReturnValue('token-after-login')
+    await getTemplates({})
+    expect(mockGet).toHaveBeenCalledWith(
+      expect.any(String),
+      { headers: { 'x-access-token': 'token-after-login' } }
+    )
+  })
+
+  describe('getTemplates', () => {
+    it('sends GET to resources/templates/ with auth header and query params', async () => {
+      await getTemplates({ page: 1 })
+      expect(mockGet).toHaveBeenCalledWith(
+        'resources/templates/?page=1',
+        { headers: { 'x-access-token': 'test-token' } }
+      )
+    })
+  })
+
+  describe('getTemplate', () => {
+    it('sends GET to resources/templates/:id with auth header', async () => {
+      await getTemplate('tpl-id')
+      expect(mockGet).toHaveBeenCalledWith(
+        'resources/templates/tpl-id',
+        { headers: { 'x-access-token': 'test-token' } }
+      )
+    })
+  })
+
+  describe('createTemplate', () => {
+    it('sends POST to resources/templates/ with auth header and body', async () => {
+      const values = { name: 'My Template', content: 'Hello {{name}}' }
+      await createTemplate(values)
+      expect(mockPost).toHaveBeenCalledWith(
+        'resources/templates/',
+        { body: values, headers: { 'x-access-token': 'test-token' } }
+      )
+    })
+  })
+
+  describe('updateTemplate', () => {
+    it('sends POST to resources/templates/:id with auth header and body', async () => {
+      const template = { id: 'tpl-id', name: 'Updated' }
+      await updateTemplate(template)
+      expect(mockPost).toHaveBeenCalledWith(
+        'resources/templates/tpl-id',
+        { headers: { 'x-access-token': 'test-token' }, body: template }
+      )
+    })
+  })
+
+  describe('importTemplates', () => {
+    it('sends POST to resources/templates/:id/importation/ with auth header and body', async () => {
+      const values = { file: 'data' }
+      await importTemplates('tpl-id', values)
+      expect(mockPost).toHaveBeenCalledWith(
+        'resources/templates/tpl-id/importation/',
+        { headers: { 'x-access-token': 'test-token' }, body: values }
+      )
+    })
+  })
+})

--- a/client/src/services/trigger.js
+++ b/client/src/services/trigger.js
@@ -2,28 +2,27 @@ import { getToken } from './auth'
 import api from './api'
 import parseUrl from './objectToQueryParameter'
 
-const token = getToken()
-const headers = { 'x-access-token': `${token}` }
+const headers = () => ({ 'x-access-token': getToken() })
 
 function createTrigger(values) {
-  return api().post('resources/triggers/', { body: values, headers })
+  return api().post('resources/triggers/', { body: values, headers: headers() })
 }
 
 function getTriggers(queryParams) {
   const url = parseUrl('resources/triggers/', queryParams)
-  return api().get(url, { headers })
+  return api().get(url, { headers: headers() })
 }
 
 function getTrigger(id) {
-  return api().get(`resources/triggers/${id}`, { headers })
+  return api().get(`resources/triggers/${id}`, { headers: headers() })
 }
 
 function updateTrigger(trigger) {
-  return api().post(`resources/triggers/${trigger.id}`, { headers, body: trigger })
+  return api().post(`resources/triggers/${trigger.id}`, { headers: headers(), body: trigger })
 }
 
 function importTriggerMultiProduct(triggerId, values) {
-  return api().post(`resources/triggers/${triggerId}/importation/`, { headers, body: values })
+  return api().post(`resources/triggers/${triggerId}/importation/`, { headers: headers(), body: values })
 }
 
 export { createTrigger, getTriggers, getTrigger, updateTrigger, importTriggerMultiProduct }

--- a/client/src/services/trigger.spec.js
+++ b/client/src/services/trigger.spec.js
@@ -1,0 +1,79 @@
+import * as auth from './auth'
+import * as apiModule from './api'
+import { createTrigger, getTriggers, getTrigger, updateTrigger, importTriggerMultiProduct } from './trigger'
+
+vi.mock('./auth')
+vi.mock('./api')
+
+describe('trigger service', () => {
+  let mockGet, mockPost
+
+  beforeEach(() => {
+    mockGet = vi.fn().mockResolvedValue({ data: [] })
+    mockPost = vi.fn().mockResolvedValue({ data: {} })
+    apiModule.default.mockReturnValue({ get: mockGet, post: mockPost })
+    auth.getToken.mockReturnValue('test-token')
+  })
+
+  it('reads the token at call time, not at module initialization', async () => {
+    auth.getToken.mockReturnValue('token-after-login')
+    await getTriggers({})
+    expect(mockGet).toHaveBeenCalledWith(
+      expect.any(String),
+      { headers: { 'x-access-token': 'token-after-login' } }
+    )
+  })
+
+  describe('getTriggers', () => {
+    it('sends GET to resources/triggers/ with auth header and query params', async () => {
+      await getTriggers({ page: 1 })
+      expect(mockGet).toHaveBeenCalledWith(
+        'resources/triggers/?page=1',
+        { headers: { 'x-access-token': 'test-token' } }
+      )
+    })
+  })
+
+  describe('getTrigger', () => {
+    it('sends GET to resources/triggers/:id with auth header', async () => {
+      await getTrigger('trg-id')
+      expect(mockGet).toHaveBeenCalledWith(
+        'resources/triggers/trg-id',
+        { headers: { 'x-access-token': 'test-token' } }
+      )
+    })
+  })
+
+  describe('createTrigger', () => {
+    it('sends POST to resources/triggers/ with auth header and body', async () => {
+      const values = { name: 'Black Friday', expression: 'bf2025' }
+      await createTrigger(values)
+      expect(mockPost).toHaveBeenCalledWith(
+        'resources/triggers/',
+        { body: values, headers: { 'x-access-token': 'test-token' } }
+      )
+    })
+  })
+
+  describe('updateTrigger', () => {
+    it('sends POST to resources/triggers/:id with auth header and body', async () => {
+      const trigger = { id: 'trg-id', name: 'Updated Trigger' }
+      await updateTrigger(trigger)
+      expect(mockPost).toHaveBeenCalledWith(
+        'resources/triggers/trg-id',
+        { headers: { 'x-access-token': 'test-token' }, body: trigger }
+      )
+    })
+  })
+
+  describe('importTriggerMultiProduct', () => {
+    it('sends POST to resources/triggers/:id/importation/ with auth header and body', async () => {
+      const values = { products: ['a', 'b'] }
+      await importTriggerMultiProduct('trg-id', values)
+      expect(mockPost).toHaveBeenCalledWith(
+        'resources/triggers/trg-id/importation/',
+        { headers: { 'x-access-token': 'test-token' }, body: values }
+      )
+    })
+  })
+})

--- a/client/src/services/user.js
+++ b/client/src/services/user.js
@@ -2,24 +2,23 @@ import { getToken } from './auth'
 import api from './api'
 import parseUrl from './objectToQueryParameter'
 
-const token = getToken()
-const headers = { 'x-access-token': `${token}` }
+const headers = () => ({ 'x-access-token': getToken() })
 
 function createUser(values) {
-  return api().post('resources/users/', { body: values, headers })
+  return api().post('resources/users/', { body: values, headers: headers() })
 }
 
 function getUsers(queryParams) {
   const url = parseUrl('resources/users/', queryParams)
-  return api().get(url, { headers })
+  return api().get(url, { headers: headers() })
 }
 
 function getUser(id) {
-  return api().get(`resources/users/${id}`, { headers })
+  return api().get(`resources/users/${id}`, { headers: headers() })
 }
 
 function updateUser(user) {
-  return api().post(`resources/users/${user.id}`, { headers, body: user })
+  return api().post(`resources/users/${user.id}`, { headers: headers(), body: user })
 }
 
 export { createUser, getUsers, getUser, updateUser }

--- a/client/src/services/user.spec.js
+++ b/client/src/services/user.spec.js
@@ -1,0 +1,68 @@
+import * as auth from './auth'
+import * as apiModule from './api'
+import { createUser, getUsers, getUser, updateUser } from './user'
+
+vi.mock('./auth')
+vi.mock('./api')
+
+describe('user service', () => {
+  let mockGet, mockPost
+
+  beforeEach(() => {
+    mockGet = vi.fn().mockResolvedValue({ data: [] })
+    mockPost = vi.fn().mockResolvedValue({ data: {} })
+    apiModule.default.mockReturnValue({ get: mockGet, post: mockPost })
+    auth.getToken.mockReturnValue('test-token')
+  })
+
+  it('reads the token at call time, not at module initialization', async () => {
+    auth.getToken.mockReturnValue('token-after-login')
+    await getUsers({})
+    expect(mockGet).toHaveBeenCalledWith(
+      expect.any(String),
+      { headers: { 'x-access-token': 'token-after-login' } }
+    )
+  })
+
+  describe('getUsers', () => {
+    it('sends GET to resources/users/ with auth header and query params', async () => {
+      await getUsers({ page: 1 })
+      expect(mockGet).toHaveBeenCalledWith(
+        'resources/users/?page=1',
+        { headers: { 'x-access-token': 'test-token' } }
+      )
+    })
+  })
+
+  describe('getUser', () => {
+    it('sends GET to resources/users/:id with auth header', async () => {
+      await getUser('user-id')
+      expect(mockGet).toHaveBeenCalledWith(
+        'resources/users/user-id',
+        { headers: { 'x-access-token': 'test-token' } }
+      )
+    })
+  })
+
+  describe('createUser', () => {
+    it('sends POST to resources/users/ with auth header and body', async () => {
+      const values = { name: 'Bob', email: 'bob@example.com' }
+      await createUser(values)
+      expect(mockPost).toHaveBeenCalledWith(
+        'resources/users/',
+        { body: values, headers: { 'x-access-token': 'test-token' } }
+      )
+    })
+  })
+
+  describe('updateUser', () => {
+    it('sends POST to resources/users/:id with auth header and body', async () => {
+      const user = { id: 'user-id', name: 'Bob Updated' }
+      await updateUser(user)
+      expect(mockPost).toHaveBeenCalledWith(
+        'resources/users/user-id',
+        { headers: { 'x-access-token': 'test-token' }, body: user }
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- `contact.js`, `licensee.js`, `template.js`, `trigger.js`, `user.js` all captured the auth token at module scope (`const token = getToken()`), so it was always `null` on the first load (before login)
- Every API call in those modules sent a null token, causing 401 on the first request after login
- Refreshing the page re-evaluated the module with the token already in localStorage, which is why refresh fixed it
- Fix: replaced the module-level object with a lazy `headers()` function that reads localStorage at call time — same pattern already used in `dashboard.js`

## Test plan

- [ ] Log in → navigate directly to Contacts, Users, Licensees, Templates, or Triggers index without refreshing → no 401
- [ ] All existing authenticated flows continue to work normally