### PR TITLE
plan(type-narrowing): Backend and Client type narrowing plans

### DIFF
--- a/.plans/README.md
+++ b/.plans/README.md
@@ -29,6 +29,8 @@ Git-native Markdown plans for multi-step work.
 | 5 | [Baileys Socket Monitor](./baileys-socket-monitor/overview.md) | `baileys-socket-monitor/` | not-started | Replace webhook-only inbound flow with a persistent Baileys socket per licensee; captures messages.upsert and messages.update natively |
 | 6 | [Local Chat Infrastructure](./local-chat-infra/overview.md) | `local-chat-infra/` | not-started | User role system (agent/supervisor/admin/super), LocalChat plugin, super licensee flow, route authorization — prerequisite for setores |
 | 7 | [Setores](./setores/overview.md) | `setores/` | not-started | Multiple WhatsApp numbers per licensee via sectors; sector-scoped message routing and agent access filtering |
+| 8 | [Backend Type Narrowing](./type-backend/overview.md) | `type-backend/` | not-started | Replace `any` with interfaces across models, repositories, use cases, controllers, and plugins — 3 phases, 11 tasks |
+| 9 | [Client Type Narrowing](./type-client/overview.md) | `type-client/` | not-started | Replace `any` with interfaces across React services, contexts, pages, and components — 2 phases, 6 tasks |
 
 ---
 

--- a/.plans/type-backend/overview.md
+++ b/.plans/type-backend/overview.md
@@ -1,0 +1,109 @@
+# Plan: Backend Type Narrowing
+
+**Status**: not-started
+**Created**: 2026-05-31
+**Last Updated**: 2026-05-31
+**Estimated Demo Date**: N/A
+**Assigned Dev**: Alan Costa Facchini
+**Assigned QA**: unassigned
+
+## Objective
+
+Replace the `any` types introduced during the JS→TS migration with specific interfaces and concrete types across the backend, working layer by layer from Mongoose models inward through repositories, use cases, controllers, and plugin boundaries.
+
+## Scope
+
+### In Scope
+- Mongoose model interfaces (`ILicensee`, `IContact`, `IMessage`, etc.) in `src/app/models/`
+- Repository method signatures (`findFirst`, `findAll`, `create`, `update`) in `src/app/repositories/`
+- Use case input/output types in `src/app/usecases/`
+- Query builder and query class types in `src/app/queries/`
+- Controller handler parameter and response types in `src/app/controllers/`
+- Messenger plugin method signatures in `src/app/plugins/messengers/`
+- Chat plugin method signatures in `src/app/plugins/chats/`
+- Helper and service utility types in `src/app/helpers/` and `src/app/services/`
+
+### Out of Scope
+- **PDV-related types (Cart, Order, Product, PagarMe)** — the `remove-pdv` plan will delete these entirely; typing them now creates wasted work. Stub with `any` and note the dependency.
+- **Client-side typing** — covered by the companion `type-client` plan.
+- **Third-party package type augmentations** — no `@types/*` packages will be installed; `src/declarations.d.ts` stubs remain.
+- **Test files** — spec files retain `any` freely; only production code is in scope.
+
+## Kill Criteria
+
+- If `remove-pdv` executes before this plan completes, reassess task-02 (transactional models) to avoid typing code slated for deletion.
+- If `mongo-to-postgres` begins before Phase 1 completes, Mongoose interfaces should be designed compatible with the Prisma migration path.
+
+## Phases
+
+| Phase | Name | Tasks | Dependencies | Description |
+|-------|------|-------|--------------|-------------|
+| 1 | Model Interfaces | task-01, task-02, task-03 | None | Define TypeScript interfaces for all Mongoose models — the foundation everything else builds on |
+| 2 | Repositories & Use Cases | task-04, task-05, task-06, task-07 | Phase 1 | Type repository method signatures and use case inputs/outputs using the interfaces from Phase 1 |
+| 3 | Controllers, Queries & Plugins | task-08, task-09, task-10, task-11 | Phase 2 | Type query classes, controllers, and plugin boundaries using repository return types from Phase 2 |
+
+## Task Summary
+
+| Task Path | Title | Phase | Status | Depends On |
+|-----------|-------|-------|--------|------------|
+| phase-1/task-01-core-model-interfaces | Core Model Interfaces | 1 | not-started | — |
+| phase-1/task-02-transactional-model-interfaces | Transactional Model Interfaces | 1 | not-started | — |
+| phase-1/task-03-system-model-interfaces | System Model Interfaces | 1 | not-started | — |
+| phase-2/task-04-core-repositories | Core Repository Types | 2 | not-started | phase-1/task-01-core-model-interfaces |
+| phase-2/task-05-remaining-repositories | Remaining Repository Types | 2 | not-started | phase-1/task-02-transactional-model-interfaces, phase-1/task-03-system-model-interfaces |
+| phase-2/task-06-message-contact-usecases | Message & Contact Use Case Types | 2 | not-started | phase-2/task-04-core-repositories |
+| phase-2/task-07-remaining-usecases | Remaining Use Case Types | 2 | not-started | phase-2/task-04-core-repositories, phase-2/task-05-remaining-repositories |
+| phase-3/task-08-queries | Query Class Types | 3 | not-started | phase-2/task-04-core-repositories, phase-2/task-05-remaining-repositories |
+| phase-3/task-09-controllers | Controller Types | 3 | not-started | phase-2/task-06-message-contact-usecases, phase-2/task-07-remaining-usecases |
+| phase-3/task-10-messenger-plugins | Messenger Plugin Types | 3 | not-started | phase-2/task-04-core-repositories |
+| phase-3/task-11-chat-plugins-helpers | Chat Plugin & Helper Types | 3 | not-started | phase-2/task-04-core-repositories |
+
+## Branch Convention
+
+Pattern: `plan/type-backend/{task-path}`
+
+Example branches:
+- `plan/type-backend/phase-1/task-01-core-model-interfaces`
+- `plan/type-backend/phase-2/task-04-core-repositories`
+- `plan/type-backend/phase-3/task-09-controllers`
+
+Base branch: `main`
+
+## Key Files
+
+| File/Directory | Relevance |
+|----------------|-----------|
+| `src/app/models/` | 15 Mongoose models — source of truth for domain shapes; Phase 1 defines interfaces here |
+| `src/app/repositories/repository.ts` | Base repository class — Phase 2 types its generic signatures |
+| `src/app/repositories/*.ts` | One file per entity — Phase 2 narrows return types |
+| `src/app/usecases/` | 10 domain subdirectories — Phase 2 types inputs and outputs |
+| `src/app/queries/` | QueryBuilder, MessagesQuery, BillingQuery, etc. — Phase 3 |
+| `src/app/controllers/` | All Express controllers — Phase 3 |
+| `src/app/plugins/messengers/` | Baileys, Dialog, YCloud, Pabbly, Wevo — Phase 3 |
+| `src/app/plugins/chats/` | Chatwoot, Crisp — Phase 3 |
+| `src/app/helpers/` | Files.ts, SanitizeErrors.ts, NormalizePhone.ts, etc. — Phase 3 |
+| `src/types/` | New directory for shared backend interfaces (created in Phase 1) |
+
+## Risks
+
+- **remove-pdv overlap** — Task-02 types Cart/Order/Product; if `remove-pdv` runs first these types become dead code. Mitigation: track `remove-pdv` status before starting task-02.
+- **mongo-to-postgres timeline** — Mongoose interfaces defined here will need to be replaced with Prisma types. Mitigation: keep interfaces in a separate `src/types/` directory for easier migration.
+- **Scope creep per task** — Each layer has 100–180 `any` occurrences. Mitigation: tasks own specific files; don't fix adjacent files not in the ownership table.
+
+## Success Criteria
+
+- [ ] All Mongoose models have a corresponding `I{Model}` interface exported from `src/types/`
+- [ ] All repository `findFirst`, `findAll`, `create`, `update` methods return typed results (no `any` in return type positions)
+- [ ] All use case `execute()` methods have typed inputs and outputs
+- [ ] All controller handlers have typed `req`, `res` parameters (no `Request<any, any, any>`)
+- [ ] Query classes have typed `filter`, `sort`, and result methods
+- [ ] Plugin `sendMessage`, `responseToMessages` methods have typed signatures
+- [ ] `npx tsc --noEmit` passes with no new errors
+- [ ] All existing tests pass
+- [ ] No regressions in existing functionality
+
+## References
+
+- **JIRA Epic**: N/A
+- **Weekly Plan Brief**: N/A
+- **Related Plans**: [JS → TypeScript](../js-to-ts/overview.md) (prerequisite, complete), [Remove PDV](../remove-pdv/overview.md) (affects task-02 scope), [MongoDB → PostgreSQL](../mongo-to-postgres/overview.md) (downstream consumer of these interfaces)

