### PR TITLE
feat(baileys): persistent socket monitor — all phases

### DIFF
--- a/.plans/README.md
+++ b/.plans/README.md
@@ -24,7 +24,7 @@ Git-native Markdown plans for multi-step work.
 |---|------|--------|--------|-------------|
 | 1 | [Remove PDV](./remove-pdv/overview.md) | `remove-pdv/` | complete | Delete cart, payment (PagarMe), and order integration (Pedidos10) domain — strip PDV fields from Licensee and Contact |
 | 2 | [MongoDB → PostgreSQL](./mongo-to-postgres/overview.md) | `mongo-to-postgres/` | not-started | Migrate all persistent data from MongoDB/Mongoose to PostgreSQL/Prisma using dual-write strategy; prerequisite: remove-pdv complete |
-| 3 | [Baileys Socket Monitor](./baileys-socket-monitor/overview.md) | `baileys-socket-monitor/` | not-started | Replace webhook-only inbound flow with a persistent Baileys socket per licensee; captures messages.upsert and messages.update natively |
+| 3 | [Baileys Socket Monitor](./baileys-socket-monitor/overview.md) | `baileys-socket-monitor/` | complete | Replace webhook-only inbound flow with a persistent Baileys socket per licensee; captures messages.upsert and messages.update natively |
 | 4 | [Local Chat Infrastructure](./local-chat-infra/overview.md) | `local-chat-infra/` | not-started | User role system (agent/supervisor/admin/super), LocalChat plugin, super licensee flow, route authorization — prerequisite for setores |
 | 5 | [Setores](./setores/overview.md) | `setores/` | not-started | Multiple WhatsApp numbers per licensee via sectors; sector-scoped message routing and agent access filtering |
 | 6 | [Backend Type Narrowing](./type-backend/overview.md) | `type-backend/` | not-started | Replace `any` with interfaces across models, repositories, use cases, controllers, and plugins — 3 phases, 11 tasks |
@@ -44,6 +44,7 @@ Git-native Markdown plans for multi-step work.
 | 4 | [Licensee Create Wizard](./licensee-wizard/overview.md) | `licensee-wizard/` | 2026-05-07 | Multi-step wizard for New Licensee (7 steps, Yes/No gates); removed question checkboxes from Edit form |
 | 5 | [Dashboard Widgets](./dashboard-widgets/overview.md) | `dashboard-widgets/` | 2026-05-07 | Role-aware dashboard: 5 super cards + 3 licensee cards, per-card REST endpoints, Redis caching, resend modal |
 | 6 | [Baileys Group Messaging & Directory Sync](./baileys-groups-directory/overview.md) | `baileys-groups-directory/` | 2026-05-16 | Extend the existing Baileys plugin to import WhatsApp groups into Contacts and send outbound messages to group JIDs |
+| 7 | [Baileys Socket Monitor](./baileys-socket-monitor/overview.md) | `baileys-socket-monitor/` | 2026-06-02 | Replace webhook-only inbound flow with a persistent Baileys socket per licensee; captures messages.upsert and messages.update natively |
 
 ---
 

--- a/.plans/baileys-socket-monitor/overview.md
+++ b/.plans/baileys-socket-monitor/overview.md
@@ -1,8 +1,8 @@
 # Plan: Baileys Socket Monitor
 
-**Status**: not-started
+**Status**: complete
 **Created**: 2026-05-29
-**Last Updated**: 2026-05-29
+**Last Updated**: 2026-06-02
 **Estimated Demo Date**: 2026-06-13
 **Assigned Dev**: Alan Costa Facchini
 **Assigned QA**: unassigned

--- a/.plans/baileys-socket-monitor/phase-1/task-01-socket-manager/status.md
+++ b/.plans/baileys-socket-monitor/phase-1/task-01-socket-manager/status.md
@@ -1,9 +1,9 @@
 # Status: BaileysSocketManager service
 
-**Current Status**: not-started
-**Last Updated**: 2026-05-29
-**Agent**: —
-**Branch**: —
+**Current Status**: complete
+**Last Updated**: 2026-06-02
+**Agent**: claude-sonnet-4-6
+**Branch**: plan/baileys-socket-monitor/phase-1/task-01-socket-manager
 **PR**: —
 
 ## Status History
@@ -11,6 +11,7 @@
 | Timestamp | Status | Agent | Notes |
 |-----------|--------|-------|-------|
 | 2026-05-29 | not-started | — | Task created |
+| 2026-06-02 | complete | claude-sonnet-4-6 | BaileysSocketManager + spec implemented; 12/12 tests pass, lint clean |
 
 ## Blockers
 

--- a/.plans/baileys-socket-monitor/phase-1/task-02-receipt-parsing/status.md
+++ b/.plans/baileys-socket-monitor/phase-1/task-02-receipt-parsing/status.md
@@ -1,9 +1,9 @@
 # Status: parseMessageStatus implementation
 
-**Current Status**: not-started
-**Last Updated**: 2026-05-29
-**Agent**: —
-**Branch**: —
+**Current Status**: complete
+**Last Updated**: 2026-06-02
+**Agent**: claude-sonnet-4-6
+**Branch**: plan/baileys-socket-monitor/phase-1/task-02-receipt-parsing
 **PR**: —
 
 ## Status History
@@ -11,6 +11,7 @@
 | Timestamp | Status | Agent | Notes |
 |-----------|--------|-------|-------|
 | 2026-05-29 | not-started | — | Task created |
+| 2026-06-02 | complete | claude-sonnet-4-6 | Implemented parseMessageStatus; 9 tests added; all 24 tests pass |
 
 ## Blockers
 

--- a/.plans/baileys-socket-monitor/phase-2/task-03-start-socket-usecase/status.md
+++ b/.plans/baileys-socket-monitor/phase-2/task-03-start-socket-usecase/status.md
@@ -1,9 +1,9 @@
 # Status: StartBaileysSocket use case
 
-**Current Status**: not-started
-**Last Updated**: 2026-05-29
-**Agent**: —
-**Branch**: —
+**Current Status**: complete
+**Last Updated**: 2026-06-02
+**Agent**: claude-sonnet-4-6
+**Branch**: plan/baileys-socket-monitor/complete
 **PR**: —
 
 ## Status History
@@ -11,6 +11,7 @@
 | Timestamp | Status | Agent | Notes |
 |-----------|--------|-------|-------|
 | 2026-05-29 | not-started | — | Task created |
+| 2026-06-02 | complete | claude-sonnet-4-6 | Created StartBaileysSocket use case, spec (4/4 passing), wired into dependencies.ts |
 
 ## Blockers
 

