### PR TITLE
feat(messages): retry button on messages screen + fix resend URL bug

### DIFF
--- a/client/src/pages/Dashboard/cards/FailedMessagesModal.spec.tsx
+++ b/client/src/pages/Dashboard/cards/FailedMessagesModal.spec.tsx
@@ -16,8 +16,8 @@ describe('<FailedMessagesModal />', () => {
   it('fetches failed messages on open and renders them in the table', async () => {
     getMessages.mockResolvedValue({
       data: [
-        { _id: 'msg1', contact: { number: '5511999990001' }, text: 'Hello world', error: 'timeout' },
-        { _id: 'msg2', contact: { number: '5511999990002' }, text: null, error: null },
+        { _id: 'msg1', contact: { number: '5511999990001' }, text: 'Hello world', error: 'timeout', createdAt: '2024-06-03T14:30:00.000Z' },
+        { _id: 'msg2', contact: { number: '5511999990002' }, text: null, error: null, createdAt: '2024-06-03T15:00:00.000Z' },
       ],
     })
 
@@ -27,6 +27,7 @@ describe('<FailedMessagesModal />', () => {
     expect(screen.getByText('Hello world')).toBeInTheDocument()
     expect(screen.getByText('timeout')).toBeInTheDocument()
     expect(screen.getByText('5511999990002')).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Data/Hora' })).toBeInTheDocument()
     expect(screen.getAllByRole('button', { name: 'Reenviar' })).toHaveLength(2)
 
     expect(getMessages).toHaveBeenCalledWith({ sended: false, limit: 50 })

--- a/client/src/pages/Dashboard/cards/FailedMessagesModal.tsx
+++ b/client/src/pages/Dashboard/cards/FailedMessagesModal.tsx
@@ -1,5 +1,13 @@
 import { useState, useEffect } from 'react'
+import moment from 'moment-timezone'
 import { getMessages, resendMessage } from '../../../services/message'
+
+const tz = Intl.DateTimeFormat().resolvedOptions().timeZone
+
+function formatDate(value: string | undefined): string {
+  if (!value) return '—'
+  return moment(value).tz(tz).format('DD/MM/YYYY HH:mm:ss')
+}
 
 export default function FailedMessagesModal({ isOpen, onClose, onResendSuccess }: any) {
   const [messages, setMessages] = useState<any[]>([])
@@ -46,7 +54,7 @@ export default function FailedMessagesModal({ isOpen, onClose, onResendSuccess }
       style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}
       onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
     >
-      <div className="modal-dialog modal-lg" role="document">
+      <div className="modal-dialog modal-xl" role="document">
         <div className="modal-content">
           <div className="modal-header">
             <h5 className="modal-title">Mensagens com Falha</h5>
@@ -63,6 +71,7 @@ export default function FailedMessagesModal({ isOpen, onClose, onResendSuccess }
                 <thead>
                   <tr>
                     <th>Contato</th>
+                    <th>Data/Hora</th>
                     <th>Mensagem</th>
                     <th>Erro</th>
                     <th></th>
@@ -72,8 +81,9 @@ export default function FailedMessagesModal({ isOpen, onClose, onResendSuccess }
                   {messages.map((msg) => (
                     <tr key={msg._id}>
                       <td>{msg.contact?.number || '—'}</td>
+                      <td className="text-nowrap">{formatDate(msg.createdAt)}</td>
                       <td>{msg.text ? msg.text.slice(0, 80) : '—'}</td>
-                      <td className="text-danger small">{msg.error || '—'}</td>
+                      <td className="text-danger small" style={{ wordBreak: 'break-word' }}>{msg.error || '—'}</td>
                       <td>
                         {rowErrors[msg._id] && (
                           <span className="text-danger small me-2">{rowErrors[msg._id]}</span>

--- a/client/src/pages/Messages/scenes/Index/index.spec.tsx
+++ b/client/src/pages/Messages/scenes/Index/index.spec.tsx
@@ -1,6 +1,6 @@
 import MessageIndex from './'
 import { fireEvent, screen, cleanup, render } from '@testing-library/react'
-import { getMessages } from '../../../../services/message'
+import { getMessages, resendMessage } from '../../../../services/message'
 import { createRoutesStub } from 'react-router'
 import { getLicensees } from '../../../../services/licensee'
 import { getContacts } from '../../../../services/contact'
@@ -215,6 +215,76 @@ describe('<MessageIndex />', () => {
       await screen.findByText('John Doe')
 
       expect(getMessages).toHaveBeenCalledWith(expect.objectContaining({ contact: '9876543' }))
+    })
+  })
+
+  describe('retry button', () => {
+    it('shows the retry button when a message has an error', async () => {
+      getMessages.mockResolvedValueOnce({
+        status: 201,
+        data: [{ id: '1', contact: { name: 'Contact' }, error: 'Some error' }],
+      })
+
+      mount({ currentUser })
+      fireEvent.click(screen.getByText('Pesquisar'))
+
+      expect(await screen.findByRole('button', { name: 'Reenviar' })).toBeInTheDocument()
+    })
+
+    it('does not show the retry button when a message has no error', async () => {
+      getMessages.mockResolvedValueOnce({
+        status: 201,
+        data: [{ id: '1', contact: { name: 'Contact' } }],
+      })
+
+      mount({ currentUser })
+      fireEvent.click(screen.getByText('Pesquisar'))
+
+      await screen.findByText('Contact')
+
+      expect(screen.queryByRole('button', { name: 'Reenviar' })).not.toBeInTheDocument()
+    })
+
+    it('calls resendMessage with the message id on click', async () => {
+      getMessages.mockResolvedValueOnce({
+        status: 201,
+        data: [{ id: 'msg1', contact: { name: 'Contact' }, error: 'Some error' }],
+      })
+      resendMessage.mockResolvedValue({})
+
+      mount({ currentUser })
+      fireEvent.click(screen.getByText('Pesquisar'))
+      fireEvent.click(await screen.findByRole('button', { name: 'Reenviar' }))
+
+      expect(resendMessage).toHaveBeenCalledWith('msg1')
+    })
+
+    it('shows success feedback after a successful retry', async () => {
+      getMessages.mockResolvedValueOnce({
+        status: 201,
+        data: [{ id: 'msg1', contact: { name: 'Contact' }, error: 'Some error' }],
+      })
+      resendMessage.mockResolvedValue({})
+
+      mount({ currentUser })
+      fireEvent.click(screen.getByText('Pesquisar'))
+      fireEvent.click(await screen.findByRole('button', { name: 'Reenviar' }))
+
+      expect(await screen.findByText('Reenviado!')).toBeInTheDocument()
+    })
+
+    it('shows error feedback after a failed retry', async () => {
+      getMessages.mockResolvedValueOnce({
+        status: 201,
+        data: [{ id: 'msg1', contact: { name: 'Contact' }, error: 'Some error' }],
+      })
+      resendMessage.mockRejectedValue(new Error('network error'))
+
+      mount({ currentUser })
+      fireEvent.click(screen.getByText('Pesquisar'))
+      fireEvent.click(await screen.findByRole('button', { name: 'Reenviar' }))
+
+      expect(await screen.findByText('Erro ao reenviar.')).toBeInTheDocument()
     })
   })
 

--- a/client/src/pages/Messages/scenes/Index/index.tsx
+++ b/client/src/pages/Messages/scenes/Index/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react'
-import { getMessages } from '../../../../services/message'
+import { getMessages, resendMessage } from '../../../../services/message'
 import SelectLicenseesWithFilter from '../../../../components/SelectLicenseesWithFilter'
 import SelectContactsWithFilter from '../../../../components/SelectContactsWithFilter'
 import CartDescription from './components/cart'
@@ -21,6 +21,14 @@ function MessagesIndex({ currentUser }: any) {
 
   const [records, setRecords] = useState<any[]>([])
   const [lastPage, setLastPage] = useState(false)
+  const [retryState, setRetryState] = useState<Record<string, 'idle' | 'loading' | 'success' | 'error'>>({})
+
+  function handleRetry(id: string) {
+    setRetryState((prev) => ({ ...prev, [id]: 'loading' }))
+    resendMessage(id)
+      .then(() => setRetryState((prev) => ({ ...prev, [id]: 'success' })))
+      .catch(() => setRetryState((prev) => ({ ...prev, [id]: 'error' })))
+  }
 
   const addPage = useCallback(
     (records: any, filters: any) => {
@@ -248,6 +256,22 @@ function MessagesIndex({ currentUser }: any) {
                         <summary className='text-muted'>Visualizar erro</summary>
                         <p>{message.error}</p>
                       </details>
+                      <div className='mt-1'>
+                        <button
+                          type='button'
+                          className='btn btn-sm btn-outline-warning'
+                          disabled={retryState[message.id] === 'loading'}
+                          onClick={() => handleRetry(message.id)}
+                        >
+                          {retryState[message.id] === 'loading' ? 'Reenviando...' : 'Reenviar'}
+                        </button>
+                        {retryState[message.id] === 'success' && (
+                          <span className='text-success small ms-2'>Reenviado!</span>
+                        )}
+                        {retryState[message.id] === 'error' && (
+                          <span className='text-danger small ms-2'>Erro ao reenviar.</span>
+                        )}
+                      </div>
                     </div>
                   )}
                 </td>

--- a/src/app/services/SendMessageToMessenger.spec.ts
+++ b/src/app/services/SendMessageToMessenger.spec.ts
@@ -59,4 +59,25 @@ describe('sendMessageToMessenger', () => {
 
     expect(dialogSendMessageSpy).toHaveBeenCalledWith(message._id, 'https://www.dialog.com', 'k4d5h8fyt')
   })
+
+  it('falls back to licensee whatsappUrl and whatsappToken when url and token are absent from data', async () => {
+    const licenseeRepository = new LicenseeRepositoryDatabase()
+    // dialog normalizes whatsappUrl to 'https://waba.360dialog.io/' on save
+    const licensee = await licenseeRepository.create(
+      licenseeFactory.build({
+        whatsappDefault: 'dialog',
+        whatsappToken: 'licensee-token',
+      }),
+    )
+
+    const contactRepository = new ContactRepositoryDatabase()
+    const contact = await contactRepository.create(contactFactory.build({ licensee }))
+
+    const messageRepository = new MessageRepositoryDatabase()
+    const message = await messageRepository.create(messageFactory.build({ contact, licensee }))
+
+    await sendMessageToMessenger({ messageId: message._id }, dependencies)
+
+    expect(dialogSendMessageSpy).toHaveBeenCalledWith(message._id, 'https://waba.360dialog.io/', 'licensee-token')
+  })
 })

--- a/src/app/services/SendMessageToMessenger.ts
+++ b/src/app/services/SendMessageToMessenger.ts
@@ -8,7 +8,7 @@ async function sendMessageToMessenger(
 
   const messegnerPlugin = createMessengerPlugin(licensee)
 
-  await messegnerPlugin.sendMessage(messageId, url, token)
+  await messegnerPlugin.sendMessage(messageId, url ?? licensee.whatsappUrl, token ?? licensee.whatsappToken)
 }
 
 export { sendMessageToMessenger }


### PR DESCRIPTION
## Summary

- **FailedMessagesModal**: adds `Data/Hora` column (local-timezone formatted via `moment-timezone`), wraps long error strings (`word-break: break-word`), widens dialog to `modal-xl`
- **Messages index**: adds a per-row **Reenviar** button visible when `message.error` is set; button goes through `loading → success/error` inline feedback states
- **Fix `SendMessageToMessenger` service**: falls back to `licensee.whatsappUrl` / `licensee.whatsappToken` when `url`/`token` are absent from job payload — resolves `undefined/whatsapp/messages/sendDirectly` error that surfaced when clicking the retry button

## Root cause

`MessagesController.resend` queues the job with only `{ messageId }`. The service destructured `url` and `token` from that data (both `undefined`) and forwarded them directly to the plugin. Fix is a single `??` fallback in the service; the licensee is already loaded there.

## Test plan

- [ ] Messages screen: search for messages with errors — **Reenviar** button appears per row; click shows loading state, then success or error feedback
- [ ] `FailedMessagesModal`: open the modal — `Data/Hora` column appears with formatted timestamps; long error strings wrap instead of overflowing
- [ ] Backend: `npx jest src/app/services/SendMessageToMessenger.spec.ts` — 2 tests pass including the new fallback case
- [ ] Frontend: `npx vitest run` in `client/` — 26 tests pass across the two changed specs