--- a/.plans/type-backend/phase-1/task-01-core-model-interfaces/status.md
+++ b/.plans/type-backend/phase-1/task-01-core-model-interfaces/status.md
@@ -1,0 +1,25 @@
+# Status: Core Model Interfaces
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-31
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-31 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/type-backend/phase-1/task-01-core-model-interfaces/task.md
+++ b/.plans/type-backend/phase-1/task-01-core-model-interfaces/task.md
@@ -1,0 +1,120 @@
+# Task: Core Model Interfaces
+
+**Plan**: Backend Type Narrowing
+**Phase**: 1
+**Task ID (phase-local)**: task-01
+**Task Path**: phase-1/task-01-core-model-interfaces
+**Depends On**: None
+**JIRA**: N/A
+
+## Objective
+
+Define TypeScript interfaces for the four core domain models — Licensee, Contact, Message, and Body — and create the `src/types/` directory that all subsequent tasks will import from.
+
+## Context
+
+The JS→TS migration introduced `any` everywhere. The foundation of narrowing the backend is giving each Mongoose document a matching TypeScript interface. These four models are referenced by almost every other layer (repositories, use cases, controllers, plugins), so they must be typed first.
+
+Mongoose document types follow the pattern: define a plain interface `ILicensee` with all fields typed, then use `mongoose.Document & ILicensee` as the document type. Export the interface from `src/types/index.ts` so downstream tasks can import from a single location.
+
+Reference models for existing field shapes:
+- `src/app/models/Licensee.ts` — ~120 lines, many enum-constrained string fields
+- `src/app/models/Contact.ts`
+- `src/app/models/Message.ts`
+- `src/app/models/Body.ts`
+
+Read `docs/kb/architecture/typescript-conventions.md` before starting.
+
+## Before You Start
+
+- [ ] Switch to main and pull: `git switch main && git pull --rebase origin main`
+- [ ] Verify `js-to-ts` plan is complete (check `status.md`)
+- [ ] Read `docs/kb/architecture/typescript-conventions.md`
+- [ ] Read `docs/kb/architecture/project-overview.md` for domain model descriptions
+- [ ] Check this task's `status.md` — if already `in-progress` or `complete`, stop and investigate
+- [ ] Mark this task `in-progress` in `status.md` before proceeding
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/types/index.ts` | create | Central export barrel — create and own this file |
+| `src/types/licensee.ts` | create | `ILicensee` interface |
+| `src/types/contact.ts` | create | `IContact` interface |
+| `src/types/message.ts` | create | `IMessage` interface |
+| `src/types/body.ts` | create | `IBody` interface |
+| `src/app/models/Licensee.ts` | modify | Import and apply `ILicensee` to schema type |
+| `src/app/models/Contact.ts` | modify | Import and apply `IContact` to schema type |
+| `src/app/models/Message.ts` | modify | Import and apply `IMessage` to schema type |
+| `src/app/models/Body.ts` | modify | Import and apply `IBody` to schema type |
+
+### Do NOT Modify
+
+- `src/app/models/Cart.ts` — owned by phase-1/task-02-transactional-model-interfaces
+- `src/app/models/Order.ts` — owned by phase-1/task-02-transactional-model-interfaces
+- `src/app/models/User.ts` — owned by phase-1/task-03-system-model-interfaces
+- `src/app/repositories/*` — Phase 2 ownership
+- `src/app/usecases/*` — Phase 2 ownership
+
+## Implementation Steps
+
+### Step 1: Create `src/types/` directory and barrel
+
+Create `src/types/index.ts` as an empty barrel — sibling tasks will add their exports to it. Own the initial file creation; task-02 and task-03 will add to it.
+
+### Step 2: Define `ILicensee`
+
+Read `src/app/models/Licensee.ts` carefully. Extract all SchemaDefinition fields into an interface. Use literal union types for enum-constrained fields (e.g., `whatsappDefault: 'dialog' | 'baileys' | 'wevo' | 'ycloud' | 'pabbly' | null`). Mark optional fields with `?`. Export from `src/types/licensee.ts` and re-export from `src/types/index.ts`.
+
+### Step 3: Define `IContact`
+
+Same process for `src/app/models/Contact.ts`. Note the `licensee` field references `ILicensee` — type it as `mongoose.Types.ObjectId | ILicensee` to support both populated and unpopulated states.
+
+### Step 4: Define `IMessage`
+
+Read `src/app/models/Message.ts`. The `contact` and `licensee` fields may be populated or ObjectId — use the union pattern. Note the `kind` enum field.
+
+### Step 5: Define `IBody`
+
+Read `src/app/models/Body.ts`. Note any references to other models.
+
+### Step 6: Apply interfaces to Mongoose schemas
+
+In each model file, update the schema/model declaration to use the interface:
+```ts
+const LicenseeSchema = new mongoose.Schema<ILicensee>({ ... })
+export default mongoose.model<ILicensee>('Licensee', LicenseeSchema)
+```
+
+Keep all existing validators and hooks — only change the type annotations.
+
+### Step 7: Typecheck
+
+Run `npx tsc --noEmit` and fix any errors introduced. Do not fix errors in files outside your ownership table.
+
+## Testing
+
+- [ ] `npx tsc --noEmit` passes with no new errors
+- [ ] `NODE_ENV=test npx jest --testPathPattern="models/(Licensee|Contact|Message|Body)" --no-coverage` — all pass
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] Update `docs/kb/architecture/typescript-conventions.md` to document the `src/types/` pattern and interface naming convention (`I{Model}`)
+- [ ] Run `check-kb-index` after updating the KB file
+
+## Completion Criteria
+
+- [ ] `src/types/` directory created with `index.ts` barrel
+- [ ] `ILicensee`, `IContact`, `IMessage`, `IBody` interfaces defined and exported
+- [ ] Mongoose models typed with their interfaces
+- [ ] No `any` in return type positions of the 4 modified model files
+- [ ] All model tests pass
+- [ ] `npx tsc --noEmit` clean
+- [ ] Status updated in `status.md`
+- [ ] Changes committed to `plan/type-backend/phase-1/task-01-core-model-interfaces`
+
+## Conflict Avoidance Notes
+
+- Task-02 and task-03 will add entries to `src/types/index.ts`. Coordinate by only adding exports for your own interfaces — do not touch other interface files.
+- If task-02 or task-03 need to reference `ILicensee` or `IContact` before this task merges, they should import a stub from this task's branch or use `any` temporarily.

--- a/.plans/type-backend/phase-1/task-02-transactional-model-interfaces/status.md
+++ b/.plans/type-backend/phase-1/task-02-transactional-model-interfaces/status.md
@@ -1,0 +1,25 @@
+# Status: Transactional Model Interfaces
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-31
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-31 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/type-backend/phase-1/task-02-transactional-model-interfaces/task.md
+++ b/.plans/type-backend/phase-1/task-02-transactional-model-interfaces/task.md
@@ -1,0 +1,102 @@
+# Task: Transactional Model Interfaces
+
+**Plan**: Backend Type Narrowing
+**Phase**: 1
+**Task ID (phase-local)**: task-02
+**Task Path**: phase-1/task-02-transactional-model-interfaces
+**Depends On**: None
+**JIRA**: N/A
+
+## Objective
+
+Define TypeScript interfaces for the transactional domain models — Cart, Order, Product, Room, and Trigger — and add them to `src/types/index.ts`.
+
+## Context
+
+These models represent the PDV (point-of-sale) and chat session domains. **Important**: the `remove-pdv` plan will eventually delete Cart, Order, Product, and PagarMe-related code. Before starting this task, check whether `remove-pdv` has begun execution — if so, skip Cart/Order/Product and note the adaptation in `status.md`.
+
+Room is the chat session model and is NOT part of remove-pdv. Trigger drives chatbot flow logic and is also permanent.
+
+Reference models:
+- `src/app/models/Cart.ts`
+- `src/app/models/Order.ts`
+- `src/app/models/Product.ts`
+- `src/app/models/Room.ts`
+- `src/app/models/Trigger.ts`
+
+## Before You Start
+
+- [ ] Switch to main and pull: `git switch main && git pull --rebase origin main`
+- [ ] **Check `remove-pdv` plan status** — if it is `in-progress` or `complete`, skip Cart, Order, Product interfaces and note the adaptation
+- [ ] Read `docs/kb/architecture/typescript-conventions.md`
+- [ ] Verify task-01 (`phase-1/task-01-core-model-interfaces`) status — if complete, import from `src/types/index.ts` as needed; if not, stub cross-references with `any`
+- [ ] Check this task's `status.md` — if already `in-progress` or `complete`, stop and investigate
+- [ ] Mark this task `in-progress` in `status.md` before proceeding
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/types/cart.ts` | create | `ICart` interface (skip if remove-pdv in progress) |
+| `src/types/order.ts` | create | `IOrder` interface (skip if remove-pdv in progress) |
+| `src/types/product.ts` | create | `IProduct` interface (skip if remove-pdv in progress) |
+| `src/types/room.ts` | create | `IRoom` interface |
+| `src/types/trigger.ts` | create | `ITrigger` interface |
+| `src/types/index.ts` | modify | Add exports for new interfaces |
+| `src/app/models/Cart.ts` | modify | Apply `ICart` (skip if remove-pdv in progress) |
+| `src/app/models/Order.ts` | modify | Apply `IOrder` (skip if remove-pdv in progress) |
+| `src/app/models/Product.ts` | modify | Apply `IProduct` (skip if remove-pdv in progress) |
+| `src/app/models/Room.ts` | modify | Apply `IRoom` |
+| `src/app/models/Trigger.ts` | modify | Apply `ITrigger` |
+
+### Do NOT Modify
+
+- `src/types/licensee.ts`, `src/types/contact.ts`, `src/types/message.ts`, `src/types/body.ts` — owned by phase-1/task-01
+- `src/app/models/Licensee.ts`, `src/app/models/Contact.ts`, `src/app/models/Message.ts`, `src/app/models/Body.ts` — owned by phase-1/task-01
+- `src/app/models/User.ts`, `src/app/models/Template.ts` — owned by phase-1/task-03
+
+## Implementation Steps
+
+### Step 1: Check remove-pdv status
+
+If `remove-pdv` is `in-progress` or `complete`, skip Cart/Order/Product and document in `status.md`.
+
+### Step 2: Define interfaces
+
+For each model in scope, read the schema definition and produce a matching interface in `src/types/{model}.ts`. Use union types for enum fields. Use `mongoose.Types.ObjectId | IRelated` for reference fields.
+
+### Step 3: Apply to Mongoose schemas
+
+Update each model file to pass the interface as the generic parameter to `Schema` and `model`.
+
+### Step 4: Export from barrel
+
+Add each new interface to `src/types/index.ts`.
+
+### Step 5: Typecheck
+
+Run `npx tsc --noEmit` and fix errors only within owned files.
+
+## Testing
+
+- [ ] `npx tsc --noEmit` passes with no new errors
+- [ ] `NODE_ENV=test npx jest --testPathPattern="models/(Cart|Order|Product|Room|Trigger)" --no-coverage` — all pass
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] No KB/doc updates required for this task (pattern established by task-01)
+
+## Completion Criteria
+
+- [ ] Interfaces defined for all in-scope models (noting any skipped due to remove-pdv)
+- [ ] Mongoose models typed with their interfaces
+- [ ] `src/types/index.ts` updated with new exports
+- [ ] All relevant model tests pass
+- [ ] `npx tsc --noEmit` clean
+- [ ] Status updated in `status.md`
+- [ ] Changes committed to `plan/type-backend/phase-1/task-02-transactional-model-interfaces`
+
+## Conflict Avoidance Notes
+
+- Only append to `src/types/index.ts` — do not modify exports added by task-01 or task-03.

--- a/.plans/type-backend/phase-1/task-03-system-model-interfaces/status.md
+++ b/.plans/type-backend/phase-1/task-03-system-model-interfaces/status.md
@@ -1,0 +1,25 @@
+# Status: System Model Interfaces
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-31
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-31 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/type-backend/phase-1/task-03-system-model-interfaces/task.md
+++ b/.plans/type-backend/phase-1/task-03-system-model-interfaces/task.md
@@ -1,0 +1,100 @@
+# Task: System Model Interfaces
+
+**Plan**: Backend Type Narrowing
+**Phase**: 1
+**Task ID (phase-local)**: task-03
+**Task Path**: phase-1/task-03-system-model-interfaces
+**Depends On**: None
+**JIRA**: N/A
+
+## Objective
+
+Define TypeScript interfaces for the infrastructure/system models — User, Template, Backgroundjob, Integrationlog, Trafficlight, and WhatsappSession — and add them to `src/types/index.ts`.
+
+## Context
+
+These models support the application infrastructure rather than the business domain. WhatsappSession is used by the Baileys plugin for QR code authentication persistence. Backgroundjob tracks async job state. Integrationlog records third-party API call history. Trafficlight manages chatbot flow control. Template stores WhatsApp message templates.
+
+Reference models:
+- `src/app/models/User.ts`
+- `src/app/models/Template.ts`
+- `src/app/models/Backgroundjob.ts`
+- `src/app/models/Integrationlog.ts`
+- `src/app/models/Trafficlight.ts`
+- `src/app/models/WhatsappSession.ts`
+
+## Before You Start
+
+- [ ] Switch to main and pull: `git switch main && git pull --rebase origin main`
+- [ ] Read `docs/kb/architecture/typescript-conventions.md`
+- [ ] Verify task-01 status — if complete, import `ILicensee` as needed; if not, stub with `any`
+- [ ] Check this task's `status.md` — if already `in-progress` or `complete`, stop and investigate
+- [ ] Mark this task `in-progress` in `status.md` before proceeding
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/types/user.ts` | create | `IUser` interface |
+| `src/types/template.ts` | create | `ITemplate` interface |
+| `src/types/backgroundjob.ts` | create | `IBackgroundjob` interface |
+| `src/types/integrationlog.ts` | create | `IIntegrationlog` interface |
+| `src/types/trafficlight.ts` | create | `ITrafficlight` interface |
+| `src/types/whatsappsession.ts` | create | `IWhatsappSession` interface |
+| `src/types/index.ts` | modify | Add exports for new interfaces |
+| `src/app/models/User.ts` | modify | Apply `IUser` |
+| `src/app/models/Template.ts` | modify | Apply `ITemplate` |
+| `src/app/models/Backgroundjob.ts` | modify | Apply `IBackgroundjob` |
+| `src/app/models/Integrationlog.ts` | modify | Apply `IIntegrationlog` |
+| `src/app/models/Trafficlight.ts` | modify | Apply `ITrafficlight` |
+| `src/app/models/WhatsappSession.ts` | modify | Apply `IWhatsappSession` |
+
+### Do NOT Modify
+
+- `src/types/licensee.ts`, `src/types/contact.ts`, `src/types/message.ts`, `src/types/body.ts` — owned by phase-1/task-01
+- `src/types/cart.ts`, `src/types/order.ts`, `src/types/product.ts`, `src/types/room.ts`, `src/types/trigger.ts` — owned by phase-1/task-02
+- `src/app/models/Licensee.ts`, `src/app/models/Contact.ts`, `src/app/models/Message.ts`, `src/app/models/Body.ts` — owned by phase-1/task-01
+
+## Implementation Steps
+
+### Step 1: Define interfaces
+
+For each model in scope, read the schema definition and produce a matching interface. Pay special attention to:
+- `IUser` — has `validPassword(password: string): Promise<boolean>` instance method; include it in the interface
+- `IWhatsappSession` — used by Baileys plugin; read `docs/kb/features/baileys-whatsapp-guide.md` for context on fields
+- `ITemplate` — has `namespace`, `name`, `licensee` fields and template components
+
+### Step 2: Apply to Mongoose schemas
+
+Update each model file to pass the interface as the generic parameter.
+
+### Step 3: Export from barrel
+
+Add each new interface to `src/types/index.ts`.
+
+### Step 4: Typecheck
+
+Run `npx tsc --noEmit` and fix errors only within owned files.
+
+## Testing
+
+- [ ] `npx tsc --noEmit` passes with no new errors
+- [ ] `NODE_ENV=test npx jest --testPathPattern="models/(User|Template|Backgroundjob|Integrationlog)" --no-coverage` — all pass
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] No KB/doc updates required (pattern established by task-01)
+
+## Completion Criteria
+
+- [ ] All 6 system model interfaces defined and exported from `src/types/`
+- [ ] Mongoose models typed with their interfaces
+- [ ] `npx tsc --noEmit` clean
+- [ ] All relevant model tests pass
+- [ ] Status updated in `status.md`
+- [ ] Changes committed to `plan/type-backend/phase-1/task-03-system-model-interfaces`
+
+## Conflict Avoidance Notes
+
+- Only append to `src/types/index.ts` — do not modify exports added by task-01 or task-02.

--- a/.plans/type-backend/phase-2/task-04-core-repositories/status.md
+++ b/.plans/type-backend/phase-2/task-04-core-repositories/status.md
@@ -1,0 +1,25 @@
+# Status: Core Repository Types
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-31
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-31 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/type-backend/phase-2/task-04-core-repositories/task.md
+++ b/.plans/type-backend/phase-2/task-04-core-repositories/task.md
@@ -1,0 +1,90 @@
+# Task: Core Repository Types
+
+**Plan**: Backend Type Narrowing
+**Phase**: 2
+**Task ID (phase-local)**: task-04
+**Task Path**: phase-2/task-04-core-repositories
+**Depends On**: phase-1/task-01-core-model-interfaces
+**JIRA**: N/A
+
+## Objective
+
+Type the base `Repository` class and the core entity repositories (licensee, contact, message, body) using the interfaces from Phase 1. Replace `any` in method signatures with concrete types.
+
+## Context
+
+`src/app/repositories/repository.ts` defines the base `Repository` and `RepositoryMemory` classes used by all concrete repos. It has generic CRUD methods (`findFirst`, `findAll`, `create`, `update`, `delete`) that currently return `any`. Making these generic will propagate types automatically to all subclasses.
+
+Core repos to type: `licensee.ts`, `contact.ts`, `message.ts`, `body.ts`.
+
+Read `docs/kb/architecture/dependency-injection-runtime-wiring.md` — it explains how repos are injected into use cases and controllers.
+
+## Before You Start
+
+- [ ] Switch to main and pull: `git switch main && git pull --rebase origin main`
+- [ ] Verify `phase-1/task-01-core-model-interfaces` status is `complete` — confirm `src/types/licensee.ts`, `src/types/contact.ts`, `src/types/message.ts`, `src/types/body.ts` exist
+- [ ] Read `docs/kb/architecture/dependency-injection-runtime-wiring.md`
+- [ ] Read `src/app/repositories/repository.ts` fully before making changes
+- [ ] Check this task's `status.md` — if already `in-progress` or `complete`, stop and investigate
+- [ ] Mark this task `in-progress` in `status.md` before proceeding
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/app/repositories/repository.ts` | modify | Make base class generic; define `IRepository<T>` interface |
+| `src/app/repositories/licensee.ts` | modify | Type methods with `ILicensee` |
+| `src/app/repositories/contact.ts` | modify | Type methods with `IContact` |
+| `src/app/repositories/message.ts` | modify | Type methods with `IMessage` |
+| `src/app/repositories/body.ts` | modify | Type methods with `IBody` |
+
+### Do NOT Modify
+
+- `src/app/repositories/cart.ts`, `src/app/repositories/order.ts`, `src/app/repositories/product.ts` — owned by phase-2/task-05
+- `src/app/repositories/room.ts`, `src/app/repositories/trigger.ts`, `src/app/repositories/user.ts` — owned by phase-2/task-05
+- `src/app/usecases/*` — Phase 2 task-06/task-07 ownership
+- `src/app/controllers/*` — Phase 3 ownership
+
+## Implementation Steps
+
+### Step 1: Make the base Repository generic
+
+In `repository.ts`, introduce a generic type parameter `T` on the class. Update `findFirst`, `findAll`, `create`, `update` to return `Promise<T | null>`, `Promise<T[]>`, `Promise<T>` etc. as appropriate. Preserve the existing `RepositoryMemory` class structure.
+
+Define and export an `IRepository<T>` interface that describes the public API — this is what use cases and controllers depend on.
+
+### Step 2: Type core repositories
+
+For each repo, extend the generic base with the appropriate type parameter:
+```ts
+class LicenseeRepositoryDatabase extends Repository<ILicensee> { ... }
+```
+
+Add typed method overrides only where the base return type isn't precise enough.
+
+### Step 3: Type memory repositories
+
+Update any in-memory repo implementations (used in tests) with the same generic parameter.
+
+### Step 4: Typecheck
+
+Run `npx tsc --noEmit`. Expect some errors in use cases and controllers — those are Phase 3. Suppress with `as any` temporarily only if they block compilation, and document in status.md.
+
+## Testing
+
+- [ ] `npx tsc --noEmit` passes (or remaining errors are only in Phase 3 files — document which)
+- [ ] `NODE_ENV=test npx jest --testPathPattern="repositories/(licensee|contact|message|body)" --no-coverage` — all pass
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] No KB/doc updates required
+
+## Completion Criteria
+
+- [ ] `IRepository<T>` interface exported from `src/app/repositories/repository.ts`
+- [ ] Base Repository class is generic
+- [ ] licensee, contact, message, body repos typed
+- [ ] All relevant repository tests pass
+- [ ] Status updated in `status.md`
+- [ ] Changes committed to `plan/type-backend/phase-2/task-04-core-repositories`

--- a/.plans/type-backend/phase-2/task-05-remaining-repositories/status.md
+++ b/.plans/type-backend/phase-2/task-05-remaining-repositories/status.md
@@ -1,0 +1,25 @@
+# Status: Remaining Repository Types
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-31
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-31 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/type-backend/phase-2/task-05-remaining-repositories/task.md
+++ b/.plans/type-backend/phase-2/task-05-remaining-repositories/task.md
@@ -1,0 +1,68 @@
+# Task: Remaining Repository Types
+
+**Plan**: Backend Type Narrowing
+**Phase**: 2
+**Task ID (phase-local)**: task-05
+**Task Path**: phase-2/task-05-remaining-repositories
+**Depends On**: phase-1/task-02-transactional-model-interfaces, phase-1/task-03-system-model-interfaces
+**JIRA**: N/A
+
+## Objective
+
+Type the remaining repositories (room, trigger, template, cart, order, product, user, backgroundjob, integrationlog, whatsappsession, messenger) using the interfaces from Phase 1 tasks 02 and 03.
+
+## Context
+
+Depends on task-04 for the generic base `IRepository<T>` and `Repository<T>` class. Once task-04 is merged, these repos just need the appropriate type parameter applied.
+
+**Note on PDV repos**: Check `remove-pdv` plan status. If it is `in-progress` or `complete`, skip cart, order, product repositories.
+
+## Before You Start
+
+- [ ] Switch to main and pull: `git switch main && git pull --rebase origin main`
+- [ ] Verify `phase-1/task-02-transactional-model-interfaces` and `phase-1/task-03-system-model-interfaces` are `complete`
+- [ ] Verify `phase-2/task-04-core-repositories` is `complete` — the generic base must exist
+- [ ] **Check `remove-pdv` status** — if in-progress/complete, skip cart/order/product repos
+- [ ] Check this task's `status.md` and mark `in-progress` before proceeding
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/app/repositories/room.ts` | modify | Type with `IRoom` |
+| `src/app/repositories/trigger.ts` | modify | Type with `ITrigger` |
+| `src/app/repositories/template.ts` | modify | Type with `ITemplate` |
+| `src/app/repositories/user.ts` | modify | Type with `IUser` |
+| `src/app/repositories/backgroundjob.ts` | modify | Type with `IBackgroundjob` |
+| `src/app/repositories/integrationlog.ts` | modify | Type with `IIntegrationlog` |
+| `src/app/repositories/whatsappsession.ts` | modify | Type with `IWhatsappSession` |
+| `src/app/repositories/messenger.ts` | modify | Type with appropriate interface |
+| `src/app/repositories/cart.ts` | modify | Type with `ICart` (skip if remove-pdv active) |
+| `src/app/repositories/order.ts` | modify | Type with `IOrder` (skip if remove-pdv active) |
+| `src/app/repositories/product.ts` | modify | Type with `IProduct` (skip if remove-pdv active) |
+
+### Do NOT Modify
+
+- `src/app/repositories/repository.ts`, `src/app/repositories/licensee.ts`, `src/app/repositories/contact.ts`, `src/app/repositories/message.ts`, `src/app/repositories/body.ts` — owned by phase-2/task-04
+
+## Implementation Steps
+
+Apply the generic `Repository<T>` base class pattern from task-04 to each remaining repository. The pattern is consistent — read task-04's implementation for reference before starting.
+
+## Testing
+
+- [ ] `npx tsc --noEmit` passes
+- [ ] `NODE_ENV=test npx jest --testPathPattern="repositories/(room|trigger|template|user)" --no-coverage` — all pass
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] No KB/doc updates required
+
+## Completion Criteria
+
+- [ ] All in-scope repositories typed (noting skipped PDV repos)
+- [ ] All relevant repository tests pass
+- [ ] `npx tsc --noEmit` clean
+- [ ] Status updated in `status.md`
+- [ ] Changes committed to `plan/type-backend/phase-2/task-05-remaining-repositories`

--- a/.plans/type-backend/phase-2/task-06-message-contact-usecases/status.md
+++ b/.plans/type-backend/phase-2/task-06-message-contact-usecases/status.md
@@ -1,0 +1,25 @@
+# Status: Message & Contact Use Case Types
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-31
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-31 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/type-backend/phase-2/task-06-message-contact-usecases/task.md
+++ b/.plans/type-backend/phase-2/task-06-message-contact-usecases/task.md
@@ -1,0 +1,75 @@
+# Task: Message & Contact Use Case Types
+
+**Plan**: Backend Type Narrowing
+**Phase**: 2
+**Task ID (phase-local)**: task-06
+**Task Path**: phase-2/task-06-message-contact-usecases
+**Depends On**: phase-2/task-04-core-repositories
+**JIRA**: N/A
+
+## Objective
+
+Type the message and contact use case classes — their constructor parameters, `execute()` inputs, and return values — using the typed repositories and interfaces from Phase 1.
+
+## Context
+
+Use cases in `src/app/usecases/messages/` and `src/app/usecases/contacts/` are the highest-traffic domain layer. They receive repository instances via dependency injection (read `docs/kb/architecture/dependency-injection-runtime-wiring.md`).
+
+The pattern: use case constructors accept `{ licenseeRepository: IRepository<ILicensee>, messageRepository: IRepository<IMessage>, ... }` — type these dependency objects. The `execute()` method's input shape and return type should be explicit.
+
+## Before You Start
+
+- [ ] Switch to main and pull: `git switch main && git pull --rebase origin main`
+- [ ] Verify `phase-2/task-04-core-repositories` is `complete`
+- [ ] Read `docs/kb/architecture/dependency-injection-runtime-wiring.md`
+- [ ] Check this task's `status.md` and mark `in-progress` before proceeding
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/app/usecases/messages/` | modify all | Type all use case classes in this directory |
+| `src/app/usecases/contacts/` | modify all | Type all use case classes in this directory |
+| `src/app/usecases/webhooks/` | modify all | Webhook use cases that process messages |
+
+### Do NOT Modify
+
+- `src/app/usecases/licensees/` — owned by phase-2/task-07
+- `src/app/usecases/users/`, `src/app/usecases/auth/` — owned by phase-2/task-07
+- `src/app/usecases/triggers/`, `src/app/usecases/carts/`, `src/app/usecases/orders/` — owned by phase-2/task-07
+
+## Implementation Steps
+
+### Step 1: Define use case dependency types
+
+For each use case class, replace the `{ licenseeRepository: any, messageRepository: any }` constructor param with a typed object. Use `IRepository<ILicensee>` etc. from task-04.
+
+### Step 2: Type execute() inputs and outputs
+
+Replace `execute(input: any)` with a typed interface. Define the input shape inline or as a named type in the same file. Return types should be specific (e.g., `Promise<IMessage | null>`).
+
+### Step 3: Type internal variables
+
+Where local variables are typed as `any` via assignment from repo calls, the type should now flow automatically from the typed repository. Remove explicit `any` annotations.
+
+### Step 4: Typecheck
+
+`npx tsc --noEmit`. Fix errors only within owned files.
+
+## Testing
+
+- [ ] `npx tsc --noEmit` passes
+- [ ] `NODE_ENV=test npx jest --testPathPattern="usecases/(messages|contacts|webhooks)" --no-coverage` — all pass
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] No KB/doc updates required
+
+## Completion Criteria
+
+- [ ] All message, contact, and webhook use case classes typed
+- [ ] No `any` in constructor dependency params or `execute()` signatures
+- [ ] All use case tests pass
+- [ ] Status updated in `status.md`
+- [ ] Changes committed to `plan/type-backend/phase-2/task-06-message-contact-usecases`

--- a/.plans/type-backend/phase-2/task-07-remaining-usecases/status.md
+++ b/.plans/type-backend/phase-2/task-07-remaining-usecases/status.md
@@ -1,0 +1,25 @@
+# Status: Remaining Use Case Types
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-31
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-31 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/type-backend/phase-2/task-07-remaining-usecases/task.md
+++ b/.plans/type-backend/phase-2/task-07-remaining-usecases/task.md
@@ -1,0 +1,70 @@
+# Task: Remaining Use Case Types
+
+**Plan**: Backend Type Narrowing
+**Phase**: 2
+**Task ID (phase-local)**: task-07
+**Task Path**: phase-2/task-07-remaining-usecases
+**Depends On**: phase-2/task-04-core-repositories, phase-2/task-05-remaining-repositories
+**JIRA**: N/A
+
+## Objective
+
+Type the remaining use case classes — licensees, users, auth, triggers, backgroundjobs, orders, and carts — using the typed repositories from Phase 2.
+
+## Context
+
+Same pattern as task-06. Constructor dependency injection params and `execute()` signatures replace `any` with typed interfaces. PDV use cases (orders, carts) should be skipped if `remove-pdv` is active.
+
+Directories in scope:
+- `src/app/usecases/licensees/`
+- `src/app/usecases/users/`
+- `src/app/usecases/auth/`
+- `src/app/usecases/triggers/`
+- `src/app/usecases/backgroundjobs/`
+- `src/app/usecases/orders/` (skip if remove-pdv active)
+- `src/app/usecases/carts/` (skip if remove-pdv active)
+
+## Before You Start
+
+- [ ] Switch to main and pull: `git switch main && git pull --rebase origin main`
+- [ ] Verify `phase-2/task-04-core-repositories` and `phase-2/task-05-remaining-repositories` are `complete`
+- [ ] **Check `remove-pdv` status** — skip orders/carts if in-progress or complete
+- [ ] Read task-06 implementation for the use case typing pattern before starting
+- [ ] Check this task's `status.md` and mark `in-progress` before proceeding
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/app/usecases/licensees/` | modify all | All licensee use cases |
+| `src/app/usecases/users/` | modify all | All user use cases |
+| `src/app/usecases/auth/` | modify all | Auth use cases |
+| `src/app/usecases/triggers/` | modify all | Trigger use cases |
+| `src/app/usecases/backgroundjobs/` | modify all | Background job use cases |
+| `src/app/usecases/orders/` | modify all | Skip if remove-pdv active |
+| `src/app/usecases/carts/` | modify all | Skip if remove-pdv active |
+
+### Do NOT Modify
+
+- `src/app/usecases/messages/`, `src/app/usecases/contacts/`, `src/app/usecases/webhooks/` — owned by phase-2/task-06
+
+## Implementation Steps
+
+Apply the same pattern established in task-06: type constructor dependency params and `execute()` signatures. Follow the convention from task-06 for consistency.
+
+## Testing
+
+- [ ] `npx tsc --noEmit` passes
+- [ ] `NODE_ENV=test npx jest --testPathPattern="usecases/(licensees|users|auth|triggers)" --no-coverage` — all pass
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] No KB/doc updates required
+
+## Completion Criteria
+
+- [ ] All in-scope use case classes typed (noting skipped PDV ones)
+- [ ] All use case tests pass
+- [ ] Status updated in `status.md`
+- [ ] Changes committed to `plan/type-backend/phase-2/task-07-remaining-usecases`

--- a/.plans/type-backend/phase-3/task-08-queries/status.md
+++ b/.plans/type-backend/phase-3/task-08-queries/status.md
@@ -1,0 +1,25 @@
+# Status: Query Class Types
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-31
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-31 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/type-backend/phase-3/task-08-queries/task.md
+++ b/.plans/type-backend/phase-3/task-08-queries/task.md
@@ -1,0 +1,77 @@
+# Task: Query Class Types
+
+**Plan**: Backend Type Narrowing
+**Phase**: 3
+**Task ID (phase-local)**: task-08
+**Task Path**: phase-3/task-08-queries
+**Depends On**: phase-2/task-04-core-repositories, phase-2/task-05-remaining-repositories
+**JIRA**: N/A
+
+## Objective
+
+Type all query classes in `src/app/queries/` — QueryBuilder, MessagesQuery, BillingQuery, LicenseeMessagesByDayQuery, and any others — replacing `any` in filter, sort, and result methods.
+
+## Context
+
+The query layer sits between repositories and controllers, building Mongoose query chains. `QueryBuilder` is the base class. Key `any` hotspots: filter method params (150 occurrences across queries directory), the `all()` return type, and builder method chaining.
+
+Files in scope:
+- `src/app/queries/QueryBuilder.ts`
+- `src/app/queries/MessagesQuery.ts`
+- `src/app/queries/BillingQuery.ts`
+- `src/app/queries/LicenseeMessagesByDayQuery.ts`
+- any other `*Query.ts` files in the directory
+
+## Before You Start
+
+- [ ] Switch to main and pull: `git switch main && git pull --rebase origin main`
+- [ ] Verify `phase-2/task-04-core-repositories` and `phase-2/task-05-remaining-repositories` are `complete`
+- [ ] `ls src/app/queries/` to confirm the full list of query files
+- [ ] Check this task's `status.md` and mark `in-progress` before proceeding
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/app/queries/QueryBuilder.ts` | modify | Make generic; define `IQueryBuilder<T>` |
+| `src/app/queries/MessagesQuery.ts` | modify | Type filters and `all()` return |
+| `src/app/queries/BillingQuery.ts` | modify | Type date params and result shape |
+| `src/app/queries/LicenseeMessagesByDayQuery.ts` | modify | Type result shape |
+| `src/app/queries/*.ts` (remaining) | modify | Same pattern |
+
+### Do NOT Modify
+
+- `src/app/controllers/*` — owned by phase-3/task-09
+- `src/app/repositories/*` — Phase 2 ownership (complete)
+
+## Implementation Steps
+
+### Step 1: Make QueryBuilder generic
+
+Introduce a type parameter `T` for the model being queried. Type the Mongoose query chain internals. Export `IQueryBuilder<T>` interface.
+
+### Step 2: Type individual query classes
+
+For each query class, extend `QueryBuilder<IMessage>` (or appropriate interface). Type filter method params (e.g., `filterByContact(contactId: mongoose.Types.ObjectId | string)`). Type the `all()` return as `Promise<IMessage[]>`.
+
+### Step 3: Typecheck and fix
+
+Run `npx tsc --noEmit`. Fix only files in the ownership table.
+
+## Testing
+
+- [ ] `npx tsc --noEmit` passes
+- [ ] `NODE_ENV=test npx jest --testPathPattern="queries/" --no-coverage` — all pass
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] No KB/doc updates required
+
+## Completion Criteria
+
+- [ ] `QueryBuilder` is generic
+- [ ] All query classes have typed filter methods and typed `all()` return
+- [ ] All query tests pass
+- [ ] Status updated in `status.md`
+- [ ] Changes committed to `plan/type-backend/phase-3/task-08-queries`

--- a/.plans/type-backend/phase-3/task-09-controllers/status.md
+++ b/.plans/type-backend/phase-3/task-09-controllers/status.md
@@ -1,0 +1,25 @@
+# Status: Controller Types
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-31
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-31 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/type-backend/phase-3/task-09-controllers/task.md
+++ b/.plans/type-backend/phase-3/task-09-controllers/task.md
@@ -1,0 +1,77 @@
+# Task: Controller Types
+
+**Plan**: Backend Type Narrowing
+**Phase**: 3
+**Task ID (phase-local)**: task-09
+**Task Path**: phase-3/task-09-controllers
+**Depends On**: phase-2/task-06-message-contact-usecases, phase-2/task-07-remaining-usecases
+**JIRA**: N/A
+
+## Objective
+
+Type all Express controllers in `src/app/controllers/`, replacing `any` on `req`, `res`, and use case dependency params with concrete types.
+
+## Context
+
+Controllers are the thinnest layer — they validate, call a use case, and respond. The 182 `any` occurrences here are mostly `req: any`, `res: any`, and `dependencies: any` constructor params.
+
+Use `Request`, `Response` from `express` for handler parameters. Type the dependency injection object using the typed use case classes from Phase 2.
+
+Read `docs/kb/architecture/express-conventions.md` before starting.
+
+Files: all `*Controller.ts` in `src/app/controllers/`.
+
+## Before You Start
+
+- [ ] Switch to main and pull: `git switch main && git pull --rebase origin main`
+- [ ] Verify `phase-2/task-06-message-contact-usecases` and `phase-2/task-07-remaining-usecases` are `complete`
+- [ ] Read `docs/kb/architecture/express-conventions.md`
+- [ ] `ls src/app/controllers/` to confirm the full file list
+- [ ] Check this task's `status.md` and mark `in-progress` before proceeding
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/app/controllers/*.ts` | modify all | All controller files |
+
+### Do NOT Modify
+
+- `src/app/usecases/*` — Phase 2 ownership (complete)
+- `src/app/routes/*` — not in scope for this task (route mounting is already typed via express)
+
+## Implementation Steps
+
+### Step 1: Type req and res
+
+Replace `req: any, res: any` with `req: Request, res: Response` from express. Use `req.body as IMyRequestBody` where body shape is known, or define request body interfaces inline.
+
+### Step 2: Type dependency injection params
+
+Replace `{ messageRepository: any, licenseeRepository: any }` constructor params with the typed interfaces from Phase 2 use cases.
+
+### Step 3: Type internal variables
+
+Local variables that previously needed `as any` to call model methods should now type-flow from the use case return types.
+
+### Step 4: Typecheck
+
+`npx tsc --noEmit`. Fix only controller files.
+
+## Testing
+
+- [ ] `npx tsc --noEmit` passes
+- [ ] `NODE_ENV=test npx jest --testPathPattern="controllers/" --no-coverage` — all pass
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] Update `docs/kb/architecture/express-conventions.md` to document the request body typing pattern if a reusable pattern is established
+
+## Completion Criteria
+
+- [ ] All controllers use `Request` / `Response` instead of `any`
+- [ ] All constructor dependency params typed
+- [ ] All controller tests pass
+- [ ] Status updated in `status.md`
+- [ ] Changes committed to `plan/type-backend/phase-3/task-09-controllers`

--- a/.plans/type-backend/phase-3/task-10-messenger-plugins/status.md
+++ b/.plans/type-backend/phase-3/task-10-messenger-plugins/status.md
@@ -1,0 +1,25 @@
+# Status: Messenger Plugin Types
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-31
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-31 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/type-backend/phase-3/task-10-messenger-plugins/task.md
+++ b/.plans/type-backend/phase-3/task-10-messenger-plugins/task.md
@@ -1,0 +1,87 @@
+# Task: Messenger Plugin Types
+
+**Plan**: Backend Type Narrowing
+**Phase**: 3
+**Task ID (phase-local)**: task-10
+**Task Path**: phase-3/task-10-messenger-plugins
+**Depends On**: phase-2/task-04-core-repositories
+**JIRA**: N/A
+
+## Objective
+
+Type the messenger plugin classes in `src/app/plugins/messengers/` — Baileys, Dialog, YCloud, Pabbly, Wevo — replacing `any` in method signatures, webhook payload types, and internal processing methods.
+
+## Context
+
+Messenger plugins receive inbound webhook payloads and convert them to `IMessage` objects, and send outbound messages given an `IMessage`. The 140 `any` occurrences here are split between payload parsing and method signatures.
+
+Key pattern: define interfaces for each provider's webhook payload shape (e.g., `IDialogWebhookPayload`, `IYCloudWebhookPayload`) and use them as input types for `responseToMessages()`. The `sendMessage()` method takes `(messageId: string, url: string)` or similar — make the signature concrete.
+
+Read `docs/kb/features/baileys-whatsapp-guide.md` before touching Baileys.ts.
+
+Files:
+- `src/app/plugins/messengers/Baileys.ts`
+- `src/app/plugins/messengers/Dialog.ts`
+- `src/app/plugins/messengers/YCloud.ts`
+- `src/app/plugins/messengers/Pabbly.ts`
+- `src/app/plugins/messengers/Wevo.ts` (if exists)
+- `src/app/plugins/messengers/Base.ts` (if exists)
+
+## Before You Start
+
+- [ ] Switch to main and pull: `git switch main && git pull --rebase origin main`
+- [ ] Verify `phase-2/task-04-core-repositories` is `complete`
+- [ ] Read `docs/kb/features/baileys-whatsapp-guide.md`
+- [ ] `ls src/app/plugins/messengers/` to confirm full file list
+- [ ] Check this task's `status.md` and mark `in-progress` before proceeding
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/app/plugins/messengers/Base.ts` | modify | Define `IMessengerPlugin` interface |
+| `src/app/plugins/messengers/Baileys.ts` | modify | Type socket events, message handlers |
+| `src/app/plugins/messengers/Dialog.ts` | modify | Type webhook payload and send params |
+| `src/app/plugins/messengers/YCloud.ts` | modify | Type webhook payload and send params |
+| `src/app/plugins/messengers/Pabbly.ts` | modify | Type webhook payload and send params |
+| `src/app/plugins/messengers/Wevo.ts` | modify | Type webhook payload and send params |
+| `src/types/messenger-payloads.ts` | create | Webhook payload interfaces per provider |
+| `src/types/index.ts` | modify | Export messenger payload interfaces |
+
+### Do NOT Modify
+
+- `src/app/plugins/chats/*` — owned by phase-3/task-11
+- `src/app/controllers/*` — owned by phase-3/task-09
+
+## Implementation Steps
+
+### Step 1: Define `IMessengerPlugin` base interface
+
+In `Base.ts`, define the interface that all messengers implement: `sendMessage(messageId: string, url: string): Promise<void>`, `responseToMessages(body: unknown): Promise<IMessage[]>`. Export it.
+
+### Step 2: Define webhook payload interfaces
+
+Create `src/types/messenger-payloads.ts` with one interface per provider for the expected inbound webhook body shape. These can start permissive and be narrowed over time.
+
+### Step 3: Type each plugin
+
+For each plugin file, apply the payload interfaces to `responseToMessages()` and make `sendMessage()` concrete. Replace `any` on internal helper functions.
+
+## Testing
+
+- [ ] `npx tsc --noEmit` passes
+- [ ] `NODE_ENV=test npx jest --testPathPattern="plugins/messengers" --no-coverage` — all pass
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] No KB/doc updates required
+
+## Completion Criteria
+
+- [ ] `IMessengerPlugin` interface defined
+- [ ] Webhook payload interfaces created per provider
+- [ ] All messenger plugin methods typed
+- [ ] All messenger tests pass
+- [ ] Status updated in `status.md`
+- [ ] Changes committed to `plan/type-backend/phase-3/task-10-messenger-plugins`

--- a/.plans/type-backend/phase-3/task-11-chat-plugins-helpers/status.md
+++ b/.plans/type-backend/phase-3/task-11-chat-plugins-helpers/status.md
@@ -1,0 +1,25 @@
+# Status: Chat Plugin & Helper Types
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-31
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-31 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/type-backend/phase-3/task-11-chat-plugins-helpers/task.md
+++ b/.plans/type-backend/phase-3/task-11-chat-plugins-helpers/task.md
@@ -1,0 +1,98 @@
+# Task: Chat Plugin & Helper Types
+
+**Plan**: Backend Type Narrowing
+**Phase**: 3
+**Task ID (phase-local)**: task-11
+**Task Path**: phase-3/task-11-chat-plugins-helpers
+**Depends On**: phase-2/task-04-core-repositories
+**JIRA**: N/A
+
+## Objective
+
+Type the chat plugin classes (Chatwoot, Crisp) and backend helper utilities, replacing remaining `any` in method signatures and utility functions.
+
+## Context
+
+Chat plugins (`src/app/plugins/chats/`) integrate with external customer service platforms. They have similar `sendMessage` / `responseToMessages` patterns to messenger plugins. Helpers (`src/app/helpers/`) contain utility functions with typed inputs.
+
+Files in scope:
+- `src/app/plugins/chats/Chatwoot.ts`
+- `src/app/plugins/chats/Crisp.ts`
+- `src/app/plugins/chats/Base.ts` (if exists)
+- `src/app/helpers/Files.ts`
+- `src/app/helpers/SanitizeErrors.ts`
+- `src/app/helpers/NormalizePhone.ts`
+- `src/app/helpers/RequireDependency.ts`
+- `src/app/helpers/logger.ts`
+- `src/app/services/Backup.ts`
+- `src/app/services/request.ts`
+
+## Before You Start
+
+- [ ] Switch to main and pull: `git switch main && git pull --rebase origin main`
+- [ ] Verify `phase-2/task-04-core-repositories` is `complete`
+- [ ] Verify `phase-3/task-10-messenger-plugins` is `complete` — use `IMessengerPlugin` pattern as reference
+- [ ] `ls src/app/plugins/chats/ src/app/helpers/` to confirm full file lists
+- [ ] Check this task's `status.md` and mark `in-progress` before proceeding
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/app/plugins/chats/Base.ts` | modify | Define `IChatPlugin` interface mirroring `IMessengerPlugin` |
+| `src/app/plugins/chats/Chatwoot.ts` | modify | Type webhook payload and send params |
+| `src/app/plugins/chats/Crisp.ts` | modify | Type webhook payload and send params |
+| `src/app/helpers/Files.ts` | modify | Type file detection function params and returns |
+| `src/app/helpers/SanitizeErrors.ts` | modify | Type error list params (already uses lodash) |
+| `src/app/helpers/NormalizePhone.ts` | modify | Type phone string params |
+| `src/app/helpers/RequireDependency.ts` | modify | Type dependency param |
+| `src/app/helpers/logger.ts` | modify | Type log method params |
+| `src/app/services/request.ts` | modify | Type axios wrapper params and returns |
+
+### Do NOT Modify
+
+- `src/app/plugins/messengers/*` — owned by phase-3/task-10
+- `src/app/controllers/*` — owned by phase-3/task-09
+
+## Implementation Steps
+
+### Step 1: Define `IChatPlugin` interface
+
+Mirror the `IMessengerPlugin` pattern from task-10. Define in `Base.ts`.
+
+### Step 2: Type Chatwoot and Crisp
+
+Apply chat payload interfaces and concrete method signatures. Define Chatwoot/Crisp-specific payload interfaces either inline or in `src/types/chat-payloads.ts`.
+
+### Step 3: Type helpers
+
+For each helper file, replace `any` params with the actual types they process. Helpers are typically small — these changes should be straightforward.
+
+### Step 4: Type service utilities
+
+In `request.ts`, type the axios wrapper methods. In `Backup.ts`, type the internal function params.
+
+### Step 5: Typecheck
+
+`npx tsc --noEmit`. Fix only owned files.
+
+## Testing
+
+- [ ] `npx tsc --noEmit` passes
+- [ ] `NODE_ENV=test npx jest --testPathPattern="plugins/chats|helpers" --no-coverage` — all pass
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] Run `document-solution` if the `IChatPlugin` / `IMessengerPlugin` interface pattern is worth documenting
+- [ ] Run `check-kb-index` if KB files are added
+
+## Completion Criteria
+
+- [ ] `IChatPlugin` interface defined
+- [ ] Chatwoot and Crisp methods typed
+- [ ] All helper function params typed
+- [ ] All chat plugin and helper tests pass
+- [ ] `npx tsc --noEmit` clean
+- [ ] Status updated in `status.md`
+- [ ] Changes committed to `plan/type-backend/phase-3/task-11-chat-plugins-helpers`

--- a/.plans/type-client/overview.md
+++ b/.plans/type-client/overview.md
@@ -1,0 +1,91 @@
+# Plan: Client Type Narrowing
+
+**Status**: not-started
+**Created**: 2026-05-31
+**Last Updated**: 2026-05-31
+**Estimated Demo Date**: N/A
+**Assigned Dev**: Alan Costa Facchini
+**Assigned QA**: unassigned
+
+## Objective
+
+Replace the `any` types in the React client with specific interfaces and prop types, working from the API service layer inward through contexts, pages, and shared components.
+
+## Scope
+
+### In Scope
+- API service layer types in `client/src/services/` (api, auth, licensee, contact, message, template, trigger, user, dashboard)
+- Context types in `client/src/contexts/`
+- Page component prop types in `client/src/pages/`
+- Shared component prop types in `client/src/components/`
+- Shared client-side entity interfaces (response shapes from the backend API)
+
+### Out of Scope
+- **Backend model interfaces** — covered by the companion `type-backend` plan; client interfaces for API responses may share shape but are defined independently (no import from `src/types/`)
+- **Test files** — spec files retain `any` freely
+- **Third-party component prop types** — only custom component interfaces; library component types are handled by their own `@types/*` packages
+
+## Kill Criteria
+
+- If the client is migrated to a different framework (e.g., Next.js), reassess scope before proceeding.
+
+## Phases
+
+| Phase | Name | Tasks | Dependencies | Description |
+|-------|------|-------|--------------|-------------|
+| 1 | Services & API Types | task-01, task-02 | None | Define shared entity interfaces and type all service functions — foundation for page components |
+| 2 | Components & Pages | task-03, task-04, task-05, task-06 | Phase 1 | Type React component props, context values, and page-level state using Phase 1 interfaces |
+
+## Task Summary
+
+| Task Path | Title | Phase | Status | Depends On |
+|-----------|-------|-------|--------|------------|
+| phase-1/task-01-api-service-types | API Base & Shared Interfaces | 1 | not-started | — |
+| phase-1/task-02-entity-services | Entity Service Types | 1 | not-started | — |
+| phase-2/task-03-context-types | Context Types | 2 | not-started | phase-1/task-01-api-service-types |
+| phase-2/task-04-licensee-pages | Licensee Page Types | 2 | not-started | phase-1/task-02-entity-services |
+| phase-2/task-05-message-contact-pages | Message & Contact Page Types | 2 | not-started | phase-1/task-02-entity-services |
+| phase-2/task-06-template-trigger-user-pages | Template, Trigger & User Page Types | 2 | not-started | phase-1/task-02-entity-services |
+
+## Branch Convention
+
+Pattern: `plan/type-client/{task-path}`
+
+Example branches:
+- `plan/type-client/phase-1/task-01-api-service-types`
+- `plan/type-client/phase-2/task-04-licensee-pages`
+
+Base branch: `main`
+
+## Key Files
+
+| File/Directory | Relevance |
+|----------------|-----------|
+| `client/src/services/api.ts` | Axios base client — typed request/response wrappers |
+| `client/src/services/*.ts` | One file per entity — 218 `any` occurrences here |
+| `client/src/contexts/` | React contexts — typed context values and providers |
+| `client/src/pages/` | Page components — prop types and local state |
+| `client/src/components/` | Shared components — SelectContactsWithFilter, form components |
+| `client/src/types/` | New directory for shared client interfaces (created in Phase 1) |
+
+## Risks
+
+- **API response shape drift** — client interfaces must match what the backend actually returns. Mitigation: derive shapes from existing service calls and spot-check against running API during development.
+- **Formik integration** — several pages use Formik with heavily `any`-typed field handlers. Mitigation: use Formik's built-in generics (`useFormik<IFormValues>`) rather than replacing Formik's internal types.
+
+## Success Criteria
+
+- [ ] `client/src/types/` directory created with shared entity interfaces
+- [ ] All service functions have typed parameters and return types (no `any` in function signatures)
+- [ ] All React contexts have typed values (no `createContext<any>`)
+- [ ] All page components have typed props and state
+- [ ] All shared components have typed props
+- [ ] `cd client && npx tsc --noEmit` passes with no new errors
+- [ ] All existing client tests pass
+- [ ] No regressions in existing UI functionality
+
+## References
+
+- **JIRA Epic**: N/A
+- **Weekly Plan Brief**: N/A
+- **Related Plans**: [Backend Type Narrowing](../type-backend/overview.md) (companion plan — defines backend interfaces; client defines its own mirrored API response types independently)

--- a/.plans/type-client/phase-1/task-01-api-service-types/status.md
+++ b/.plans/type-client/phase-1/task-01-api-service-types/status.md
@@ -1,0 +1,25 @@
+# Status: API Base & Shared Interfaces
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-31
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-31 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/type-client/phase-1/task-01-api-service-types/task.md
+++ b/.plans/type-client/phase-1/task-01-api-service-types/task.md
@@ -1,0 +1,91 @@
+# Task: API Base & Shared Interfaces
+
+**Plan**: Client Type Narrowing
+**Phase**: 1
+**Task ID (phase-local)**: task-01
+**Task Path**: phase-1/task-01-api-service-types
+**Depends On**: None
+**JIRA**: N/A
+
+## Objective
+
+Create `client/src/types/` with shared entity interfaces (ILicensee, IContact, IMessage, etc. as seen from the client), and type the base `api.ts` axios wrapper and `auth.ts` service.
+
+## Context
+
+The client defines its own interfaces for the shapes it receives from the backend REST API — these are independent from `src/types/` on the backend. They live in `client/src/types/`.
+
+`client/src/services/api.ts` wraps axios with base URL and auth headers. `client/src/services/auth.ts` handles login/logout. Typing these first gives all other service files a typed base to build on.
+
+## Before You Start
+
+- [ ] Switch to main and pull: `git switch main && git pull --rebase origin main`
+- [ ] Read `client/src/services/api.ts` and `client/src/services/auth.ts` fully
+- [ ] Read several existing service files (licensee.ts, message.ts) to understand what shapes the API returns
+- [ ] Check this task's `status.md` and mark `in-progress` before proceeding
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `client/src/types/index.ts` | create | Central barrel for client interfaces |
+| `client/src/types/licensee.ts` | create | `ILicensee` client interface |
+| `client/src/types/contact.ts` | create | `IContact` client interface |
+| `client/src/types/message.ts` | create | `IMessage` client interface |
+| `client/src/types/user.ts` | create | `IUser` client interface |
+| `client/src/types/template.ts` | create | `ITemplate` client interface |
+| `client/src/types/trigger.ts` | create | `ITrigger` client interface |
+| `client/src/types/pagination.ts` | create | `IPaginatedResponse<T>` generic wrapper |
+| `client/src/services/api.ts` | modify | Type axios instance and request helpers |
+| `client/src/services/auth.ts` | modify | Type login/logout params and returns |
+
+### Do NOT Modify
+
+- `client/src/services/licensee.ts`, `client/src/services/contact.ts`, etc. — owned by phase-1/task-02
+- `client/src/contexts/*` — owned by phase-2/task-03
+- `client/src/pages/*` — Phase 2 ownership
+- `client/src/components/*` — Phase 2 ownership
+
+## Implementation Steps
+
+### Step 1: Create `client/src/types/`
+
+Create each interface file by reading the backend API response shapes from the existing service calls. The interfaces should match what `axios.get('/resources/licensees')` actually returns — not what the Mongoose model looks like internally.
+
+### Step 2: Create `IPaginatedResponse<T>`
+
+Many list endpoints return `{ data: T[], total: number, page: number }` or similar. Define a generic wrapper.
+
+### Step 3: Type api.ts
+
+Replace `any` on axios response types with generics: `api.get<T>(url)` returning `Promise<T>`.
+
+### Step 4: Type auth.ts
+
+Type `login(email: string, password: string): Promise<{ token: string }>` and `logout(): Promise<void>`.
+
+### Step 5: Typecheck
+
+`cd client && npx tsc --noEmit`. Fix only owned files.
+
+## Testing
+
+- [ ] `cd client && npx tsc --noEmit` passes
+- [ ] `NODE_ENV=test npx jest --testPathPattern="client/src/services/(api|auth)" --no-coverage` — all pass
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] No KB/doc updates required
+
+## Completion Criteria
+
+- [ ] `client/src/types/` created with entity interfaces
+- [ ] `api.ts` and `auth.ts` typed
+- [ ] `cd client && npx tsc --noEmit` clean
+- [ ] Status updated in `status.md`
+- [ ] Changes committed to `plan/type-client/phase-1/task-01-api-service-types`
+
+## Conflict Avoidance Notes
+
+- Task-02 runs in parallel — only append to `client/src/types/index.ts`, do not overwrite task-01 exports.

--- a/.plans/type-client/phase-1/task-02-entity-services/status.md
+++ b/.plans/type-client/phase-1/task-02-entity-services/status.md
@@ -1,0 +1,25 @@
+# Status: Entity Service Types
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-31
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-31 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/type-client/phase-1/task-02-entity-services/task.md
+++ b/.plans/type-client/phase-1/task-02-entity-services/task.md
@@ -1,0 +1,85 @@
+# Task: Entity Service Types
+
+**Plan**: Client Type Narrowing
+**Phase**: 1
+**Task ID (phase-local)**: task-02
+**Task Path**: phase-1/task-02-entity-services
+**Depends On**: None
+**JIRA**: N/A
+
+## Objective
+
+Type all entity service files in `client/src/services/` — licensee, contact, message, template, trigger, user, dashboard — replacing `any` in function parameters and return types with the interfaces defined in task-01.
+
+## Context
+
+Service files make API calls and return data to page components. They have the highest concentration of `any` in the client (218 total). The pattern per service function is: typed params → typed axios call using `api.get<IEntity[]>()` → typed return value.
+
+This task runs in parallel with task-01 — if task-01 is not yet merged, use the same interfaces locally (they'll be the same shape) and import from task-01's branch or stub temporarily.
+
+Files: all `*.ts` in `client/src/services/` except `api.ts` and `auth.ts`.
+
+## Before You Start
+
+- [ ] Switch to main and pull: `git switch main && git pull --rebase origin main`
+- [ ] Verify task-01 is `complete` or get interfaces from its branch
+- [ ] Read `client/src/services/licensee.ts` as a representative sample before starting others
+- [ ] Check this task's `status.md` and mark `in-progress` before proceeding
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `client/src/services/licensee.ts` | modify | Type all CRUD functions |
+| `client/src/services/contact.ts` | modify | Type all CRUD functions |
+| `client/src/services/message.ts` | modify | Type message list/send functions |
+| `client/src/services/template.ts` | modify | Type template CRUD functions |
+| `client/src/services/trigger.ts` | modify | Type trigger CRUD functions |
+| `client/src/services/user.ts` | modify | Type user CRUD functions |
+| `client/src/services/dashboard.ts` | modify | Type dashboard metric functions |
+| `client/src/services/objectToQueryParameter.ts` | modify | Type the query builder utility |
+
+### Do NOT Modify
+
+- `client/src/services/api.ts`, `client/src/services/auth.ts` — owned by phase-1/task-01
+- `client/src/pages/*`, `client/src/contexts/*` — Phase 2 ownership
+
+## Implementation Steps
+
+### Step 1: Type each service function
+
+For each service file, replace `any` params and return types:
+```ts
+// Before
+export const getLicensees = async (params: any): Promise<any> => { ... }
+
+// After
+export const getLicensees = async (params: ILicenseeFilters): Promise<IPaginatedResponse<ILicensee>> => { ... }
+```
+
+Define filter/param interfaces inline in each service file if they are not generic enough to share.
+
+### Step 2: Type objectToQueryParameter
+
+This utility converts an object to a query string. Type its input as `Record<string, string | number | boolean | undefined>` and return as `string`.
+
+### Step 3: Typecheck
+
+`cd client && npx tsc --noEmit`. Fix only owned files.
+
+## Testing
+
+- [ ] `cd client && npx tsc --noEmit` passes
+- [ ] `NODE_ENV=test npx jest --testPathPattern="client/src/services/(licensee|contact|message|template|trigger|user)" --no-coverage` — all pass
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] No KB/doc updates required
+
+## Completion Criteria
+
+- [ ] All entity service functions have typed params and return types
+- [ ] All service tests pass
+- [ ] Status updated in `status.md`
+- [ ] Changes committed to `plan/type-client/phase-1/task-02-entity-services`

--- a/.plans/type-client/phase-2/task-03-context-types/status.md
+++ b/.plans/type-client/phase-2/task-03-context-types/status.md
@@ -1,0 +1,25 @@
+# Status: Context Types
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-31
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-31 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/type-client/phase-2/task-03-context-types/task.md
+++ b/.plans/type-client/phase-2/task-03-context-types/task.md
@@ -1,0 +1,95 @@
+# Task: Context Types
+
+**Plan**: Client Type Narrowing
+**Phase**: 2
+**Task ID (phase-local)**: task-03
+**Task Path**: phase-2/task-03-context-types
+**Depends On**: phase-1/task-01-api-service-types
+**JIRA**: N/A
+
+## Objective
+
+Type all React contexts in `client/src/contexts/`, replacing `createContext<any>(null)` with properly typed context values and provider props.
+
+## Context
+
+React contexts currently use `createContext<any>(null)` which defeats the purpose of TypeScript. The pattern to use:
+
+```ts
+interface IAuthContext {
+  user: IUser | null
+  token: string | null
+  login: (email: string, password: string) => Promise<void>
+  logout: () => void
+}
+
+const AuthContext = createContext<IAuthContext | null>(null)
+
+// Custom hook with null guard:
+export function useAuth(): IAuthContext {
+  const ctx = useContext(AuthContext)
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider')
+  return ctx
+}
+```
+
+## Before You Start
+
+- [ ] Switch to main and pull: `git switch main && git pull --rebase origin main`
+- [ ] Verify `phase-1/task-01-api-service-types` is `complete`
+- [ ] `ls client/src/contexts/` to see all context files
+- [ ] Read each context file before making changes
+- [ ] Check this task's `status.md` and mark `in-progress` before proceeding
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `client/src/contexts/*.tsx` | modify all | All context files |
+
+### Do NOT Modify
+
+- `client/src/services/*` — Phase 1 ownership (complete)
+- `client/src/pages/*` — other Phase 2 tasks
+- `client/src/components/*` — other Phase 2 tasks
+
+## Implementation Steps
+
+### Step 1: Define context value interfaces
+
+For each context, define the interface for its value object. Import entity interfaces from `client/src/types/` as needed.
+
+### Step 2: Apply typed createContext
+
+Replace `createContext<any>(null)` with `createContext<IContextValue | null>(null)`.
+
+### Step 3: Add typed custom hooks
+
+Ensure each context has a typed custom hook (e.g., `useAuth()`) with a null guard.
+
+### Step 4: Type provider props and state
+
+Replace `any` in useState, useReducer, and event handlers within each provider component.
+
+### Step 5: Typecheck
+
+`cd client && npx tsc --noEmit`. Fix only owned files.
+
+## Testing
+
+- [ ] `cd client && npx tsc --noEmit` passes
+- [ ] `NODE_ENV=test npx jest --testPathPattern="client/src" --no-coverage` — all pass (contexts affect the whole app)
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] No KB/doc updates required
+
+## Completion Criteria
+
+- [ ] All contexts have typed value interfaces
+- [ ] No `createContext<any>` remaining
+- [ ] Custom context hooks are typed with null guards
+- [ ] All client tests pass
+- [ ] Status updated in `status.md`
+- [ ] Changes committed to `plan/type-client/phase-2/task-03-context-types`

--- a/.plans/type-client/phase-2/task-04-licensee-pages/status.md
+++ b/.plans/type-client/phase-2/task-04-licensee-pages/status.md
@@ -1,0 +1,25 @@
+# Status: Licensee Page Types
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-31
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-31 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/type-client/phase-2/task-04-licensee-pages/task.md
+++ b/.plans/type-client/phase-2/task-04-licensee-pages/task.md
@@ -1,0 +1,80 @@
+# Task: Licensee Page Types
+
+**Plan**: Client Type Narrowing
+**Phase**: 2
+**Task ID (phase-local)**: task-04
+**Task Path**: phase-2/task-04-licensee-pages
+**Depends On**: phase-1/task-02-entity-services
+**JIRA**: N/A
+
+## Objective
+
+Type all components in `client/src/pages/Licensees/` and the `SelectLicenseesWithFilter` shared component, replacing `any` in props, state, Formik fields, and event handlers.
+
+## Context
+
+The Licensee pages have the highest `any` count in the client (17 occurrences in `LicenseeWizard.tsx` alone). The wizard is multi-step with complex Formik integration. Use Formik's built-in generics (`useFormik<ILicenseeFormValues>`) rather than trying to replace Formik's internal types.
+
+The `SelectLicenseesWithFilter` component in `client/src/components/` is also licensee-specific and should be typed in this task.
+
+## Before You Start
+
+- [ ] Switch to main and pull: `git switch main && git pull --rebase origin main`
+- [ ] Verify `phase-1/task-02-entity-services` is `complete`
+- [ ] `ls -R client/src/pages/Licensees/` to see all files
+- [ ] Read `client/src/pages/Licensees/scenes/New/LicenseeWizard.tsx` (most complex file) before starting
+- [ ] Check this task's `status.md` and mark `in-progress` before proceeding
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `client/src/pages/Licensees/` | modify all | All files recursively |
+| `client/src/components/SelectLicenseesWithFilter/` | modify all | Shared licensee selector component |
+
+### Do NOT Modify
+
+- `client/src/pages/Messages/`, `client/src/pages/Contacts/` — owned by phase-2/task-05
+- `client/src/pages/Templates/`, `client/src/pages/Triggers/`, `client/src/pages/Users/` — owned by phase-2/task-06
+- `client/src/services/*` — Phase 1 ownership (complete)
+
+## Implementation Steps
+
+### Step 1: Define form value interfaces
+
+For the Licensee wizard and edit form, define `ILicenseeFormValues` with all form field types. Use this with Formik: `useFormik<ILicenseeFormValues>`.
+
+### Step 2: Type component props
+
+Replace `(props: any)` with typed prop interfaces for each component and scene.
+
+### Step 3: Type useState and event handlers
+
+Replace `useState<any>` with typed versions. Type onChange/onSubmit event handlers using `React.ChangeEvent<HTMLInputElement>` etc.
+
+### Step 4: Type SelectLicenseesWithFilter
+
+Type the `onChange`, `value`, and `options` props. The selected value is `ILicensee | null`.
+
+### Step 5: Typecheck
+
+`cd client && npx tsc --noEmit`. Fix only owned files.
+
+## Testing
+
+- [ ] `cd client && npx tsc --noEmit` passes
+- [ ] `NODE_ENV=test npx jest --testPathPattern="client/src/pages/Licensees" --no-coverage` — all pass
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] No KB/doc updates required
+
+## Completion Criteria
+
+- [ ] All Licensee page components have typed props and state
+- [ ] Formik usage typed with `ILicenseeFormValues`
+- [ ] `SelectLicenseesWithFilter` typed
+- [ ] All relevant tests pass
+- [ ] Status updated in `status.md`
+- [ ] Changes committed to `plan/type-client/phase-2/task-04-licensee-pages`

--- a/.plans/type-client/phase-2/task-05-message-contact-pages/status.md
+++ b/.plans/type-client/phase-2/task-05-message-contact-pages/status.md
@@ -1,0 +1,25 @@
+# Status: Message & Contact Page Types
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-31
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-31 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/type-client/phase-2/task-05-message-contact-pages/task.md
+++ b/.plans/type-client/phase-2/task-05-message-contact-pages/task.md
@@ -1,0 +1,80 @@
+# Task: Message & Contact Page Types
+
+**Plan**: Client Type Narrowing
+**Phase**: 2
+**Task ID (phase-local)**: task-05
+**Task Path**: phase-2/task-05-message-contact-pages
+**Depends On**: phase-1/task-02-entity-services
+**JIRA**: N/A
+
+## Objective
+
+Type all components in `client/src/pages/Messages/`, `client/src/pages/Contacts/`, `client/src/pages/Reports/`, and the `SelectContactsWithFilter` shared component.
+
+## Context
+
+Messages and Contacts are the two most active data domains in the UI. The Reports page (`client/src/pages/Reports/Message/`) shows filtered message history with date range params — 9 `any` occurrences.
+
+The `SelectContactsWithFilter` component in `client/src/components/` is contact-specific and should be typed in this task.
+
+## Before You Start
+
+- [ ] Switch to main and pull: `git switch main && git pull --rebase origin main`
+- [ ] Verify `phase-1/task-02-entity-services` is `complete`
+- [ ] `ls -R client/src/pages/Messages/ client/src/pages/Contacts/ client/src/pages/Reports/` to see all files
+- [ ] Check this task's `status.md` and mark `in-progress` before proceeding
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `client/src/pages/Messages/` | modify all | All files recursively |
+| `client/src/pages/Contacts/` | modify all | All files recursively |
+| `client/src/pages/Reports/` | modify all | All files recursively |
+| `client/src/components/SelectContactsWithFilter/` | modify all | Shared contact selector component |
+
+### Do NOT Modify
+
+- `client/src/pages/Licensees/` — owned by phase-2/task-04
+- `client/src/pages/Templates/`, `client/src/pages/Triggers/`, `client/src/pages/Users/` — owned by phase-2/task-06
+- `client/src/services/*` — Phase 1 ownership (complete)
+
+## Implementation Steps
+
+### Step 1: Type component props
+
+For each page component and scene, define prop interfaces using `IMessage`, `IContact` from `client/src/types/`.
+
+### Step 2: Type state and handlers
+
+Replace `useState<any>`, `useState([])`, etc. with typed versions. Type filter state objects.
+
+### Step 3: Type SelectContactsWithFilter
+
+Type `onChange`, `value` (IContact | null), and filter params.
+
+### Step 4: Type date range and filter params in Reports
+
+Define a `IMessageReportFilters` interface for the date range and licensee filter state.
+
+### Step 5: Typecheck
+
+`cd client && npx tsc --noEmit`. Fix only owned files.
+
+## Testing
+
+- [ ] `cd client && npx tsc --noEmit` passes
+- [ ] `NODE_ENV=test npx jest --testPathPattern="client/src/pages/(Messages|Contacts|Reports)" --no-coverage` — all pass
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] No KB/doc updates required
+
+## Completion Criteria
+
+- [ ] All Message, Contact, and Report page components typed
+- [ ] `SelectContactsWithFilter` typed
+- [ ] All relevant tests pass
+- [ ] Status updated in `status.md`
+- [ ] Changes committed to `plan/type-client/phase-2/task-05-message-contact-pages`

--- a/.plans/type-client/phase-2/task-06-template-trigger-user-pages/status.md
+++ b/.plans/type-client/phase-2/task-06-template-trigger-user-pages/status.md
@@ -1,0 +1,25 @@
+# Status: Template, Trigger & User Page Types
+
+**Current Status**: not-started
+**Last Updated**: 2026-05-31
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-05-31 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/type-client/phase-2/task-06-template-trigger-user-pages/task.md
+++ b/.plans/type-client/phase-2/task-06-template-trigger-user-pages/task.md
@@ -1,0 +1,82 @@
+# Task: Template, Trigger & User Page Types
+
+**Plan**: Client Type Narrowing
+**Phase**: 2
+**Task ID (phase-local)**: task-06
+**Task Path**: phase-2/task-06-template-trigger-user-pages
+**Depends On**: phase-1/task-02-entity-services
+**JIRA**: N/A
+
+## Objective
+
+Type all components in `client/src/pages/Templates/`, `client/src/pages/Triggers/`, `client/src/pages/Users/`, and `client/src/pages/Dashboard/`, plus the `client/src/components/form/` shared form components.
+
+## Context
+
+These pages follow similar CRUD patterns. Templates and Triggers have form scenes with Formik. Users has a list + form. Dashboard displays metric cards.
+
+The `client/src/components/form/` directory contains shared form components (likely input wrappers) that are used across pages — typing them benefits all pages simultaneously.
+
+## Before You Start
+
+- [ ] Switch to main and pull: `git switch main && git pull --rebase origin main`
+- [ ] Verify `phase-1/task-02-entity-services` is `complete`
+- [ ] `ls -R client/src/pages/Templates/ client/src/pages/Triggers/ client/src/pages/Users/ client/src/pages/Dashboard/ client/src/components/form/` to see all files
+- [ ] Check this task's `status.md` and mark `in-progress` before proceeding
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `client/src/pages/Templates/` | modify all | All files recursively |
+| `client/src/pages/Triggers/` | modify all | All files recursively |
+| `client/src/pages/Users/` | modify all | All files recursively |
+| `client/src/pages/Dashboard/` | modify all | All files recursively |
+| `client/src/components/form/` | modify all | Shared form input components |
+| `client/src/pages/SignIn/` | modify all | Login page |
+| `client/src/pages/App/` | modify all | Root app shell |
+
+### Do NOT Modify
+
+- `client/src/pages/Licensees/` — owned by phase-2/task-04
+- `client/src/pages/Messages/`, `client/src/pages/Contacts/`, `client/src/pages/Reports/` — owned by phase-2/task-05
+- `client/src/services/*` — Phase 1 ownership (complete)
+- `client/src/contexts/*` — owned by phase-2/task-03
+
+## Implementation Steps
+
+### Step 1: Type shared form components
+
+Type props for all components in `client/src/components/form/` first — these are consumed by page components.
+
+### Step 2: Type each page domain
+
+For Templates, Triggers, Users, Dashboard: type props, `useState`, Formik form values, and event handlers per the pattern established in task-04.
+
+### Step 3: Type SignIn and App shell
+
+Type the login form values and the App shell props/routing state.
+
+### Step 4: Typecheck
+
+`cd client && npx tsc --noEmit`. Fix only owned files.
+
+## Testing
+
+- [ ] `cd client && npx tsc --noEmit` passes
+- [ ] `NODE_ENV=test npx jest --testPathPattern="client/src/pages/(Templates|Triggers|Users|Dashboard|SignIn|App)" --no-coverage` — all pass
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] Run `document-solution` if the Formik generic pattern warrants documenting for future reference
+
+## Completion Criteria
+
+- [ ] All Template, Trigger, User, Dashboard page components typed
+- [ ] Shared form components typed
+- [ ] SignIn and App shell typed
+- [ ] All relevant tests pass
+- [ ] `cd client && npx tsc --noEmit` clean across the entire client
+- [ ] Status updated in `status.md`
+- [ ] Changes committed to `plan/type-client/phase-2/task-06-template-trigger-user-pages`


### PR DESCRIPTION
## Plan: Progressive Type Narrowing

Replace the `any` types introduced during the JS→TS migration with specific interfaces and concrete types — backend and client.

**Type**: Type 2 (Technical)

---

### type-backend — 3 phases, 11 tasks

| Phase | Tasks | Description |
|-------|-------|-------------|
| 1 — Model Interfaces | task-01, task-02, task-03 | `ILicensee`, `IContact`, `IMessage`, `IBody`, `IRoom`, `ITrigger`, `IUser`, etc. in `src/types/` |
| 2 — Repositories & Use Cases | task-04, task-05, task-06, task-07 | Generic `Repository<T>`, typed repo methods, use case DI params and `execute()` signatures |
| 3 — Controllers, Queries & Plugins | task-08, task-09, task-10, task-11 | Query classes, Express controllers, messenger plugins, chat plugins and helpers |

**Dependency note**: task-02 (transactional models) should be skipped if `remove-pdv` is active — Cart/Order/Product will be deleted.

---

### type-client — 2 phases, 6 tasks

| Phase | Tasks | Description |
|-------|-------|-------------|
| 1 — Services & API | task-01, task-02 | `client/src/types/` shared interfaces, typed axios wrappers, all entity service functions |
| 2 — Components & Pages | task-03, task-04, task-05, task-06 | Contexts, Licensee wizard, Messages/Contacts/Reports, Templates/Triggers/Users/Dashboard |

---

**Assigned Dev**: Alan Costa Facchini

> Merge this PR before running `/execute-plan type-backend` or `/execute-plan type-client` or any `/execute-task`.