--- a/.plans/baileys-socket-monitor/phase-3/task-04-boot-and-qr-integration/status.md
+++ b/.plans/baileys-socket-monitor/phase-3/task-04-boot-and-qr-integration/status.md
@@ -1,9 +1,9 @@
 # Status: App boot wiring + QR integration
 
-**Current Status**: not-started
-**Last Updated**: 2026-05-29
-**Agent**: —
-**Branch**: —
+**Current Status**: complete
+**Last Updated**: 2026-06-02
+**Agent**: claude-sonnet-4-6
+**Branch**: plan/baileys-socket-monitor/complete
 **PR**: —
 
 ## Status History
@@ -11,6 +11,7 @@
 | Timestamp | Status | Agent | Notes |
 |-----------|--------|-------|-------|
 | 2026-05-29 | not-started | — | Task created |
+| 2026-06-02 | complete | claude-sonnet-4-6 | BootBaileysSocketSessions use case + spec, GetBaileysQr wired, dependencies.ts updated, server.ts boot hook, KB doc Step 6 added |
 
 ## Blockers
 

--- a/docs/kb/features/baileys-whatsapp-guide.md
+++ b/docs/kb/features/baileys-whatsapp-guide.md
@@ -493,6 +493,94 @@ Live WhatsApp verification requires a real linked account and cannot be automate
 
 ---
 
+---
+
+## Step 6 — Persistent Socket Monitor
+
+> Feature added: 2026-06-02  
+> Gated by environment variable: `ENABLE_BAILEYS_SOCKET=true`
+
+### What it enables
+
+When `ENABLE_BAILEYS_SOCKET=true` is set, the server maintains a **persistent WebSocket per Baileys licensee** that stays open for the lifetime of the process. This removes the need for the licensee's app (or any external relay) to push messages to the HTTP webhook for inbound flow.
+
+Two event streams are consumed:
+
+| Event | What it does |
+|-------|-------------|
+| `messages.upsert` | Captures inbound messages (`fromMe: false`) and feeds them directly into the `messenger-message` BullMQ pipeline — identical to the existing HTTP webhook flow |
+| `messages.update` | Captures delivery receipts and updates `Message.sendedAt`, `Message.deliveredAt`, and `Message.readAt` via `Baileys.responseToMessages()` |
+
+### Boot behavior
+
+On server start, `BootBaileysSocketSessions` is called as a fire-and-forget hook:
+
+1. All `Licensee` records with `whatsappDefault === 'baileys'` are loaded.
+2. For each licensee, the corresponding `WhatsappSession` record is checked.
+3. If `session.creds` is non-empty (i.e., the account has been authenticated), `startBaileysSocket(licensee)` is called.
+4. Licensees with empty or missing `creds` are logged and skipped — no socket is opened until they re-authenticate via QR.
+5. Errors for any single licensee are caught and logged; boot continues for the remaining licensees.
+
+### Post-QR behavior
+
+When `POST /api/v1/resources/licensees/:id/baileys-qr` is called:
+
+- If `ENABLE_BAILEYS_SOCKET=true`, `startBaileysSocket(licensee)` is triggered as a fire-and-forget call regardless of whether the response is a new QR string or `"Já conectado"`.
+- This ensures the persistent socket is started (or reconnected) after every QR interaction without requiring an app restart.
+
+### How inbound messages reach the DB
+
+The persistent socket calls `IngestMessengerMessage.execute({ body: msg, licenseeId })`, which is the same entry point used by the HTTP webhook. The full pipeline is:
+
+```
+socket messages.upsert event
+→ IngestMessengerMessage.execute({ body, licenseeId })
+  → Body record saved
+  → "messenger-message" BullMQ job queued
+  → Baileys.responseToMessages(body.content)
+     → parseContactData(body)  — extracts phone number and name
+     → parseMessage(body)      — extracts text
+  → Contact created/updated
+  → Message created with destination "to-chat" or "to-chatbot"
+```
+
+### How delivery receipts update message timestamps
+
+The `messages.update` event carries a `status` code per message key. `parseMessageStatus(statusCode)` maps these to timestamp fields:
+
+| Status code | Field updated |
+|-------------|--------------|
+| `2` (server received) | `sendedAt` |
+| `3` (delivered to device) | `deliveredAt` |
+| `4` (read by recipient) | `readAt` |
+
+`Baileys.responseToMessages(update)` is called from the socket's `onReceiptUpdate` callback, which delegates to the existing `responseToMessages` flow.
+
+### HTTP webhook fallback
+
+The HTTP webhook endpoint (`POST /v1/messenger/message/?token=<apiToken>`) **remains active** and is not removed. It serves as:
+
+- A fallback for environments where `ENABLE_BAILEYS_SOCKET` is not set.
+- A compatibility path for non-Baileys messengers (`utalk`, `dialog`, `ycloud`, `pabbly`).
+- A manual override if the persistent socket is not running.
+
+When both the persistent socket and the HTTP webhook are active for the same licensee, duplicate messages are possible if the external relay also sends to the webhook. Use only one inbound path per licensee.
+
+### Manual verification checklist
+
+Before enabling `ENABLE_BAILEYS_SOCKET=true` in production:
+
+- [ ] Set `ENABLE_BAILEYS_SOCKET=true` in the environment and restart the server
+- [ ] Confirm server logs show `"Baileys boot: iniciando socket para licensee <id>"` for each authenticated licensee
+- [ ] Send a text message from a real WhatsApp account to the licensee's number — confirm a `Message` record appears in the DB without hitting the HTTP webhook
+- [ ] Confirm delivery receipt (`delivered`) updates `message.deliveredAt` on the corresponding record
+- [ ] Confirm read receipt updates `message.readAt`
+- [ ] Call `POST /api/v1/resources/licensees/:id/baileys-qr` on a connected licensee — confirm logs show socket start and no duplicate messages appear
+- [ ] Restart the server — confirm sockets reconnect automatically at boot for all licensees with active sessions
+- [ ] Confirm the HTTP webhook (`POST /v1/messenger/message`) still works for non-Baileys licensees
+
+---
+
 ## Troubleshooting
 
 | Symptom | Likely cause | Action |

--- a/server.ts
+++ b/server.ts
@@ -15,6 +15,15 @@ const PORT = process.env.PORT || '5000'
 server.listen(PORT)
 server.on('error', onError)
 
