### PR TITLE
plan(js-to-ts): create root tsconfig.json

### DIFF
--- a/.plans/js-to-ts/overview.md
+++ b/.plans/js-to-ts/overview.md
@@ -46,7 +46,7 @@ Migrate the entire codebase (backend + client) from JavaScript to TypeScript inc
 |-----------|-------|-------|--------|------------|
 | phase-0/task-00-verify-cra-to-vite-complete | Verify cra-to-vite prerequisite is complete | 0 | not-started | — |
 | phase-1/task-01-backend-ts-deps | Install backend TypeScript dependencies | 1 | not-started | — |
-| phase-1/task-02-tsconfig-root | Create root tsconfig.json | 1 | not-started | phase-1/task-01-backend-ts-deps |
+| phase-1/task-02-tsconfig-root | Create root tsconfig.json | 1 | complete | phase-1/task-01-backend-ts-deps |
 | phase-1/task-03-jest-babel-ts-transform | Configure Jest/Babel to process .ts files | 1 | not-started | phase-1/task-01-backend-ts-deps |
 | phase-1/task-04-typecheck-ci-script | Add typecheck script and verify zero TS errors | 1 | not-started | phase-1/task-02-tsconfig-root |
 | phase-2/task-05-domain-types | Create src/types/index.ts with domain enums and interfaces | 2 | not-started | phase-1/task-02-tsconfig-root |

--- a/.plans/js-to-ts/phase-1/task-02-tsconfig-root/status.md
+++ b/.plans/js-to-ts/phase-1/task-02-tsconfig-root/status.md
@@ -1,9 +1,9 @@
 # Status: Create root tsconfig.json
 
-**Current Status**: not-started
-**Last Updated**: 2026-04-28
-**Agent**: —
-**Branch**: —
+**Current Status**: complete
+**Last Updated**: 2026-05-29
+**Agent**: claude-sonnet-4-6
+**Branch**: plan/js-to-ts/phase-1/task-02-tsconfig-root
 **PR**: —
 
 ## Status History
@@ -11,6 +11,8 @@
 | Timestamp | Status | Agent | Notes |
 |-----------|--------|-------|-------|
 | 2026-04-28 | not-started | — | Task created |
+| 2026-05-29 | in-progress | claude-sonnet-4-6 | Started |
+| 2026-05-29 | complete | claude-sonnet-4-6 | tsc --noEmit exits 0; all paths wired |
 
 ## Blockers
 
@@ -22,4 +24,5 @@ None
 
 ## Adaptations
 
-None
+- `moduleResolution: "node10"` + `"ignoreDeprecations": "6.0"` — TypeScript 6 deprecates `"node"` (now `node10`) and requires explicit opt-in; keeps CJS resolution semantics intact as a migration bridge until task-27/29 when strict mode is tightened
+- `skipLibCheck: true` added — `@whiskeysockets/baileys` and `rollbar` `.d.ts` files have type errors that would block `tsc --noEmit` before any source is migrated; standard practice for incremental migrations

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,41 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": false,
+    "strict": false,
+    "noImplicitAny": false,
+    "esModuleInterop": true,
+    "module": "CommonJS",
+    "moduleResolution": "node10",
+    "ignoreDeprecations": "6.0",
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "resolveJsonModule": true,
+    "paths": {
+      "@models/*": ["./src/app/models/*"],
+      "@controllers/*": ["./src/app/controllers/*"],
+      "@routes/*": ["./src/app/routes/*"],
+      "@config/*": ["./src/config/*"],
+      "@queries/*": ["./src/app/queries/*"],
+      "@reports/*": ["./src/app/reports/*"],
+      "@helpers/*": ["./src/app/helpers/*"],
+      "@plugins/*": ["./src/app/plugins/*"],
+      "@repositories/*": ["./src/app/repositories/*"],
+      "@factories/*": ["./src/app/factories/*"]
+    }
+  },
+  "include": [
+    "src/**/*",
+    "server.js",
+    "worker.js"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "client",
+    ".jest",
+    "**/*.spec.js",
+    "**/*.spec.ts"
+  ]
+}


### PR DESCRIPTION
## Summary

- Creates `tsconfig.json` at repo root with `allowJs: true`, `checkJs: false`, `strict: false` for incremental migration
- Uses `module: CommonJS` + `moduleResolution: node10` (TypeScript 6 renamed `"node"` → `"node10"`; opts in via `ignoreDeprecations: "6.0"`)
- Adds `skipLibCheck: true` for upstream type errors in `@whiskeysockets/baileys` and `rollbar`
- `paths` maps all aliases from `_moduleAliases` plus `@factories` (jest-only alias)

## Plan

Part of [js-to-ts](/.plans/js-to-ts/overview.md) — Phase 1, task-02. Depends on task-01.

## Test plan

- [ ] `npx tsc --noEmit` passes with zero errors
- [ ] `npx jest` still passes (2756 tests)