### PR TITLE
plan(js-to-ts): review corrections

### DIFF
--- a/.plans/js-to-ts/overview.md
+++ b/.plans/js-to-ts/overview.md
@@ -97,13 +97,27 @@ Base branch: `main`
 
 | Defect Task | Title | Found During | Blocks | Status |
 
+## Sequencing with Active Feature Plans
+
+Three feature plans (`setores`, `baileys-socket-monitor`, `local-chat-infra`) are in progress and will add new `.js` backend files (models, services, controllers, plugins). This creates two valid execution strategies:
+
+**Option A — js-to-ts after all feature plans** (recommended): Wait until all three feature plans are merged, then run js-to-ts. Phase 3 tasks will cover the full final file set in one pass. No merge conflicts with feature branches.
+
+**Option B — Phase 1 now, rest later**: Phases 1–2 (tooling, shared types) touch no feature-plan files and can start immediately in parallel with feature plan work. Pause at Phase 3 until feature plans are complete.
+
+Do NOT start Phase 3 or 4 while a feature branch that adds new `.js` files is open — that guarantees merge conflicts.
+
+## Parallelization Opportunities in Phase 3
+
+Tasks 12–16 (messenger, chat, chatbot, cart, integration/payment/storage plugins) all depend only on task-11 and are independent of each other — they can run in parallel across separate branches if desired.
+
 ## Risks
 
 - Mongoose model types are complex (dynamic validators, virtuals) — Use `mongoose` generic types (`Schema<ILicensee>`); keep validators untyped initially
 - 30+ plugin files with deep inheritance chains — Migrate Base class first, then subclasses in the same task
 - `allowJs` means no type-checking on unmigrated files — Acceptable; `tsc --noEmit` only errors on `.ts` files
 - Circular imports may surface as TS errors — Investigate with `madge` if errors appear
-- `_moduleAliases` vs `paths` divergence — Mirror exact aliases in `tsconfig.json` `paths` field
+- `_moduleAliases` vs `paths` divergence — tsconfig `paths` must include all aliases from `_moduleAliases` **and** jest `moduleNameMapper` (notably `@factories`, which is in jest but not in `_moduleAliases`)
 
 ## Success Criteria
 

--- a/.plans/js-to-ts/phase-0/task-00-verify-cra-to-vite-complete/status.md
+++ b/.plans/js-to-ts/phase-0/task-00-verify-cra-to-vite-complete/status.md
@@ -1,7 +1,7 @@
 # Status: Verify cra-to-vite prerequisite is complete
 
-**Current Status**: not-started
-**Last Updated**: 2026-04-28
+**Current Status**: complete
+**Last Updated**: 2026-05-29
 **Agent**: —
 **Branch**: —
 **PR**: —
@@ -11,6 +11,7 @@
 | Timestamp | Status | Agent | Notes |
 |-----------|--------|-------|-------|
 | 2026-04-28 | not-started | — | Task created |
+| 2026-05-29 | complete | — | vite.config.js present; vitest run passes; client fully on Vite — no action needed |
 
 ## Blockers
 

--- a/.plans/js-to-ts/phase-1/task-02-tsconfig-root.md
+++ b/.plans/js-to-ts/phase-1/task-02-tsconfig-root.md
@@ -8,11 +8,19 @@
 
 ## Objective
 
-Create a root-level `tsconfig.json` configured for incremental migration: `allowJs: true`, `checkJs: false`, `strict: false`, `noImplicitAny: false`, `module: NodeNext`, `moduleResolution: NodeNext`, with path aliases matching the existing `_moduleAliases` in `package.json`.
+Create a root-level `tsconfig.json` configured for incremental migration: `allowJs: true`, `checkJs: false`, `strict: false`, `noImplicitAny: false`, `module: CommonJS`, `moduleResolution: node`, with path aliases matching all runtime and test aliases (`_moduleAliases` in `package.json` plus `@factories` from `jest.config.mjs`).
 
 ## Context
 