+if (process.env.ENABLE_BAILEYS_SOCKET === 'true') {
+  import('./src/app/runtime/dependencies').then(({ createRuntimeDependencies }) => {
+    const { bootBaileysSocketSessions } = createRuntimeDependencies()
+    bootBaileysSocketSessions().catch((err: any) => {
+      console.error('Baileys boot: erro ao iniciar sockets', err)
+    })
+  })
+}
+
 server.on('listening', onListening)
 
 function onError(error: any) {

--- a/src/app/controllers/LicenseesController.ts
+++ b/src/app/controllers/LicenseesController.ts
@@ -23,13 +23,14 @@ class LicenseesController {
     createMessengerPlugin,
     whatsappSessionRepository,
     contactRepository,
+    startBaileysSocket,
   }: Record<string, any> = {}) {
     this.licenseeRepository = licenseeRepository
     this.createLicenseesQuery = createLicenseesQuery
     this.createLicensee = createLicensee
     this.updateLicensee = updateLicensee
     this.setDialogWebhookUseCase = setDialogWebhook
-    this.getBaileysQrUseCase = new GetBaileysQr({ licenseeRepository, createMessengerPlugin })
+    this.getBaileysQrUseCase = new GetBaileysQr({ licenseeRepository, createMessengerPlugin, startBaileysSocket })
     this.getBaileysStatusUseCase = new GetBaileysStatus({ licenseeRepository, whatsappSessionRepository })
     this.syncBaileysDirectoryUseCase = new SyncBaileysDirectory({
       licenseeRepository,

--- a/src/app/plugins/messengers/Baileys.spec.ts
+++ b/src/app/plugins/messengers/Baileys.spec.ts
@@ -595,4 +595,60 @@ describe('Baileys plugin', () => {
       expect(updatedSession.keys).toEqual(keys)
     })
   })
+
+  describe('#parseMessageStatus', () => {
+    it('sets messageStatus to sent when status is 1 (SERVER_ACK)', () => {
+      const baileys = new Baileys(licensee, dependencies)
+      baileys.parseMessageStatus({ key: { id: 'MSG-001', fromMe: true }, update: { status: 1 } })
+      expect(baileys.messageStatus).toEqual({ id: 'MSG-001', status: 'sent' })
+    })
+
+    it('sets messageStatus to delivered when status is 2 (DELIVERY_ACK)', () => {
+      const baileys = new Baileys(licensee, dependencies)
+      baileys.parseMessageStatus({ key: { id: 'MSG-002', fromMe: true }, update: { status: 2 } })
+      expect(baileys.messageStatus).toEqual({ id: 'MSG-002', status: 'delivered' })
+    })
+
+    it('sets messageStatus to read when status is 3 (READ)', () => {
+      const baileys = new Baileys(licensee, dependencies)
+      baileys.parseMessageStatus({ key: { id: 'MSG-003', fromMe: true }, update: { status: 3 } })
+      expect(baileys.messageStatus).toEqual({ id: 'MSG-003', status: 'read' })
+    })
+
+    it('sets messageStatus to read when status is 4 (PLAYED)', () => {
+      const baileys = new Baileys(licensee, dependencies)
+      baileys.parseMessageStatus({ key: { id: 'MSG-004', fromMe: true }, update: { status: 4 } })
+      expect(baileys.messageStatus).toEqual({ id: 'MSG-004', status: 'read' })
+    })
+
+    it('sets messageStatus to null when fromMe is false', () => {
+      const baileys = new Baileys(licensee, dependencies)
+      baileys.parseMessageStatus({ key: { id: 'MSG-005', fromMe: false }, update: { status: 2 } })
+      expect(baileys.messageStatus).toBeNull()
+    })
+
+    it('sets messageStatus to null when body is null', () => {
+      const baileys = new Baileys(licensee, dependencies)
+      baileys.parseMessageStatus(null)
+      expect(baileys.messageStatus).toBeNull()
+    })
+
+    it('sets messageStatus to null when body is missing key', () => {
+      const baileys = new Baileys(licensee, dependencies)
+      baileys.parseMessageStatus({ update: { status: 2 } })
+      expect(baileys.messageStatus).toBeNull()
+    })
+
+    it('sets messageStatus to null for unknown status code', () => {
+      const baileys = new Baileys(licensee, dependencies)
+      baileys.parseMessageStatus({ key: { id: 'MSG-006', fromMe: true }, update: { status: 99 } })
+      expect(baileys.messageStatus).toBeNull()
+    })
+
+    it('sets messageStatus.id equal to body.key.id', () => {
+      const baileys = new Baileys(licensee, dependencies)
+      baileys.parseMessageStatus({ key: { id: 'EXPECTED-ID', fromMe: true }, update: { status: 3 } })
+      expect(baileys.messageStatus.id).toEqual('EXPECTED-ID')
+    })
+  })
 })

--- a/src/app/plugins/messengers/Baileys.ts
+++ b/src/app/plugins/messengers/Baileys.ts
@@ -36,10 +36,10 @@ class Baileys extends MessengersBase {
     }
 
     const statusMap: Record<number, string> = {
-      1: 'sent',      // SERVER_ACK
+      1: 'sent', // SERVER_ACK
       2: 'delivered', // DELIVERY_ACK
-      3: 'read',      // READ
-      4: 'read',      // PLAYED (audio)
+      3: 'read', // READ
+      4: 'read', // PLAYED (audio)
     }
 
     const mapped = statusMap[body.update.status]

--- a/src/app/plugins/messengers/Baileys.ts
+++ b/src/app/plugins/messengers/Baileys.ts
@@ -29,10 +29,29 @@ class Baileys extends MessengersBase {
     }
   }
 
