### PR TITLE
fix: enforce data isolation and correct licensee field handling

### DIFF
--- a/client/src/pages/Contacts/scenes/Index/index.spec.tsx
+++ b/client/src/pages/Contacts/scenes/Index/index.spec.tsx
@@ -135,7 +135,7 @@ describe('<ContactsIndex />', () => {
     it('does not show the licensee if logged user is not super', async () => {
       getContacts.mockResolvedValue({ status: 201, data: [contactFactory.build({ name: 'Contact' })] })
 
-      const currentUser = { isSuper: false }
+      const currentUser = { isSuper: false, licensee: 'licensee-abc' }
 
       mount({ currentUser })
 
@@ -144,6 +144,18 @@ describe('<ContactsIndex />', () => {
       await screen.findByText('Contact')
 
       expect(screen.queryByLabelText('Licenciado')).not.toBeInTheDocument()
+    })
+
+    it('includes the user licensee in the initial fetch for non-super users', async () => {
+      getContacts.mockResolvedValue({ status: 201, data: [contactFactory.build({ name: 'Contact' })] })
+
+      const currentUser = { isSuper: false, licensee: 'licensee-abc' }
+
+      mount({ currentUser })
+
+      await screen.findByText('Contact')
+
+      expect(getContacts).toHaveBeenCalledWith(expect.objectContaining({ licensee: 'licensee-abc', page: 1 }))
     })
 
     it('changes the filters to get the contacts', async () => {

--- a/client/src/pages/Contacts/scenes/Index/index.tsx
+++ b/client/src/pages/Contacts/scenes/Index/index.tsx
@@ -25,8 +25,14 @@ function ContactsIndex({ currentUser }: any) {
 
     try {
       if (!isEmpty(filters)) return
+      if (!currentUser) return
 
-      onFilter({ page: 1 })
+      const initialFilters: any = { page: 1 }
+      if (!currentUser.isSuper) {
+        initialFilters.licensee = currentUser.licensee
+      }
+
+      onFilter(initialFilters)
     } catch (error: any) {
       if (error.name === 'AbortError') {
         // Handling error thrown by aborting request
@@ -36,16 +42,7 @@ function ContactsIndex({ currentUser }: any) {
     return () => {
       abortController.abort()
     }
-  }, [filters, onFilter])
-
-  useEffect(() => {
-    if (isEmpty(filters)) return
-
-    if (currentUser && !currentUser.isSuper && filters?.licensee !== currentUser.licensee) {
-      const newFilters = { ...filters, licensee: currentUser.licensee, page: 1 }
-      onFilter(newFilters)
-    }
-  }, [currentUser, filters, onFilter])
+  }, [filters, onFilter, currentUser])
 
   function changeExpression(event: any) {
     setExpression(event.target.value)

--- a/src/app/controllers/ContactsController.spec.ts
+++ b/src/app/controllers/ContactsController.spec.ts
@@ -308,7 +308,10 @@ describe('ContactsController delegation', () => {
     const { controller, contactsQueryInstance } = buildController()
     contactsQueryInstance.all.mockResolvedValue([])
 
-    const req = { userId: 'user-id', query: { updatedAtStart: '2024-01-01T00:00:00.000Z', updatedAtEnd: '2024-01-31T23:59:59.000Z' } }
+    const req = {
+      userId: 'user-id',
+      query: { updatedAtStart: '2024-01-01T00:00:00.000Z', updatedAtEnd: '2024-01-31T23:59:59.000Z' },
+    }
     const res = buildResponse()
 
     await controller.index(req, res)

--- a/src/app/controllers/ContactsController.spec.ts
+++ b/src/app/controllers/ContactsController.spec.ts
@@ -16,8 +16,11 @@ async function runValidations(controller, req) {
   }
 }
 
-function buildController() {
+function buildController({ userIsSuper = true } = {}) {
   const contactRepository = new ContactRepositoryMemory()
+  const userRepository = {
+    findFirst: jest.fn().mockResolvedValue({ isSuper: userIsSuper, licensee: 'user-licensee-id' }),
+  }
   const contactsQueryInstance = {
     page: jest.fn(),
     limit: jest.fn(),
@@ -40,6 +43,7 @@ function buildController() {
 
   const controller = new ContactsController({
     contactRepository,
+    userRepository,
     createContactsQuery,
     createContact,
     updateContact,
@@ -48,6 +52,7 @@ function buildController() {
   return {
     controller,
     contactRepository,
+    userRepository,
     createContactsQuery,
     contactsQueryInstance,
     createContact,
@@ -251,7 +256,7 @@ describe('ContactsController delegation', () => {
     const contacts = [{ _id: 'contact-id' }]
     contactsQueryInstance.all.mockResolvedValue(contacts)
 
-    const req = { query: { page: '1', limit: '3', expression: 'Doe' } }
+    const req = { userId: 'user-id', query: { page: '1', limit: '3', expression: 'Doe' } }
     const res = buildResponse()
 
     await controller.index(req, res)
@@ -267,7 +272,7 @@ describe('ContactsController delegation', () => {
     const { controller, contactsQueryInstance } = buildController()
     contactsQueryInstance.all.mockResolvedValue([])
 
-    const req = { query: { isGroup: 'true' } }
+    const req = { userId: 'user-id', query: { isGroup: 'true' } }
     const res = buildResponse()
 
     await controller.index(req, res)
@@ -279,7 +284,7 @@ describe('ContactsController delegation', () => {
     const { controller, contactsQueryInstance } = buildController()
     contactsQueryInstance.all.mockResolvedValue([])
 
-    const req = { query: { isGroup: 'false' } }
+    const req = { userId: 'user-id', query: { isGroup: 'false' } }
     const res = buildResponse()
 
     await controller.index(req, res)
@@ -291,7 +296,7 @@ describe('ContactsController delegation', () => {
     const { controller, contactsQueryInstance } = buildController()
     contactsQueryInstance.all.mockResolvedValue([])
 
-    const req = { query: {} }
+    const req = { userId: 'user-id', query: {} }
     const res = buildResponse()
 
     await controller.index(req, res)
@@ -303,12 +308,61 @@ describe('ContactsController delegation', () => {
     const { controller, contactsQueryInstance } = buildController()
     contactsQueryInstance.all.mockResolvedValue([])
 
-    const req = { query: { updatedAtStart: '2024-01-01T00:00:00.000Z', updatedAtEnd: '2024-01-31T23:59:59.000Z' } }
+    const req = { userId: 'user-id', query: { updatedAtStart: '2024-01-01T00:00:00.000Z', updatedAtEnd: '2024-01-31T23:59:59.000Z' } }
     const res = buildResponse()
 
     await controller.index(req, res)
 
     expect(contactsQueryInstance.filterByUpdatedAtStart).toHaveBeenCalledWith(new Date('2024-01-01T00:00:00.000Z'))
     expect(contactsQueryInstance.filterByUpdatedAtEnd).toHaveBeenCalledWith(new Date('2024-01-31T23:59:59.000Z'))
+  })
+
+  it('forces the authenticated user licensee filter when user is not super', async () => {
+    const { controller, contactsQueryInstance } = buildController({ userIsSuper: false })
+    contactsQueryInstance.all.mockResolvedValue([])
+
+    const req = { userId: 'user-id', query: {} }
+    const res = buildResponse()
+
+    await controller.index(req, res)
+
+    expect(contactsQueryInstance.filterByLicensee).toHaveBeenCalledWith('user-licensee-id')
+  })
+
+  it('ignores query.licensee for non-super users and uses their own licensee', async () => {
+    const { controller, contactsQueryInstance } = buildController({ userIsSuper: false })
+    contactsQueryInstance.all.mockResolvedValue([])
+
+    const req = { userId: 'user-id', query: { licensee: 'another-licensee-id' } }
+    const res = buildResponse()
+
+    await controller.index(req, res)
+
+    expect(contactsQueryInstance.filterByLicensee).toHaveBeenCalledWith('user-licensee-id')
+    expect(contactsQueryInstance.filterByLicensee).not.toHaveBeenCalledWith('another-licensee-id')
+  })
+
+  it('applies query.licensee filter for super users when provided', async () => {
+    const { controller, contactsQueryInstance } = buildController()
+    contactsQueryInstance.all.mockResolvedValue([])
+
+    const req = { userId: 'user-id', query: { licensee: 'specific-licensee-id' } }
+    const res = buildResponse()
+
+    await controller.index(req, res)
+
+    expect(contactsQueryInstance.filterByLicensee).toHaveBeenCalledWith('specific-licensee-id')
+  })
+
+  it('does not call filterByLicensee for super users when no query.licensee', async () => {
+    const { controller, contactsQueryInstance } = buildController()
+    contactsQueryInstance.all.mockResolvedValue([])
+
+    const req = { userId: 'user-id', query: {} }
+    const res = buildResponse()
+
+    await controller.index(req, res)
+
+    expect(contactsQueryInstance.filterByLicensee).not.toHaveBeenCalled()
   })
 })

--- a/src/app/controllers/ContactsController.ts
+++ b/src/app/controllers/ContactsController.ts
@@ -3,12 +3,20 @@ import { sanitizeExpressErrors, sanitizeModelErrors } from '../helpers/SanitizeE
 
 class ContactsController {
   contactRepository: any
+  userRepository: any
   createContactsQuery: any
   createContact: any
   updateContact: any
 
-  constructor({ contactRepository, createContactsQuery, createContact, updateContact }: Record<string, any> = {}) {
+  constructor({
+    contactRepository,
+    userRepository,
+    createContactsQuery,
+    createContact,
+    updateContact,
+  }: Record<string, any> = {}) {
     this.contactRepository = contactRepository
+    this.userRepository = userRepository
     this.createContactsQuery = createContactsQuery
     this.createContact = createContact
     this.updateContact = updateContact
@@ -85,16 +93,20 @@ class ContactsController {
       contactsQuery.page(page)
       contactsQuery.limit(limit)
 
+      const user = await this.userRepository.findFirst({ _id: req.userId })
+
+      if (!user?.isSuper) {
+        contactsQuery.filterByLicensee(user?.licensee)
+      } else if (req.query.licensee) {
+        contactsQuery.filterByLicensee(req.query.licensee)
+      }
+
       if (req.query.type) {
         contactsQuery.filterByType(req.query.type)
       }
 
       if (req.query.talkingWithChatbot) {
         contactsQuery.filterByTalkingWithChatbot(req.query.talkingWithChatbot)
-      }
-
-      if (req.query.licensee) {
-        contactsQuery.filterByLicensee(req.query.licensee)
       }
 
       if (req.query.expression) {

--- a/src/app/controllers/UsersController.ts
+++ b/src/app/controllers/UsersController.ts
@@ -64,8 +64,8 @@ class UsersController {
   async show(req: any, res: any) {
     try {
       const user = req.params.id.includes('@')
-        ? await this.userRepository.findFirst({ email: req.params.id })
-        : await this.userRepository.findFirst({ _id: req.params.id })
+        ? await this.userRepository.findFirst({ email: req.params.id }, ['licensee'])
+        : await this.userRepository.findFirst({ _id: req.params.id }, ['licensee'])
 
       res.status(200).send(user)
     } catch (err: any) {

--- a/src/app/repositories/user.ts
+++ b/src/app/repositories/user.ts
@@ -33,7 +33,10 @@ class UserRepositoryMemory extends RepositoryMemory {
   }
 
   async findFirst(params: any = {}, relations: any[] = []) {
-    const record = await super.findFirst(params, relations)
+    // Call RepositoryMemory.prototype.find directly to avoid the projection
+    // collision in UserRepositoryMemory.find whose second param is `projection`, not `relations`.
+    const records = await RepositoryMemory.prototype.find.call(this, params, relations)
+    const record = (records[0] as any) ?? null
     return record ? this.attachValidPassword(record) : null
   }
 

--- a/src/app/routes/resources-routes.ts
+++ b/src/app/routes/resources-routes.ts
@@ -61,6 +61,7 @@ const licenseesController = new LicenseesController({
 })
 const contactsController = new ContactsController({
   contactRepository,
+  userRepository,
   createContactsQuery: () => new ContactsQuery({ contactRepository }),
   createContact: new CreateContact({ contactRepository }),
   updateContact: new UpdateContact({ contactRepository }),

--- a/src/app/usecases/licensees/CreateLicensee.spec.ts
+++ b/src/app/usecases/licensees/CreateLicensee.spec.ts
@@ -22,4 +22,16 @@ describe('CreateLicensee', () => {
     )
     expect(licensee.ignoredField).toBeUndefined()
   })
+
+  it('always sets active to true regardless of what is passed', async () => {
+    const licenseeRepository = new LicenseeRepositoryMemory()
+    const createLicensee = new CreateLicensee({ licenseeRepository })
+
+    const licensee = await createLicensee.execute({
+      ...licenseeCompleteFactory.build(),
+      active: false,
+    })
+
+    expect(licensee.active).toBe(true)
+  })
 })

--- a/src/app/usecases/licensees/CreateLicensee.ts
+++ b/src/app/usecases/licensees/CreateLicensee.ts
@@ -2,7 +2,6 @@ const CREATE_LICENSEE_FIELDS = [
   'name',
   'email',
   'phone',
-  'active',
   'licenseKind',
   'useChatbot',
   'chatbotDefault',
@@ -54,7 +53,7 @@ class CreateLicensee {
   }
 
   async execute(fields = {}) {
-    const payload = pickFields(fields, CREATE_LICENSEE_FIELDS)
+    const payload = { ...pickFields(fields, CREATE_LICENSEE_FIELDS), active: true }
 
     return await this.licenseeRepository.create(payload)
   }

--- a/src/app/usecases/users/UpdateUser.spec.ts
+++ b/src/app/usecases/users/UpdateUser.spec.ts
@@ -36,11 +36,11 @@ describe('UpdateUser', () => {
         email: 'bruno@mars.com',
         active: false,
         isAdmin: true,
-        licensee: originalLicensee._id,
+        licensee: nextLicensee._id,
       }),
     )
 
     const storedUser = await userRepository.findFirst({ _id: user._id })
-    expect(storedUser.licensee).toEqual(originalLicensee._id)
+    expect(storedUser.licensee).toEqual(nextLicensee._id)
   })
 })

--- a/src/app/usecases/users/UpdateUser.ts
+++ b/src/app/usecases/users/UpdateUser.ts
@@ -1,4 +1,4 @@
-const UPDATE_USER_FIELDS = ['name', 'active', 'password', 'isAdmin', 'isSuper', 'email']
+const UPDATE_USER_FIELDS = ['name', 'active', 'password', 'isAdmin', 'isSuper', 'email', 'licensee']
 
 function pickFields(fields: Record<string, any> = {}, keys: any[] = []) {
   return keys.reduce((payload: Record<string, any>, key: any) => {


### PR DESCRIPTION
## Summary

- **CreateLicensee always active**: removed `active` from permitted create fields and hardcoded `active: true`, so newly created licensees are never accidentally inactive
- **UpdateUser licensee field**: added `licensee` to `UPDATE_USER_FIELDS` so the user's licensee can be changed from the edit page
- **User edit page licensee not loading**: `UsersController.show` now populates the `licensee` relation, returning a full object instead of a bare ObjectId; also fixed `UserRepositoryMemory.findFirst` parameter collision that stripped all fields when relations were passed
- **Contacts cross-licensee leakage (security)**: `ContactsController.index` now looks up the authenticated user and forces `filterByLicensee` for non-super users — no query param can bypass this; super users retain the existing `?licensee=` filter
- **Contacts page unfiltered flash (frontend)**: `ContactsIndex` now waits for `currentUser` before firing the initial fetch and includes the user's licensee from the very first call, eliminating the race condition that briefly showed all contacts

## Test plan

- [ ] Create a licensee — confirm it is created with `active: true` regardless of what is sent in the body
- [ ] Edit a user and change the licensee — confirm the change is saved
- [ ] Open the user edit page — confirm the licensee select is pre-populated
- [ ] Log in as a non-super user and navigate to Contacts — confirm only contacts from their own licensee are shown
- [ ] Log in as a super user and navigate to Contacts — confirm the licensee filter dropdown is present and all contacts are visible by default
- [ ] All 48 affected backend tests and 10 frontend tests pass