-The tsconfig must mirror the `_moduleAliases` paths exactly so TypeScript resolves the same module shortcuts the runtime uses. `outDir: dist` is set but `tsc --noEmit` is used throughout the migration (no emit). `allowJs: true` lets TS process existing `.js` files without renaming them.
+The backend uses CommonJS (`require`/`module.exports`) — `module` must be `CommonJS`, not `NodeNext` (NodeNext requires ESM syntax and would immediately break all existing files). `moduleResolution: node` matches how Node resolves modules at runtime.
+
+The tsconfig `paths` must cover **both** sources of aliases:
+- `_moduleAliases` in `package.json` (runtime resolution via `module-alias`)
+- `moduleNameMapper` entries in `jest.config.mjs` (test resolution)
+
+`@factories` is present in jest's mapper but absent from `_moduleAliases` — include it in `paths` or TS will error on any `.ts` file that imports `@factories`.
+
+`outDir: dist` is set but `tsc --noEmit` is used throughout the migration (no emit). `allowJs: true` lets TS process existing `.js` files without renaming them.
 
 ## Before You Start
 
@@ -33,7 +41,7 @@ The tsconfig must mirror the `_moduleAliases` paths exactly so TypeScript resolv
 Identify all aliases to mirror in `paths`.
 
 ### Step 2: Create tsconfig.json
-Set `compilerOptions`: `allowJs: true`, `checkJs: false`, `strict: false`, `noImplicitAny: false`, `esModuleInterop: true`, `module: NodeNext`, `moduleResolution: NodeNext`, `outDir: "dist"`, `rootDir: "."`, `paths` mirroring all `_moduleAliases` entries.
+Set `compilerOptions`: `allowJs: true`, `checkJs: false`, `strict: false`, `noImplicitAny: false`, `esModuleInterop: true`, `module: "CommonJS"`, `moduleResolution: "node"`, `outDir: "dist"`, `rootDir: "."`, `paths` mirroring all `_moduleAliases` entries **plus** `@factories → ["./src/app/factories"]` (present in jest mapper but not in `_moduleAliases`).
 
 ### Step 3: Verify zero errors
 Run `npx tsc --noEmit` — should report zero errors on the current JS-only codebase.

--- a/.plans/js-to-ts/phase-3/task-08-migrate-models.md
+++ b/.plans/js-to-ts/phase-3/task-08-migrate-models.md
@@ -8,7 +8,7 @@
 
 ## Objective
 
-Rename all 14 Mongoose model files in `src/app/models/` from `.js` to `.ts`, type schema fields, and export typed `Document` interfaces using Mongoose generics.
+Rename all Mongoose model files in `src/app/models/` from `.js` to `.ts`, type schema fields, and export typed `Document` interfaces using Mongoose generics. Baseline count is 14 files; if the `setores`, `baileys-socket-monitor`, or `local-chat-infra` feature plans have been merged before this task runs, additional models (e.g. `Setor.js`) will be present — migrate all `.js` files found, regardless of count.
 
 ## Context
 
@@ -25,7 +25,7 @@ Each model file exports a Mongoose model. After renaming, add `Schema<IModelName
 
 | File | Action | Notes |
 |------|--------|-------|
-| `src/app/models/*.js` | rename to `.ts` + add types | 14 files |
+| `src/app/models/*.js` | rename to `.ts` + add types | 14+ files (count grows if feature plans merged first) |
 | `src/app/models/*.spec.js` | rename to `.spec.ts` | Matching test files |
 
 ## Implementation Steps
@@ -47,7 +47,7 @@ For each model: rename `.js` → `.ts`. Add `Schema<IModelName>` typing. Export 
 
 ## Completion Criteria
 
-- [ ] All 14 model files renamed to `.ts` with typed schemas
+- [ ] All model files renamed to `.ts` with typed schemas (14 baseline + any added by feature plans)
 - [ ] No remaining `.js` in `src/app/models/`
 - [ ] Changes committed to `plan/js-to-ts/phase-3/task-08-migrate-models` branch
 - [ ] Status updated in `status.md`


### PR DESCRIPTION
## Summary

Corrections surfaced during plan review:

- **task-00**: marked complete — Vite is already in use, no action needed
- **task-02**: `module: NodeNext` → `module: CommonJS` + `moduleResolution: node` (backend is CJS; NodeNext would break all `require()` calls immediately); added `@factories` to required `paths` entries (present in jest `moduleNameMapper` but absent from `_moduleAliases`)
- **task-08**: file count changed to "14+ files" with a note that feature plans (setores, baileys-socket-monitor, local-chat-infra) add new models — migrate all `.js` files found regardless of count
- **overview**: added sequencing guidance (Phase 3+ should run after feature plans complete, or Phase 1–2 can run in parallel); documented that tasks 12–16 can be parallelized; updated `@factories` risk note