-  parseMessageStatus(_body: any) {
-    // Baileys delivery receipts are not received via HTTP webhook body in the same shape.
-    // For now, no status parsing is needed from incoming HTTP payloads.
-    this.messageStatus = null
+  parseMessageStatus(body: any) {
+    if (!body?.key?.id || !body?.key?.fromMe || body.update?.status == null) {
+      this.messageStatus = null
+      return
+    }
+
+    const statusMap: Record<number, string> = {
+      1: 'sent',      // SERVER_ACK
+      2: 'delivered', // DELIVERY_ACK
+      3: 'read',      // READ
+      4: 'read',      // PLAYED (audio)
+    }
+
+    const mapped = statusMap[body.update.status]
+    if (!mapped) {
+      this.messageStatus = null
+      return
+    }
+
+    this.messageStatus = {
+      id: body.key.id,
+      status: mapped,
+    }
   }
 
   parseMessage(body: any) {

--- a/src/app/routes/resources-routes.ts
+++ b/src/app/routes/resources-routes.ts
@@ -42,6 +42,7 @@ const {
   whatsappSessionRepository,
   createMessengerPlugin,
   createTemplatesImporter,
+  startBaileysSocket,
 } = createRuntimeDependencies()
 
 const usersController = new UsersController({
@@ -58,6 +59,7 @@ const licenseesController = new LicenseesController({
   createMessengerPlugin,
   whatsappSessionRepository,
   contactRepository,
+  startBaileysSocket,
 })
 const contactsController = new ContactsController({
   contactRepository,

--- a/src/app/runtime/dependencies.ts
+++ b/src/app/runtime/dependencies.ts
@@ -15,6 +15,7 @@ import { createMessengerPlugin as createMessengerPluginFactory } from '../plugin
 import { TemplatesImporter } from '../plugins/importers/template/index'
 import { BaileysSocketManager } from '../services/BaileysSocketManager'
 import { StartBaileysSocket } from '../usecases/licensees/StartBaileysSocket'
+import { BootBaileysSocketSessions } from '../usecases/licensees/BootBaileysSocketSessions'
 import { IngestMessengerMessage } from '../usecases/webhooks/IngestMessengerMessage'
 import { queueServer } from '../../config/queue'
 
@@ -76,6 +77,13 @@ function buildRuntimeDependencies({
       }),
     }).execute(licensee)
 
+  const bootBaileysSocketSessions = () =>
+    new BootBaileysSocketSessions({
+      licenseeRepository,
+      whatsappSessionRepository,
+      startBaileysSocket,
+    }).execute()
+
   return {
     bodyRepository,
     contactRepository,
@@ -94,6 +102,7 @@ function buildRuntimeDependencies({
     createTemplatesImporter,
     socketManager,
     startBaileysSocket,
+    bootBaileysSocketSessions,
   }
 }
 

--- a/src/app/runtime/dependencies.ts
+++ b/src/app/runtime/dependencies.ts
@@ -13,6 +13,10 @@ import { createChatPlugin as createChatPluginFactory } from '../plugins/chats/fa
 import { createChatbotPlugin as createChatbotPluginFactory } from '../plugins/chatbots/factory'
 import { createMessengerPlugin as createMessengerPluginFactory } from '../plugins/messengers/factory'
 import { TemplatesImporter } from '../plugins/importers/template/index'
+import { BaileysSocketManager } from '../services/BaileysSocketManager'
+import { StartBaileysSocket } from '../usecases/licensees/StartBaileysSocket'
+import { IngestMessengerMessage } from '../usecases/webhooks/IngestMessengerMessage'
+import { queueServer } from '../../config/queue'
 
 // Builds the full runtime dependency graph from caller-supplied repositories.
 // All repository arguments are required at call time; undefined repos will cause runtime errors
@@ -61,6 +65,17 @@ function buildRuntimeDependencies({
       createMessengerPlugin,
     })
 
+  const socketManager = new BaileysSocketManager({ whatsappSessionRepository })
+  const startBaileysSocket = (licensee: any) =>
+    new StartBaileysSocket({
+      socketManager,
+      createMessengerPlugin,
+      ingestMessengerMessage: new IngestMessengerMessage({
+        messengerRepository: bodyRepository,
+        jobQueue: queueServer,
+      }),
+    }).execute(licensee)
+
   return {
     bodyRepository,
     contactRepository,
@@ -77,6 +92,8 @@ function buildRuntimeDependencies({
     createChatbotPlugin,
     createMessengerPlugin,
     createTemplatesImporter,
+    socketManager,
+    startBaileysSocket,
   }
 }
 

--- a/src/app/services/BaileysSocketManager.spec.ts
+++ b/src/app/services/BaileysSocketManager.spec.ts
@@ -1,0 +1,216 @@
+import { BaileysSocketManager } from './BaileysSocketManager'
+
+jest.mock('../helpers/logger', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), fatal: jest.fn() },
+}))
+
+// Capture event handlers registered on the socket so tests can trigger them
+const socketEventHandlers: Record<string, ((...args: any[]) => void)[]> = {}
+
+const mockSocketEnd = jest.fn()
+const mockSocketEvOn = jest.fn((event: string, callback: (...args: any[]) => void) => {
+  if (!socketEventHandlers[event]) {
+    socketEventHandlers[event] = []
+  }
+  socketEventHandlers[event].push(callback)
+})
+
+const mockMakeWASocket = jest.fn(() => ({
+  end: mockSocketEnd,
+  ev: { on: mockSocketEvOn },
+}))
+
+const LOGGED_OUT_STATUS = 401
+
+jest.mock('@whiskeysockets/baileys', () => ({
+  __esModule: true,
+  default: (...args: any[]) => mockMakeWASocket(...args),
+  initAuthCreds: () => ({ noiseKey: {}, signedIdentityKey: {}, signedPreKey: {}, registrationId: 0, advSecretKey: '' }),
+  BufferJSON: { replacer: (_: any, val: any) => val, reviver: (_: any, val: any) => val },
+  Browsers: { ubuntu: () => ['Ubuntu', 'Chrome', '22.04.4'] },
+  fetchLatestBaileysVersion: jest.fn().mockResolvedValue({ version: [2, 3000, 0] }),
+  DisconnectReason: { loggedOut: LOGGED_OUT_STATUS },
+}))
+
+function makeSession(overrides: Record<string, any> = {}) {
+  return { _id: 'session-id-1', licensee: 'licensee-id-1', creds: {}, keys: {}, ...overrides }
+}
+
+function makeLicensee(overrides: Record<string, any> = {}) {
+  return { _id: { toString: () => 'licensee-id-1' }, ...overrides }
+}
+
+function makeRepository(session: ReturnType<typeof makeSession>) {
+  return {
+    findFirst: jest.fn().mockResolvedValue(session),
+    create: jest.fn().mockResolvedValue(session),
+    update: jest.fn().mockResolvedValue(session),
+  }
+}
+
+function fireEvent(event: string, payload: any) {
+  const handlers = socketEventHandlers[event] ?? []
+  for (const handler of handlers) {
+    handler(payload)
+  }
+}
+
+describe('BaileysSocketManager', () => {
+  let manager: BaileysSocketManager
+  let repo: ReturnType<typeof makeRepository>
+  let licensee: ReturnType<typeof makeLicensee>
+  let session: ReturnType<typeof makeSession>
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    jest.clearAllMocks()
+    for (const key of Object.keys(socketEventHandlers)) {
+      delete socketEventHandlers[key]
+    }
+
+    session = makeSession()
+    repo = makeRepository(session)
+    licensee = makeLicensee()
+    manager = new BaileysSocketManager({ whatsappSessionRepository: repo })
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  describe('messages.upsert', () => {
+    it('calls onMessage when type is notify and fromMe is false', async () => {
+      const onMessage = jest.fn()
+      await manager.start(licensee, { onMessage })
+
+      const msg = {
+        key: { fromMe: false, remoteJid: '5511@s.whatsapp.net', id: 'msg-1' },
+        message: { conversation: 'hello' },
+      }
+      fireEvent('messages.upsert', { messages: [msg], type: 'notify' })
+
+      expect(onMessage).toHaveBeenCalledWith(msg)
+    })
+
+    it('does NOT call onMessage when fromMe is true', async () => {
+      const onMessage = jest.fn()
+      await manager.start(licensee, { onMessage })
+
+      const msg = {
+        key: { fromMe: true, remoteJid: '5511@s.whatsapp.net', id: 'msg-2' },
+        message: { conversation: 'sent by me' },
+      }
+      fireEvent('messages.upsert', { messages: [msg], type: 'notify' })
+
+      expect(onMessage).not.toHaveBeenCalled()
+    })
+
+    it('does NOT call onMessage when type is not notify', async () => {
+      const onMessage = jest.fn()
+      await manager.start(licensee, { onMessage })
+
+      const msg = {
+        key: { fromMe: false, remoteJid: '5511@s.whatsapp.net', id: 'msg-3' },
+        message: { conversation: 'hi' },
+      }
+      fireEvent('messages.upsert', { messages: [msg], type: 'append' })
+
+      expect(onMessage).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('messages.update', () => {
+    it('calls onReceiptUpdate for each update', async () => {
+      const onReceiptUpdate = jest.fn()
+      await manager.start(licensee, { onReceiptUpdate })
+
+      const updates = [
+        { key: { id: 'msg-1' }, update: { status: 2 } },
+        { key: { id: 'msg-2' }, update: { status: 3 } },
+      ]
+      fireEvent('messages.update', updates)
+
+      expect(onReceiptUpdate).toHaveBeenCalledTimes(2)
+      expect(onReceiptUpdate).toHaveBeenNthCalledWith(1, updates[0])
+      expect(onReceiptUpdate).toHaveBeenNthCalledWith(2, updates[1])
+    })
+  })
+
+  describe('connection.update', () => {
+    it('schedules reconnect on non-logout close error', async () => {
+      const scheduleReconnectSpy = jest.spyOn(manager, '_scheduleReconnect')
+      await manager.start(licensee, { reconnectDelay: 2000 })
+
+      const disconnectError = { output: { statusCode: 500 } }
+      fireEvent('connection.update', { connection: 'close', lastDisconnect: { error: disconnectError } })
+
+      expect(scheduleReconnectSpy).toHaveBeenCalledWith(
+        licensee,
+        expect.objectContaining({ reconnectDelay: 2000 }),
+        2000,
+      )
+    })
+
+    it('clears creds and calls onLogout on loggedOut (401) disconnect', async () => {
+      const onLogout = jest.fn()
+      await manager.start(licensee, { onLogout })
+
+      const loggedOutError = { output: { statusCode: LOGGED_OUT_STATUS } }
+      fireEvent('connection.update', { connection: 'close', lastDisconnect: { error: loggedOutError } })
+
+      expect(repo.update).toHaveBeenCalledWith(session._id, { creds: {}, keys: {} })
+      expect(onLogout).toHaveBeenCalled()
+    })
+
+    it('stores socket in registry when connection opens', async () => {
+      await manager.start(licensee, {})
+
+      expect(manager.isConnected(licensee._id)).toBe(false)
+      fireEvent('connection.update', { connection: 'open' })
+      expect(manager.isConnected(licensee._id)).toBe(true)
+    })
+
+    it('removes socket from registry when connection closes', async () => {
+      await manager.start(licensee, {})
+
+      fireEvent('connection.update', { connection: 'open' })
+      expect(manager.isConnected(licensee._id)).toBe(true)
+
+      fireEvent('connection.update', {
+        connection: 'close',
+        lastDisconnect: { error: { output: { statusCode: 500 } } },
+      })
+      expect(manager.isConnected(licensee._id)).toBe(false)
+    })
+  })
+
+  describe('stop()', () => {
+    it('calls socket.end() and removes from registry', async () => {
+      await manager.start(licensee, {})
+      fireEvent('connection.update', { connection: 'open' })
+      expect(manager.isConnected(licensee._id)).toBe(true)
+
+      manager.stop(licensee._id)
+
+      expect(mockSocketEnd).toHaveBeenCalled()
+      expect(manager.isConnected(licensee._id)).toBe(false)
+    })
+
+    it('is a no-op when no socket is registered', () => {
+      expect(() => manager.stop('unknown-licensee-id')).not.toThrow()
+      expect(mockSocketEnd).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('isConnected()', () => {
+    it('returns false when socket is not in registry', () => {
+      expect(manager.isConnected(licensee._id)).toBe(false)
+    })
+
+    it('returns true only when socket is in registry', async () => {
+      await manager.start(licensee, {})
+      fireEvent('connection.update', { connection: 'open' })
+      expect(manager.isConnected(licensee._id)).toBe(true)
+    })
+  })
+})

--- a/src/app/services/BaileysSocketManager.ts
+++ b/src/app/services/BaileysSocketManager.ts
@@ -1,0 +1,142 @@
+import { logger } from '../helpers/logger'
+
+class BaileysSocketManager {
+  private _whatsappSessionRepository: any
+  private _sockets: Map<string, { socket: any; licensee: any }>
+
+  constructor({ whatsappSessionRepository }: Record<string, any> = {}) {
+    this._whatsappSessionRepository = whatsappSessionRepository
+    this._sockets = new Map()
+  }
+
+  isConnected(licenseeId: any): boolean {
+    return this._sockets.has(licenseeId.toString())
+  }
+
+  async start(
+    licensee: any,
+    { onMessage, onReceiptUpdate, onLogout, reconnectDelay }: Record<string, any> = {},
+  ): Promise<void> {
+    // Load or create session for this licensee
+    let session = await this._whatsappSessionRepository.findFirst({ licensee: licensee._id })
+    if (!session) {
+      session = await this._whatsappSessionRepository.create({ licensee: licensee._id })
+    }
+
+    const {
+      default: makeWASocket,
+      initAuthCreds,
+      BufferJSON,
+      fetchLatestBaileysVersion,
+      Browsers,
+      DisconnectReason,
+    } = await import('@whiskeysockets/baileys')
+
+    // Inline buildAuthState logic from Baileys.ts (intentional duplication — service is self-contained)
+    const rawCredsData =
+      session.creds && Object.keys(session.creds).length > 0
+        ? JSON.parse(JSON.stringify(session.creds), BufferJSON.reviver)
+        : initAuthCreds()
+
+    const rawKeysData = session.keys ? JSON.parse(JSON.stringify(session.keys), BufferJSON.reviver) : {}
+
+    const state = {
+      creds: rawCredsData,
+      keys: {
+        get: (type: any, ids: any) => {
+          const keyMap = rawKeysData[type] ?? {}
+          return ids.reduce((acc: any, id: any) => {
+            if (keyMap[id] !== undefined) acc[id] = keyMap[id]
+            return acc
+          }, {})
+        },
+        set: (data: any) => {
+          for (const category of Object.keys(data)) {
+            rawKeysData[category] = { ...(rawKeysData[category] ?? {}), ...data[category] }
+          }
+        },
+      },
+    }
+
+    const { version } = await fetchLatestBaileysVersion()
+
+    const socket = makeWASocket({
+      version,
+      auth: state,
+      printQRInTerminal: false,
+      browser: Browsers.ubuntu('Chrome'),
+    })
+
+    const callbacks = { onMessage, onReceiptUpdate, onLogout, reconnectDelay }
+
+    // Inline saveSession logic from Baileys.ts (intentional duplication — service is self-contained)
+    socket.ev.on('creds.update', () => {
+      const serialized = JSON.parse(JSON.stringify({ creds: state.creds, keys: rawKeysData }, BufferJSON.replacer))
+      this._whatsappSessionRepository.update(session._id, serialized).catch((err: any) => {
+        logger.error(`BaileysSocketManager: erro ao salvar sessão: ${err.message ?? err}`)
+      })
+    })
+
+    socket.ev.on('connection.update', ({ connection, lastDisconnect }: any) => {
+      if (connection === 'open') {
+        this._sockets.set(licensee._id.toString(), { socket, licensee })
+        logger.info(`BaileysSocketManager: socket aberto para licensee ${licensee._id}`)
+        return
+      }
+
+      if (connection === 'close') {
+        this._sockets.delete(licensee._id.toString())
+
+        const statusCode = lastDisconnect?.error?.output?.statusCode
+        const isLoggedOut = statusCode === DisconnectReason.loggedOut
+
+        if (isLoggedOut) {
+          this._whatsappSessionRepository.update(session._id, { creds: {}, keys: {} }).catch(() => {})
+          logger.warn(`BaileysSocketManager: licensee ${licensee._id} deslogado do WhatsApp`)
+          onLogout?.()
+        } else {
+          this._scheduleReconnect(licensee, callbacks, reconnectDelay ?? 2000)
+        }
+      }
+    })
+
+    socket.ev.on('messages.upsert', ({ messages, type }: any) => {
+      if (type !== 'notify') return
+      for (const msg of messages) {
+        if (!msg.key.fromMe) {
+          onMessage?.(msg)
+        }
+      }
+    })
+
+    socket.ev.on('messages.update', (updates: any) => {
+      for (const update of updates) {
+        onReceiptUpdate?.(update)
+      }
+    })
+  }
+
+  stop(licenseeId: any): void {
+    const key = licenseeId.toString()
+    const entry = this._sockets.get(key)
+    if (!entry) return
+
+    try {
+      entry.socket.end()
+    } catch {
+      // socket may already be closed — guard is intentional
+    }
+
+    this._sockets.delete(key)
+  }
+
+  _scheduleReconnect(licensee: any, callbacks: any, delayMs = 2000): void {
+    const jitter = Math.random() * 1000
+    const nextDelay = Math.min(delayMs * 2, 30000)
+    setTimeout(() => {
+      this.start(licensee, { ...callbacks, reconnectDelay: nextDelay })
+    }, delayMs + jitter)
+  }
+}
+
+export { BaileysSocketManager }

--- a/src/app/usecases/licensees/BootBaileysSocketSessions.spec.ts
+++ b/src/app/usecases/licensees/BootBaileysSocketSessions.spec.ts
@@ -1,0 +1,85 @@
+jest.mock('../../helpers/logger', () => ({
+  logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    fatal: jest.fn(),
+  },
+}))
+
+import { logger } from '../../helpers/logger'
+import { LicenseeRepositoryMemory } from '@repositories/licensee'
+import { WhatsappSessionRepositoryMemory } from '@repositories/whatsappsession'
+import { licenseeComplete as licenseeCompleteFactory } from '@factories/licensee'
+import { BootBaileysSocketSessions } from './BootBaileysSocketSessions'
+
+function buildUseCase(overrides: Record<string, any> = {}) {
+  const licenseeRepository = overrides.licenseeRepository ?? new LicenseeRepositoryMemory()
+  const whatsappSessionRepository = overrides.whatsappSessionRepository ?? new WhatsappSessionRepositoryMemory()
+  const startBaileysSocket = overrides.startBaileysSocket ?? jest.fn().mockResolvedValue(undefined)
+  const useCase = new BootBaileysSocketSessions({ licenseeRepository, whatsappSessionRepository, startBaileysSocket })
+  return { useCase, licenseeRepository, whatsappSessionRepository, startBaileysSocket }
+}
+
+describe('BootBaileysSocketSessions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('starts socket for each baileys licensee with active session creds', async () => {
+    const { useCase, licenseeRepository, whatsappSessionRepository, startBaileysSocket } = buildUseCase()
+    const licensee = await licenseeRepository.create(licenseeCompleteFactory.build({ whatsappDefault: 'baileys' }))
+    await whatsappSessionRepository.create({ licensee: licensee._id, creds: { noiseKey: 'some-creds' }, keys: {} })
+
+    await useCase.execute()
+
+    expect(startBaileysSocket).toHaveBeenCalledWith(licensee)
+  })
+
+  it('skips licensee when session has no creds', async () => {
+    const { useCase, licenseeRepository, whatsappSessionRepository, startBaileysSocket } = buildUseCase()
+    const licensee = await licenseeRepository.create(licenseeCompleteFactory.build({ whatsappDefault: 'baileys' }))
+    await whatsappSessionRepository.create({ licensee: licensee._id, creds: {}, keys: {} })
+
+    await useCase.execute()
+
+    expect(startBaileysSocket).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith(`Baileys boot: licensee ${licensee._id} sem sessão ativa, ignorando.`)
+  })
+
+  it('skips licensee when session does not exist', async () => {
+    const { useCase, licenseeRepository, startBaileysSocket } = buildUseCase()
+    await licenseeRepository.create(licenseeCompleteFactory.build({ whatsappDefault: 'baileys' }))
+
+    await useCase.execute()
+
+    expect(startBaileysSocket).not.toHaveBeenCalled()
+  })
+
+  it('does not start socket for licensees not using baileys', async () => {
+    const { useCase, licenseeRepository, startBaileysSocket } = buildUseCase()
+    await licenseeRepository.create(licenseeCompleteFactory.build({ whatsappDefault: 'dialog' }))
+
+    await useCase.execute()
+
+    expect(startBaileysSocket).not.toHaveBeenCalled()
+  })
+
+  it('logs error and continues when startBaileysSocket throws for one licensee', async () => {
+    const { useCase, licenseeRepository, whatsappSessionRepository, startBaileysSocket } = buildUseCase()
+    const licensee1 = await licenseeRepository.create(licenseeCompleteFactory.build({ whatsappDefault: 'baileys' }))
+    const licensee2 = await licenseeRepository.create(licenseeCompleteFactory.build({ whatsappDefault: 'baileys' }))
+    await whatsappSessionRepository.create({ licensee: licensee1._id, creds: { noiseKey: 'creds-1' }, keys: {} })
+    await whatsappSessionRepository.create({ licensee: licensee2._id, creds: { noiseKey: 'creds-2' }, keys: {} })
+
+    startBaileysSocket.mockRejectedValueOnce(new Error('socket failure'))
+
+    await useCase.execute()
+
+    expect(startBaileysSocket).toHaveBeenCalledTimes(2)
+    expect(logger.error).toHaveBeenCalledWith(
+      `Baileys boot: falha ao iniciar socket para licensee ${licensee1._id}: socket failure`,
+    )
+  })
+})

--- a/src/app/usecases/licensees/BootBaileysSocketSessions.ts
+++ b/src/app/usecases/licensees/BootBaileysSocketSessions.ts
@@ -1,0 +1,33 @@
+import { logger } from '../../helpers/logger'
+
+class BootBaileysSocketSessions {
+  licenseeRepository: any
+  whatsappSessionRepository: any
+  startBaileysSocket: any
+
+  constructor({ licenseeRepository, whatsappSessionRepository, startBaileysSocket }: Record<string, any> = {}) {
+    this.licenseeRepository = licenseeRepository
+    this.whatsappSessionRepository = whatsappSessionRepository
+    this.startBaileysSocket = startBaileysSocket
+  }
+
+  async execute() {
+    const licensees = await this.licenseeRepository.find({ whatsappDefault: 'baileys' })
+
+    for (const licensee of licensees) {
+      try {
+        const session = await this.whatsappSessionRepository.findFirst({ licensee: licensee._id })
+        if (!session?.creds || Object.keys(session.creds).length === 0) {
+          logger.info(`Baileys boot: licensee ${licensee._id} sem sessão ativa, ignorando.`)
+          continue
+        }
+        logger.info(`Baileys boot: iniciando socket para licensee ${licensee._id}`)
+        await this.startBaileysSocket(licensee)
+      } catch (err: any) {
+        logger.error(`Baileys boot: falha ao iniciar socket para licensee ${licensee._id}: ${err.message ?? err}`)
+      }
+    }
+  }
+}
+
+export { BootBaileysSocketSessions }

--- a/src/app/usecases/licensees/GetBaileysQr.spec.ts
+++ b/src/app/usecases/licensees/GetBaileysQr.spec.ts
@@ -3,6 +3,17 @@ import { LicenseeRepositoryMemory } from '@repositories/licensee'
 import { GetBaileysQr } from './GetBaileysQr'
 
 describe('GetBaileysQr', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+    delete process.env.ENABLE_BAILEYS_SOCKET
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+  })
+
   it('returns { qr } when plugin.getQrCode() returns a QR string', async () => {
     const licenseeRepository = new LicenseeRepositoryMemory()
     const plugin = { getQrCode: jest.fn().mockResolvedValue('qr-string-data') }
@@ -41,5 +52,48 @@ describe('GetBaileysQr', () => {
     expect(createMessengerPlugin).not.toHaveBeenCalled()
     expect(plugin.getQrCode).not.toHaveBeenCalled()
     expect(response).toEqual({ message: 'Licensee não usa Baileys' })
+  })
+
+  it('calls startBaileysSocket when ENABLE_BAILEYS_SOCKET is true and QR is returned', async () => {
+    process.env.ENABLE_BAILEYS_SOCKET = 'true'
+    const licenseeRepository = new LicenseeRepositoryMemory()
+    const plugin = { getQrCode: jest.fn().mockResolvedValue('qr-string-data') }
+    const createMessengerPlugin = jest.fn().mockReturnValue(plugin)
+    const startBaileysSocket = jest.fn().mockResolvedValue(undefined)
+    const useCase = new GetBaileysQr({ licenseeRepository, createMessengerPlugin, startBaileysSocket })
+    const licensee = await licenseeRepository.create(licenseeCompleteFactory.build({ whatsappDefault: 'baileys' }))
+
+    const response = await useCase.execute(licensee._id)
+
+    expect(response).toEqual({ qr: 'qr-string-data' })
+    expect(startBaileysSocket).toHaveBeenCalledWith(licensee)
+  })
+
+  it('calls startBaileysSocket when ENABLE_BAILEYS_SOCKET is true and already connected (qr is null)', async () => {
+    process.env.ENABLE_BAILEYS_SOCKET = 'true'
+    const licenseeRepository = new LicenseeRepositoryMemory()
+    const plugin = { getQrCode: jest.fn().mockResolvedValue(null) }
+    const createMessengerPlugin = jest.fn().mockReturnValue(plugin)
+    const startBaileysSocket = jest.fn().mockResolvedValue(undefined)
+    const useCase = new GetBaileysQr({ licenseeRepository, createMessengerPlugin, startBaileysSocket })
+    const licensee = await licenseeRepository.create(licenseeCompleteFactory.build({ whatsappDefault: 'baileys' }))
+
+    const response = await useCase.execute(licensee._id)
+
+    expect(response).toEqual({ message: 'Já conectado' })
+    expect(startBaileysSocket).toHaveBeenCalledWith(licensee)
+  })
+
+  it('does not call startBaileysSocket when ENABLE_BAILEYS_SOCKET is not set', async () => {
+    const licenseeRepository = new LicenseeRepositoryMemory()
+    const plugin = { getQrCode: jest.fn().mockResolvedValue('qr-string-data') }
+    const createMessengerPlugin = jest.fn().mockReturnValue(plugin)
+    const startBaileysSocket = jest.fn()
+    const useCase = new GetBaileysQr({ licenseeRepository, createMessengerPlugin, startBaileysSocket })
+    const licensee = await licenseeRepository.create(licenseeCompleteFactory.build({ whatsappDefault: 'baileys' }))
+
+    await useCase.execute(licensee._id)
+
+    expect(startBaileysSocket).not.toHaveBeenCalled()
   })
 })

--- a/src/app/usecases/licensees/GetBaileysQr.ts
+++ b/src/app/usecases/licensees/GetBaileysQr.ts
@@ -1,10 +1,12 @@
 class GetBaileysQr {
   licenseeRepository: any
   createMessengerPlugin: any
+  startBaileysSocket: any
 
-  constructor({ licenseeRepository, createMessengerPlugin }: Record<string, any> = {}) {
+  constructor({ licenseeRepository, createMessengerPlugin, startBaileysSocket }: Record<string, any> = {}) {
     this.licenseeRepository = licenseeRepository
     this.createMessengerPlugin = createMessengerPlugin
+    this.startBaileysSocket = startBaileysSocket
   }
 
   async execute(id: any) {
@@ -18,7 +20,14 @@ class GetBaileysQr {
     const qr = await plugin.getQrCode()
 
     if (!qr) {
+      if (process.env.ENABLE_BAILEYS_SOCKET === 'true') {
+        this.startBaileysSocket?.(licensee).catch(() => {})
+      }
       return { message: 'Já conectado' }
+    }
+
+    if (process.env.ENABLE_BAILEYS_SOCKET === 'true') {
+      this.startBaileysSocket?.(licensee).catch(() => {})
     }
 
     return { qr }

--- a/src/app/usecases/licensees/StartBaileysSocket.spec.ts
+++ b/src/app/usecases/licensees/StartBaileysSocket.spec.ts
@@ -1,0 +1,73 @@
+jest.mock('../../helpers/logger', () => ({
+  logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    fatal: jest.fn(),
+  },
+}))
+
+import { logger } from '../../helpers/logger'
+import { StartBaileysSocket } from './StartBaileysSocket'
+
+function buildUseCase() {
+  const socketManager = { start: jest.fn().mockResolvedValue(undefined) }
+  const plugin = { responseToMessages: jest.fn().mockResolvedValue(undefined) }
+  const createMessengerPlugin = jest.fn().mockReturnValue(plugin)
+  const ingestMessengerMessage = { execute: jest.fn().mockResolvedValue(undefined) }
+  const useCase = new StartBaileysSocket({ socketManager, createMessengerPlugin, ingestMessengerMessage })
+  return { useCase, socketManager, plugin, createMessengerPlugin, ingestMessengerMessage }
+}
+
+describe('StartBaileysSocket', () => {
+  const licensee = { _id: 'licensee-id-123' }
+
+  it('calls socketManager.start with the licensee', async () => {
+    const { useCase, socketManager } = buildUseCase()
+
+    await useCase.execute(licensee)
+
+    expect(socketManager.start).toHaveBeenCalledWith(licensee, expect.any(Object))
+  })
+
+  it('onMessage callback calls ingestMessengerMessage.execute with body and licenseeId', async () => {
+    const { useCase, socketManager, ingestMessengerMessage } = buildUseCase()
+
+    await useCase.execute(licensee)
+
+    const { onMessage } = socketManager.start.mock.calls[0][1]
+    const msg = { key: { id: 'msg-1' }, message: { conversation: 'hello' } }
+
+    await onMessage(msg)
+
+    expect(ingestMessengerMessage.execute).toHaveBeenCalledWith({
+      body: msg,
+      licenseeId: licensee._id,
+    })
+  })
+
+  it('onReceiptUpdate callback calls plugin.responseToMessages with the update', async () => {
+    const { useCase, socketManager, plugin } = buildUseCase()
+
+    await useCase.execute(licensee)
+
+    const { onReceiptUpdate } = socketManager.start.mock.calls[0][1]
+    const update = { key: { id: 'msg-1' }, status: 2 }
+
+    await onReceiptUpdate(update)
+
+    expect(plugin.responseToMessages).toHaveBeenCalledWith(update)
+  })
+
+  it('onLogout callback logs a warning with the licensee id', async () => {
+    const { useCase, socketManager } = buildUseCase()
+
+    await useCase.execute(licensee)
+
+    const { onLogout } = socketManager.start.mock.calls[0][1]
+    onLogout()
+
+    expect(logger.warn).toHaveBeenCalledWith(`Baileys: sessão do licensee ${licensee._id} foi desconectada (logout).`)
+  })
+})

--- a/src/app/usecases/licensees/StartBaileysSocket.ts
+++ b/src/app/usecases/licensees/StartBaileysSocket.ts
@@ -1,0 +1,34 @@
+import { logger } from '../../helpers/logger'
+
+class StartBaileysSocket {
+  socketManager: any
+  createMessengerPlugin: any
+  ingestMessengerMessage: any
+
+  constructor({ socketManager, createMessengerPlugin, ingestMessengerMessage }: Record<string, any> = {}) {
+    this.socketManager = socketManager
+    this.createMessengerPlugin = createMessengerPlugin
+    this.ingestMessengerMessage = ingestMessengerMessage
+  }
+
+  async execute(licensee: any) {
+    const plugin = this.createMessengerPlugin(licensee)
+
+    await this.socketManager.start(licensee, {
+      onMessage: async (msg: any) => {
+        await this.ingestMessengerMessage.execute({
+          body: msg,
+          licenseeId: licensee._id,
+        })
+      },
+      onReceiptUpdate: async (update: any) => {
+        await plugin.responseToMessages(update)
+      },
+      onLogout: () => {
+        logger.warn(`Baileys: sessão do licensee ${licensee._id} foi desconectada (logout).`)
+      },
+    })
+  }
+}
+
+export { StartBaileysSocket }


### PR DESCRIPTION
## Summary

- Adds `BaileysSocketManager` — a per-licensee persistent Baileys WebSocket registry with reconnect logic and jitter backoff
- Implements `parseMessageStatus` in `Baileys.ts` to map `messages.update` delivery receipts to `sendedAt`/`deliveredAt`/`readAt`
- Adds `StartBaileysSocket` use case wiring inbound messages to `IngestMessengerMessage` and receipts to `responseToMessages`
- Adds `BootBaileysSocketSessions` use case to start all active Baileys sessions at server boot
- Wires a startup hook in `server.ts` gated by `ENABLE_BAILEYS_SOCKET=true`
- Triggers `startBaileysSocket` from `GetBaileysQr` after QR pairing (fire-and-forget)
- Updates `docs/kb/features/baileys-whatsapp-guide.md` with Step 6 — Persistent Socket Monitor

## Commits

- `feat(baileys): add BaileysSocketManager persistent socket service`
- `feat(baileys): implement parseMessageStatus for delivery receipt tracking`
- `feat(baileys): add StartBaileysSocket use case and wire into dependencies`
- `feat(baileys): wire boot sessions, QR socket trigger, and KB doc`
- `style(baileys): fix prettier formatting in parseMessageStatus`

## Test plan

- [ ] All 2493 tests pass (`npx jest`)
- [ ] `npx eslint` clean on all new/modified files
- [ ] Manual: set `ENABLE_BAILEYS_SOCKET=true`, start server, verify sockets boot for active Baileys licensees
- [ ] Manual: scan QR, verify persistent socket starts without restart
- [ ] Manual: send a text message → appears as `Message` record in DB without HTTP webhook
- [ ] Manual: delivery receipt updates `message.deliveredAt`; read receipt updates `message.readAt`
- [ ] Manual: existing outbound `sendMessage` flow unaffected
- [ ] Manual: `ENABLE_BAILEYS_SOCKET` unset → no sockets started (existing behaviour preserved)