### PR TITLE
plan(setores-webhook-providers): sector routing for webhook-based messenger providers

### DIFF
--- a/.plans/README.md
+++ b/.plans/README.md
@@ -27,6 +27,7 @@ Git-native Markdown plans for multi-step work.
 | 3 | [Baileys Socket Monitor](./baileys-socket-monitor/overview.md) | `baileys-socket-monitor/` | complete | Replace webhook-only inbound flow with a persistent Baileys socket per licensee; captures messages.upsert and messages.update natively |
 | 4 | [Local Chat Infrastructure](./local-chat-infra/overview.md) | `local-chat-infra/` | complete | User role system (agent/supervisor/admin/super), LocalChat plugin, super licensee flow, route authorization — prerequisite for setores |
 | 5 | [Setores](./setores/overview.md) | `setores/` | not-started | Multiple WhatsApp numbers per licensee via sectors; sector-scoped message routing and agent access filtering |
+| 8 | [Setores — Webhook Providers](./setores-webhook-providers/overview.md) | `setores-webhook-providers/` | not-started | Extend sector routing to utalk/dialog/ycloud/pabbly via sector token in webhook URL; prerequisite: setores complete |
 | 6 | [Backend Type Narrowing](./type-backend/overview.md) | `type-backend/` | not-started | Replace `any` with interfaces across models, repositories, use cases, controllers, and plugins — 3 phases, 11 tasks |
 | 7 | [Client Type Narrowing](./type-client/overview.md) | `type-client/` | not-started | Replace `any` with interfaces across React services, contexts, pages, and components — 2 phases, 6 tasks |
 

--- a/.plans/setores-webhook-providers/overview.md
+++ b/.plans/setores-webhook-providers/overview.md
@@ -1,0 +1,113 @@
+# Plan: Setores — Webhook Providers
+
+**Status**: not-started
+**Created**: 2026-06-04
+**Last Updated**: 2026-06-04
+**Estimated Demo Date**: TBD — depends on `setores` plan completion
+**Assigned Dev**: Alan Costa Facchini
+**Assigned QA**: unassigned
+
+## Objective
+
+Extend sector (Setor) support to non-Baileys messenger plugins (utalk, dialog, ycloud, pabbly) by embedding a sector token in the inbound webhook URL, so the system can identify which sector a message belongs to and route it correctly through the Body → Message → Room pipeline.
+
+## Scope
+
+### In Scope
+
+- `setorToken` field on `Setor` — auto-generated UUID (same pattern as `licensee.apiToken`), unique, used as the sector identifier in webhook URLs
+- `webhookUrl` virtual on `Setor` — computed from `licensee.apiToken` + `setorToken`; exposed in `SetoresController` responses so admins can copy it into provider dashboards
+- Auth middleware (`api-routes.ts`) — reads optional `?setor={setorToken}` query param, looks up the Setor, and attaches `req.setor` to the request
+- `MessengersController` — forwards `req.setor?._id` as `setorId` to `IngestMessengerMessage`
+- `IngestMessengerMessage` — accepts `setorId` and persists it on the `Body` document (the async job bridge)
+- `transformMessengerBody` (`MessengerMessage.ts`) — reads `body.setor` and stamps it onto each created `Message`
+- The rest of the pipeline (`LocalChat.sendMessage()` → `Room.create()`) already handles `setor` from the `setores` plan
+
+### Out of Scope
+
+- Baileys — sector routing for Baileys is handled by the `setores` plan via `BaileysSocketManager` re-keying
+- Per-sector chatbot configuration — uses licensee chatbot settings
+- Rotating or revoking sector tokens — v1 only; token is fixed at creation
+- Sector support for chat plugins (rocketchat, crisp, chatwoot) — those receive events from their own platforms; sector awareness there is a separate concern
+- Multi-sector webhook fan-out — one sector maps to one webhook URL; a message arriving without `?setor=` is treated as belonging to no sector (licensee-level)
+
+## Kill Criteria
+
+- If the `setores` plan is not merged to `main` before execution starts, stop — the `Setor` model, `Body.setor`, `Message.setor`, and `Room.setor` fields are all prerequisites
+- If any messenger provider (utalk, dialog, ycloud, pabbly) does not support custom webhook URLs with query parameters, that provider cannot use sector routing — document the limitation and continue with the others
+
+## Prerequisites
+
+> **This plan cannot be executed until `setores` is fully merged to `main`.**
+>
+> Required from `setores`:
+> - `Setor` model and `SetorRepositoryDatabase` (task-01)
+> - `Body.setor`, `Message.setor`, `Room.setor` fields (task-02)
+> - `setorRepository` wired in `dependencies.ts` (task-01)
+> - `LocalChat.sendMessage()` reading `message.setor` → `Room.create()` (task-04)
+
+## Phases
+
+| Phase | Name | Tasks | Dependencies | Description |
+|-------|------|-------|--------------|-------------|
+| 1 | Token & URL | task-01 | None | Add `setorToken` to Setor model and expose `webhookUrl` virtual in the controller |
+| 2 | Inbound Pipeline | task-02, task-03 | Phase 1 | Auth middleware reads `?setor=` param; ingest pipeline threads `setorId` from controller to Body to Message — parallel, no shared files |
+
+## Task Summary
+
+| Task Path | Title | Phase | Status | Depends On |
+|-----------|-------|-------|--------|------------|
+| phase-1/task-01-setor-token | Setor token field + webhook URL virtual | 1 | not-started | — |
+| phase-2/task-02-auth-middleware | Auth middleware: resolve sector from query param | 2 | not-started | phase-1/task-01-setor-token |
+| phase-2/task-03-ingest-pipeline | Ingest pipeline: thread setorId from controller to Message | 2 | not-started | phase-1/task-01-setor-token |
+
+## Branch Convention
+
+Pattern: `plan/setores-webhook-providers/{task-path}`
+
+Example branches:
+- `plan/setores-webhook-providers/phase-1/task-01-setor-token`
+- `plan/setores-webhook-providers/phase-2/task-02-auth-middleware`
+- `plan/setores-webhook-providers/phase-2/task-03-ingest-pipeline`
+
+Base branch: `main`
+
+## Key Files
+
+| File/Directory | Relevance |
+|----------------|-----------|
+| `src/app/models/Setor.ts` | Add `setorToken` field and `webhookUrl` virtual |
+| `src/app/models/Setor.spec.ts` | Add token generation and virtual tests |
+| `src/app/controllers/SetoresController.ts` | Populate `licensee` in show/index so `webhookUrl` virtual resolves |
+| `src/app/controllers/SetoresController.spec.ts` | Add webhook URL assertion |
+| `src/app/routes/api-routes.ts` | Auth middleware — read `?setor=` param, attach `req.setor` |
+| `src/app/controllers/MessengersController.ts` | Forward `req.setor?._id` as `setorId` |
+| `src/app/controllers/MessengersController.spec.ts` | Add sector forwarding test |
+| `src/app/usecases/webhooks/IngestMessengerMessage.ts` | Accept + persist `setorId` on Body |
+| `src/app/usecases/webhooks/IngestMessengerMessage.spec.ts` | Add setorId test |
+| `src/app/services/MessengerMessage.ts` | Read `body.setor`, stamp onto each Message |
+| `src/app/services/MessengerMessage.spec.ts` | Add setor propagation test |
+
+## Risks
+
+- **Provider query param support** — utalk, dialog, ycloud, and pabbly must accept a webhook URL with query parameters. Most do, but if a provider URL-encodes or strips query params, sector routing silently falls back to licensee-level. Mitigation: test each provider's webhook configuration in staging before deploying.
+- **Token collision** — `setorToken` is a UUID v4; collision probability is negligible but the unique index on `Setor.setorToken` enforces correctness at the DB level.
+- **Missing `?setor=` on existing webhooks** — providers already configured without a sector token will continue to work exactly as before (`req.setor` is null, sector routing is skipped). Zero breaking change for existing integrations.
+
+## Success Criteria
+
+- [ ] A `Setor` is created with a unique `setorToken` auto-generated on save
+- [ ] `SetoresController.show` response includes `webhookUrl` with the correct `?token=&setor=` format
+- [ ] A webhook POST to `/api/v1/messenger/message?token={licenseeToken}&setor={setorToken}` attaches the correct Setor to the request
+- [ ] A webhook POST without `?setor=` continues to work as before (no regression)
+- [ ] A Body created from a sector-scoped webhook has `setor` populated
+- [ ] A Message created from that Body has `setor` populated
+- [ ] A Room created by `LocalChat.sendMessage()` from that Message has `setor` populated
+- [ ] All unit tests pass: `npx jest`
+- [ ] `npx eslint .` produces no new errors
+
+## References
+
+- **JIRA Epic**: N/A
+- **Related Plans**: [Setores](../setores/overview.md) — prerequisite; provides Setor model and pipeline setor fields
+- **Rock Alignment**: N/A

--- a/.plans/setores-webhook-providers/phase-1/task-01-setor-token/status.md
+++ b/.plans/setores-webhook-providers/phase-1/task-01-setor-token/status.md
@@ -1,0 +1,25 @@
+# Status: Setor token field + webhook URL virtual
+
+**Current Status**: not-started
+**Last Updated**: 2026-06-04
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-06-04 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/setores-webhook-providers/phase-1/task-01-setor-token/task.md
+++ b/.plans/setores-webhook-providers/phase-1/task-01-setor-token/task.md
@@ -1,0 +1,126 @@
+# Task: Setor token field + webhook URL virtual
+
+**Plan**: Setores — Webhook Providers
+**Phase**: 1
+**Task ID (phase-local)**: task-01
+**Task Path**: phase-1/task-01-setor-token
+**Depends On**: None (but requires `setores` plan fully merged to `main`)
+**JIRA**: N/A
+
+## Objective
+
+Add a `setorToken` field (auto-generated UUID, unique) to the `Setor` model and a `webhookUrl` virtual that computes the full sector-scoped webhook URL. Expose the virtual in `SetoresController` by populating `licensee` in `show` and `index`.
+
+## Context
+
+`licensee.apiToken` is a UUID auto-generated via `uuidv4` as the Mongoose field default — follow the exact same pattern for `setorToken` on Setor.
+
+The sector webhook URL format is:
+```
+https://clave-digital.herokuapp.com/api/v1/messenger/message/?token={licensee.apiToken}&setor={setor.setorToken}
+```
+
+This is analogous to the existing `urlChatWebhook`, `urlWhatsappWebhook` virtuals on `Licensee.ts` (see lines 206–219).
+
+The virtual requires `licensee` to be populated to resolve `licensee.apiToken`. Use `this.populated('licensee')` to guard it. The controller's `show` and `index` must populate `licensee` so the virtual renders in API responses.
+
+`Setor` model and `SetoresController` were created by `setores` plan task-01. Read those files in full before making changes.
+
+## Before You Start
+
+- [ ] Switch to main and pull: `git switch main && git pull --rebase origin main`
+- [ ] Create task branch: `git switch -c plan/setores-webhook-providers/phase-1/task-01-setor-token`
+- [ ] Verify `setores` plan is merged — confirm `src/app/models/Setor.ts` exists
+- [ ] Read `src/app/models/Setor.ts` (full file)
+- [ ] Read `src/app/controllers/SetoresController.ts` (full file)
+- [ ] Read `src/app/models/Licensee.ts` lines 1–30 and 176–224 (apiToken field + virtual pattern)
+- [ ] Mark this task `in-progress` in `status.md`
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/app/models/Setor.ts` | modify | Add `setorToken` field + `webhookUrl` virtual |
+| `src/app/models/Setor.spec.ts` | modify | Add token auto-generation and virtual tests |
+| `src/app/controllers/SetoresController.ts` | modify | Populate `licensee` in `show` and `index` |
+| `src/app/controllers/SetoresController.spec.ts` | modify | Assert `webhookUrl` appears in response |
+
+### Do NOT Modify
+
+- `src/app/routes/api-routes.ts` — owned by phase-2/task-02-auth-middleware
+- `src/app/controllers/MessengersController.ts` — owned by phase-2/task-03-ingest-pipeline
+- `src/app/usecases/webhooks/IngestMessengerMessage.ts` — owned by phase-2/task-03-ingest-pipeline
+- `src/app/services/MessengerMessage.ts` — owned by phase-2/task-03-ingest-pipeline
+
+## Implementation Steps
+
+### Step 1: Add `setorToken` to `src/app/models/Setor.ts`
+
+Import `uuidv4` (already a project dependency — see `Licensee.ts`):
+```ts
+import { v4 as uuidv4 } from 'uuid'
+```
+
+Add the field inside the schema definition (alongside `active`):
+```ts
+setorToken: { type: String, unique: true, default: uuidv4 },
+```
+
+### Step 2: Add `webhookUrl` virtual to `src/app/models/Setor.ts`
+
+After the `pre('save')` hook and before `setorSchema.set('toJSON', ...)`:
+```ts
+setorSchema.virtual('webhookUrl').get(function () {
+  if (!this.populated('licensee')) return null
+  return `https://clave-digital.herokuapp.com/api/v1/messenger/message/?token=${(this.licensee as any).apiToken}&setor=${this.setorToken}`
+})
+```
+
+Ensure `setorSchema.set('toJSON', { virtuals: true })` is already present (it should be from task-01 of the `setores` plan).
+
+### Step 3: Populate `licensee` in `SetoresController`
+
+In `SetoresController.ts`, update `show` and `index` to populate `licensee` so the `webhookUrl` virtual resolves:
+
+```ts
+// show
+async show(req: any, res: any) {
+  const setor = await this.setorRepository.findFirst({ _id: req.params.id }, ['licensee', 'users'])
+  // ...
+}
+
+// index
+async index(req: any, res: any) {
+  const setores = await this.setorRepository.findAll({ licensee: req.query.licensee }, ['licensee', 'users'])
+  // ...
+}
+```
+
+Match the exact method signatures of the existing controller — read the file before editing.
+
+## Testing
+
+- [ ] `Setor` created without specifying `setorToken` — field is auto-populated with a UUID string
+- [ ] Two `Setor` documents with the same `setorToken` — second save fails (unique index violation)
+- [ ] `SetoresController.show` response includes `webhookUrl` with correct format `?token=...&setor=...`
+- [ ] `SetoresController.show` response `webhookUrl` is `null` when licensee is not populated
+- [ ] All existing Setor and SetoresController tests still pass
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] No KB doc updates required at this task
+
+## Completion Criteria
+
+- [ ] `setorToken` field added with unique index and UUID default
+- [ ] `webhookUrl` virtual added and resolves when `licensee` is populated
+- [ ] `SetoresController.show` and `index` populate `licensee`
+- [ ] All tests pass: `npx jest src/app/models/Setor.spec.ts src/app/controllers/SetoresController.spec.ts`
+- [ ] `npx eslint src/app/models/Setor.ts src/app/controllers/SetoresController.ts` passes
+- [ ] Changes committed to `plan/setores-webhook-providers/phase-1/task-01-setor-token` branch
+- [ ] Status updated to `complete` in `status.md`
+
+## Conflict Avoidance Notes
+
+This is the only task in phase 1. Phase-2 tasks depend on `setorToken` existing — they must not start until this task is merged.

--- a/.plans/setores-webhook-providers/phase-2/task-02-auth-middleware/status.md
+++ b/.plans/setores-webhook-providers/phase-2/task-02-auth-middleware/status.md
@@ -1,0 +1,25 @@
+# Status: Auth middleware — resolve sector from query param
+
+**Current Status**: not-started
+**Last Updated**: 2026-06-04
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-06-04 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/setores-webhook-providers/phase-2/task-02-auth-middleware/task.md
+++ b/.plans/setores-webhook-providers/phase-2/task-02-auth-middleware/task.md
@@ -1,0 +1,135 @@
+# Task: Auth middleware — resolve sector from query param
+
+**Plan**: Setores — Webhook Providers
+**Phase**: 2
+**Task ID (phase-local)**: task-02
+**Task Path**: phase-2/task-02-auth-middleware
+**Depends On**: phase-1/task-01-setor-token
+**JIRA**: N/A
+
+## Objective
+
+Extend the `authenticateLicensee` middleware in `api-routes.ts` to read an optional `?setor={setorToken}` query parameter, look up the matching `Setor` document, and attach it to `req.setor`. If `?setor=` is absent or invalid, the request continues without a sector (existing behaviour is preserved).
+
+## Context
+
+`api-routes.ts` defines `buildAuthenticateLicensee`, which currently:
+1. Reads `req.query.token`
+2. Calls `licenseeRepository.findFirst({ apiToken: req.query.token })`
+3. Attaches result to `req.licensee` or returns 401
+
+The sector lookup must happen **after** the licensee is resolved (the Setor is validated against that licensee to prevent cross-licensee token spoofing). The logic is:
+
+```
+if req.query.setor present:
+  setor = setorRepository.findFirst({ setorToken: req.query.setor, licensee: licensee._id })
+  if setor found AND setor.active:
+    req.setor = setor
+  else:
+    return 401  ← invalid/inactive sector token for this licensee
+```
+
+Returning 401 on an invalid `?setor=` (rather than silently ignoring it) prevents misconfigured provider webhooks from silently routing to the wrong sector or dropping sector context.
+
+`SetorRepositoryDatabase` and `setorRepository` are wired in `dependencies.ts` by the `setores` plan. Import and instantiate `SetorRepositoryDatabase` directly in `api-routes.ts`, following the same pattern as `LicenseeRepositoryDatabase` on line 6 of the current file.
+
+## Before You Start
+
+- [ ] Switch to main and pull: `git switch main && git pull --rebase origin main`
+- [ ] Create task branch: `git switch -c plan/setores-webhook-providers/phase-2/task-02-auth-middleware`
+- [ ] Verify phase-1/task-01-setor-token is complete — confirm `Setor.setorToken` field exists
+- [ ] Read `src/app/routes/api-routes.ts` (full file)
+- [ ] Read `src/app/repositories/setor.ts` (confirm `findFirst` signature)
+- [ ] Check if `src/app/routes/api-routes.spec.ts` exists — if so, read it before editing
+- [ ] Mark this task `in-progress` in `status.md`
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/app/routes/api-routes.ts` | modify | Add `?setor=` resolution to `authenticateLicensee` |
+| `src/app/routes/api-routes.spec.ts` | create or modify | Add sector resolution tests |
+
+### Do NOT Modify
+
+- `src/app/models/Setor.ts` — owned by phase-1/task-01-setor-token (already complete)
+- `src/app/controllers/MessengersController.ts` — owned by phase-2/task-03-ingest-pipeline
+- `src/app/usecases/webhooks/IngestMessengerMessage.ts` — owned by phase-2/task-03-ingest-pipeline
+- `src/app/services/MessengerMessage.ts` — owned by phase-2/task-03-ingest-pipeline
+
+## Implementation Steps
+
+### Step 1: Import `SetorRepositoryDatabase` in `api-routes.ts`
+
+```ts
+import { SetorRepositoryDatabase } from '../repositories/setor'
+```
+
+Instantiate alongside `licenseeRepository`:
+```ts
+const setorRepository = new SetorRepositoryDatabase()
+```
+
+### Step 2: Update `buildAuthenticateLicensee` signature and logic
+
+```ts
+function buildAuthenticateLicensee({ licenseeRepository, setorRepository }: any) {
+  return async function authenticateLicensee(req: any, res: any, next: any) {
+    if (req.query.token) {
+      const licensee = await licenseeRepository.findFirst({ apiToken: req.query.token })
+      if (licensee) {
+        req.licensee = licensee
+
+        if (req.query.setor) {
+          const setor = await setorRepository.findFirst({
+            setorToken: req.query.setor,
+            licensee: licensee._id,
+          })
+          if (!setor || !setor.active) {
+            return res.status(401).json({ message: 'Token de setor inválido ou inativo.' })
+          }
+          req.setor = setor
+        }
+
+        return next()
+      }
+    }
+
+    res.status(401).json({ message: 'Token não informado ou inválido.' })
+  }
+}
+```
+
+Pass both repositories when calling `buildAuthenticateLicensee`:
+```ts
+router.use(buildAuthenticateLicensee({ licenseeRepository, setorRepository }))
+```
+
+## Testing
+
+- [ ] Request with valid `?token=` and no `?setor=` — `req.licensee` set, `req.setor` undefined, `next()` called (existing behaviour unchanged)
+- [ ] Request with valid `?token=` and valid active `?setor=` matching that licensee — `req.licensee` set, `req.setor` set, `next()` called
+- [ ] Request with valid `?token=` and `?setor=` that belongs to a different licensee — 401 returned
+- [ ] Request with valid `?token=` and `?setor=` for an inactive sector — 401 returned
+- [ ] Request with valid `?token=` and unknown `?setor=` — 401 returned
+- [ ] Request with no `?token=` — 401 returned (existing behaviour unchanged)
+- [ ] All existing api-routes tests still pass
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] No KB doc updates required at this task
+
+## Completion Criteria
+
+- [ ] `authenticateLicensee` resolves sector from `?setor=` query param
+- [ ] Invalid/inactive/cross-licensee sector tokens return 401
+- [ ] Existing no-sector requests are unaffected
+- [ ] All tests pass: `npx jest src/app/routes/`
+- [ ] `npx eslint src/app/routes/api-routes.ts` passes
+- [ ] Changes committed to `plan/setores-webhook-providers/phase-2/task-02-auth-middleware` branch
+- [ ] Status updated to `complete` in `status.md`
+
+## Conflict Avoidance Notes
+
+task-03 (ingest-pipeline) owns `MessengersController.ts`, `IngestMessengerMessage.ts`, and `MessengerMessage.ts`. No file overlap with this task. Both can run in parallel once phase-1 is merged.

--- a/.plans/setores-webhook-providers/phase-2/task-03-ingest-pipeline/status.md
+++ b/.plans/setores-webhook-providers/phase-2/task-03-ingest-pipeline/status.md
@@ -1,0 +1,25 @@
+# Status: Ingest pipeline — thread setorId from controller to Message
+
+**Current Status**: not-started
+**Last Updated**: 2026-06-04
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-06-04 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/setores-webhook-providers/phase-2/task-03-ingest-pipeline/task.md
+++ b/.plans/setores-webhook-providers/phase-2/task-03-ingest-pipeline/task.md
@@ -1,0 +1,132 @@
+# Task: Ingest pipeline — thread setorId from controller to Message
+
+**Plan**: Setores — Webhook Providers
+**Phase**: 2
+**Task ID (phase-local)**: task-03
+**Task Path**: phase-2/task-03-ingest-pipeline
+**Depends On**: phase-1/task-01-setor-token
+**JIRA**: N/A
+
+## Objective
+
+Thread `setorId` through the inbound message pipeline: `MessengersController` reads `req.setor?._id` and passes it to `IngestMessengerMessage`, which persists it on the `Body` document. `transformMessengerBody` then reads `body.setor` and stamps it onto each created `Message`. From that point the existing pipeline (job worker → `LocalChat.sendMessage()` → `Room.create()`) already propagates `setor` — no further changes are needed beyond this task.
+
+## Context
+
+The full propagation chain this task enables:
+
+```
+req.setor._id (set by task-02 auth middleware)
+  → MessengersController.message() passes setorId
+    → IngestMessengerMessage.execute({ body, licenseeId, setorId })
+      → Body.create({ content, licensee, kind, setor: setorId })  ← persisted here
+        → job queue: { bodyId, licenseeId }
+          → transformMessengerBody() reads body.setor
+            → Message.create({ ..., setor: body.setor })
+              → (existing) LocalChat.sendMessage() reads message.setor
+                → Room.create({ contact, status: 'pending', setor: message.setor })
+```
+
+`Body.setor` and `Message.setor` fields already exist — they were added by the `setores` plan (task-02). This task only wires up the data flow; no schema changes are needed.
+
+`transformMessengerBody` currently calls `messengerPlugin.responseToMessages(body.content)` which returns `Message` objects already saved to the DB. The `setor` must be set on each message **after** `responseToMessages` returns, using `message.setor = body.setor` + `messageRepository.save(message)`, OR by passing `setorId` into `responseToMessages` if the base class supports it. Read the actual implementation before choosing — do not assume the interface.
+
+## Before You Start
+
+- [ ] Switch to main and pull: `git switch main && git pull --rebase origin main`
+- [ ] Create task branch: `git switch -c plan/setores-webhook-providers/phase-2/task-03-ingest-pipeline`
+- [ ] Verify phase-1/task-01-setor-token is complete
+- [ ] Read `src/app/controllers/MessengersController.ts` (full file)
+- [ ] Read `src/app/usecases/webhooks/IngestMessengerMessage.ts` (full file)
+- [ ] Read `src/app/services/MessengerMessage.ts` (full file)
+- [ ] Read `src/app/plugins/messengers/Base.ts` — understand how `responseToMessages` creates Messages
+- [ ] Mark this task `in-progress` in `status.md`
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/app/controllers/MessengersController.ts` | modify | Read `req.setor?._id`, forward as `setorId` |
+| `src/app/controllers/MessengersController.spec.ts` | modify | Add sector forwarding tests |
+| `src/app/usecases/webhooks/IngestMessengerMessage.ts` | modify | Accept `setorId`, persist on Body |
+| `src/app/usecases/webhooks/IngestMessengerMessage.spec.ts` | modify | Add setorId tests |
+| `src/app/services/MessengerMessage.ts` | modify | Read `body.setor`, stamp onto Messages |
+| `src/app/services/MessengerMessage.spec.ts` | modify | Add setor propagation test |
+
+### Do NOT Modify
+
+- `src/app/routes/api-routes.ts` — owned by phase-2/task-02-auth-middleware
+- `src/app/models/Body.ts` — schema already updated by `setores` plan task-02; do not re-edit
+- `src/app/models/Message.ts` — schema already updated by `setores` plan task-02; do not re-edit
+- `src/app/plugins/chats/LocalChat.ts` — owned by `setores` plan phase-2/task-04; already handles `message.setor`
+
+## Implementation Steps
+
+### Step 1: Update `MessengersController.ts`
+
+```ts
+async message(req: any, res: any) {
+  await this.ingestMessengerMessage.execute({
+    body: req.body,
+    licenseeId: req.licensee._id,
+    setorId: req.setor?._id ?? null,
+  })
+
+  res.status(200).send({ body: 'Solicitação de mensagem para a plataforma de messenger agendado' })
+}
+```
+
+### Step 2: Update `IngestMessengerMessage.ts`
+
+```ts
+async execute({ body, licenseeId, setorId }: Record<string, any> = {}) {
+  const bodySaved = await this.messengerRepository.create({
+    content: body,
+    licensee: licenseeId,
+    kind: MESSENGER_MESSAGE_KIND,
+    setor: setorId ?? null,
+  })
+
+  await this.jobQueue.addJob(MESSENGER_MESSAGE_JOB, {
+    bodyId: bodySaved._id,
+    licenseeId,
+  })
+
+  return bodySaved
+}
+```
+
+### Step 3: Update `transformMessengerBody` in `MessengerMessage.ts`
+
+After `messengerPlugin.responseToMessages(body.content)` returns the list of created messages, stamp `body.setor` onto each message. Read the actual implementation to understand how messages are returned and saved — the approach (update each message's `setor` field in the returned objects, or use a repository save) depends on whether messages are already persisted at this point.
+
+The goal: every `Message` document created from a sector-scoped `Body` must have `setor` set to `body.setor`.
+
+## Testing
+
+- [ ] `MessengersController.message`: when `req.setor` is set, `ingestMessengerMessage.execute` is called with `setorId` equal to `req.setor._id`
+- [ ] `MessengersController.message`: when `req.setor` is absent, `ingestMessengerMessage.execute` is called with `setorId: null`
+- [ ] `IngestMessengerMessage.execute`: Body saved with `setor` when `setorId` provided
+- [ ] `IngestMessengerMessage.execute`: Body saved with `setor: null` when `setorId` is absent
+- [ ] `transformMessengerBody`: each returned Message has `setor` matching `body.setor`
+- [ ] `transformMessengerBody`: when `body.setor` is null, Messages have `setor: null`
+- [ ] All existing tests in the three spec files still pass
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] No KB doc updates required at this task — the full feature is documented in the plan overview
+
+## Completion Criteria
+
+- [ ] `MessengersController` forwards `setorId` from `req.setor?._id`
+- [ ] `IngestMessengerMessage` persists `setorId` on `Body`
+- [ ] `transformMessengerBody` stamps `body.setor` onto each created `Message`
+- [ ] All tests pass: `npx jest src/app/controllers/MessengersController.spec.ts src/app/usecases/webhooks/IngestMessengerMessage.spec.ts src/app/services/MessengerMessage.spec.ts`
+- [ ] `npx eslint src/app/controllers/MessengersController.ts src/app/usecases/webhooks/IngestMessengerMessage.ts src/app/services/MessengerMessage.ts` passes
+- [ ] Changes committed to `plan/setores-webhook-providers/phase-2/task-03-ingest-pipeline` branch
+- [ ] Status updated to `complete` in `status.md`
+
+## Conflict Avoidance Notes
+
+task-02 (auth-middleware) owns `api-routes.ts` only. No file overlap with this task. Both can run in parallel once phase-1 is merged.

--- a/.plans/setores/overview.md
+++ b/.plans/setores/overview.md
@@ -2,7 +2,7 @@
 
 **Status**: not-started
 **Created**: 2026-05-29
-**Last Updated**: 2026-05-29
+**Last Updated**: 2026-06-04
 **Estimated Demo Date**: TBD — depends on local-chat-infra completion
 **Assigned Dev**: Alan Costa Facchini
 **Assigned QA**: unassigned
@@ -30,9 +30,10 @@ Add a Setor (department) entity to the platform, allowing a licensee to have mul
 ### Out of Scope
 - Cross-sector message forwarding or escalation
 - Sector-level chatbot configuration — uses licensee chatbot settings
-- Group WhatsApp numbers per sector (one Baileys session per sector max)
+- Multiple WhatsApp numbers per sector — each sector is limited to exactly one Baileys session (one phone number). Pooling two or more numbers under the same sector is not supported; it would require `WhatsappSession.setor` to become a 1-to-many relationship and a more complex room-lookup strategy.
 - Sector analytics / reporting
 - Automatic agent assignment within a sector (manual pickup only, for now)
+- Sectors for non-Baileys messenger plugins (utalk, dialog, ycloud, pabbly) — those plugins are webhook-based and share a single `licensee.apiToken` endpoint with no mechanism to identify which sector's number a message arrived on. Sector routing is Baileys-only in this plan.
 
 ## Kill Criteria
 
@@ -59,7 +60,7 @@ Add a Setor (department) entity to the platform, allowing a licensee to have mul
 | Task Path | Title | Phase | Status | Depends On |
 |-----------|-------|-------|--------|------------|
 | phase-1/task-01-setor-model-api | Setor model + CRUD API | 1 | not-started | — |
-| phase-1/task-02-schema-migrations | Schema migrations (WhatsappSession, Room, Licensee) | 1 | not-started | — |
+| phase-1/task-02-schema-migrations | Schema migrations (WhatsappSession, Room, Licensee, Message, Body) | 1 | not-started | — |
 | phase-2/task-03-multi-session-baileys | Multi-session BaileysSocketManager + sector endpoints | 2 | not-started | phase-1/task-01-setor-model-api, phase-1/task-02-schema-migrations |
 | phase-2/task-04-message-routing | Message routing + agent access filtering | 2 | not-started | phase-1/task-01-setor-model-api, phase-1/task-02-schema-migrations |
 | phase-3/task-05-frontend-setor-crud | Frontend: Setor CRUD + Baileys connect | 3 | not-started | phase-2/task-03-multi-session-baileys |
@@ -89,6 +90,8 @@ Base branch: `main`
 | `src/app/models/WhatsappSession.ts` | Modify — add `setor` field, change unique index |
 | `src/app/models/Room.ts` | Modify — add `setor` field |
 | `src/app/models/Licensee.ts` | Modify — add `useSetores` flag |
+| `src/app/models/Message.ts` | Modify — add `setor` field (pipeline carrier from socket to Room) |
+| `src/app/models/Body.ts` | Modify — add `setor` field (async job bridge) |
 | `src/app/services/BaileysSocketManager.ts` | Modify — re-key by `session._id` |
 | `src/app/usecases/licensees/StartBaileysSocket.ts` | Modify — accept optional `setor` param |
 | `src/app/routes/resources-routes.ts` | Modify — add sector routes |

--- a/.plans/setores/phase-1/task-02-schema-migrations/task.md
+++ b/.plans/setores/phase-1/task-02-schema-migrations/task.md
@@ -1,4 +1,4 @@
-# Task: Schema migrations (WhatsappSession, Room, Licensee)
+# Task: Schema migrations (WhatsappSession, Room, Licensee, Message, Body)
 
 **Plan**: Setores
 **Phase**: 1
@@ -9,7 +9,7 @@
 
 ## Objective
 
-Add `setor` field to `WhatsappSession` and `Room`, change the `WhatsappSession` unique index from `{ licensee }` to `{ licensee, setor }`, and add `useSetores` flag to `Licensee`.
+Add `setor` field to `WhatsappSession`, `Room`, `Message`, and `Body`; change the `WhatsappSession` unique index from `{ licensee }` to `{ licensee, setor }`; add `useSetores` flag to `Licensee`.
 
 ## Context
 
@@ -27,6 +27,23 @@ Adding `setor` as an optional ObjectId reference. Existing rooms have no sector 
 **`Licensee`:**
 Adding `useSetores: { type: Boolean, default: false }`. Existing licensees default to `false` — no behavioral change until explicitly enabled.
 
+**`Message`:**
+Adding `setor` as an optional ObjectId reference. This is the **pipeline carrier** — the only way the sector context can travel from the Baileys socket event, through the async job worker, and into Room creation. Without it, `LocalChat.sendMessage()` has no way to know which sector's socket received the inbound message.
+
+**`Body`:**
+Adding `setor` as an optional ObjectId reference. `Body` is the persistence bridge between `IngestMessengerMessage` (socket callback, sync) and `transformMessengerBody` (job worker, async). The job payload only carries `bodyId` + `licenseeId` — if `setor` is not stored on the `Body` document, the sector context is lost before message creation.
+
+The propagation chain is:
+```
+WhatsappSession.setor
+  → BaileysSocketManager (passes setorId in onMessage callback)
+    → IngestMessengerMessage({ body, licenseeId, setorId })
+      → Body.create({ ..., setor: setorId })   ← stored here to survive the async gap
+        → job queue: { bodyId, licenseeId }
+          → transformMessengerBody() reads body.setor → Message.create({ ..., setor })
+            → LocalChat.sendMessage() reads message.setor → Room.create({ ..., setor })
+```
+
 ## Before You Start
 
 - [ ] Switch to main and pull: `git switch main && git pull --rebase origin main`
@@ -35,6 +52,8 @@ Adding `useSetores: { type: Boolean, default: false }`. Existing licensees defau
 - [ ] Read `src/app/models/WhatsappSession.ts` (full file)
 - [ ] Read `src/app/models/Room.ts` (full file)
 - [ ] Read `src/app/models/Licensee.ts` (scan for existing field patterns)
+- [ ] Read `src/app/models/Message.ts` (full file)
+- [ ] Read `src/app/models/Body.ts` (full file)
 - [ ] Mark this task `in-progress` in `status.md`
 
 ## File Ownership
@@ -47,12 +66,19 @@ Adding `useSetores: { type: Boolean, default: false }`. Existing licensees defau
 | `src/app/models/Room.spec.ts` | modify | Add field test |
 | `src/app/models/Licensee.ts` | modify | Add `useSetores` flag |
 | `src/app/models/Licensee.spec.ts` | modify | Add flag test |
+| `src/app/models/Message.ts` | modify | Add `setor` field (pipeline carrier) |
+| `src/app/models/Message.spec.ts` | modify | Add field test |
+| `src/app/models/Body.ts` | modify | Add `setor` field (async job bridge) |
+| `src/app/models/Body.spec.ts` | modify | Add field test |
 
 ### Do NOT Modify
 
 - `src/app/models/Setor.ts` — owned by phase-1/task-01-setor-model-api
 - `src/app/repositories/whatsappsession.ts` — read-only (no changes needed to repository layer)
 - `src/app/services/BaileysSocketManager.ts` — owned by phase-2/task-03
+- `src/app/usecases/webhooks/IngestMessengerMessage.ts` — owned by phase-2/task-03
+- `src/app/services/MessengerMessage.ts` — owned by phase-2/task-03
+- `src/app/plugins/chats/LocalChat.ts` — owned by phase-2/task-04
 
 ## Implementation Steps
 
@@ -107,6 +133,28 @@ Add `useSetores` with the other feature flags (near `useChatbot`, `useSenderName
 useSetores: { type: Boolean, default: false },
 ```
 
+### Step 4: Update `Message.ts`
+
+Add after the `room` field:
+```js
+setor: {
+  type: ObjectId,
+  ref: 'Setor',
+  default: null,
+},
+```
+
+### Step 5: Update `Body.ts`
+
+Add after the `kind` field:
+```js
+setor: {
+  type: ObjectId,
+  ref: 'Setor',
+  default: null,
+},
+```
+
 ## Testing
 
 - [ ] `WhatsappSession`: two sessions with the same `licensee` and `setor: null` — second create should fail (application-level guard test)
@@ -114,6 +162,8 @@ useSetores: { type: Boolean, default: false },
 - [ ] `WhatsappSession`: existing session without `setor` field defaults to `null`
 - [ ] `Room`: `setor` field defaults to `null` on new rooms
 - [ ] `Licensee`: `useSetores` defaults to `false`
+- [ ] `Message`: `setor` field defaults to `null`
+- [ ] `Body`: `setor` field defaults to `null`
 - [ ] All existing model tests still pass
 - [ ] `pre-commit-check` passes
 
@@ -123,7 +173,7 @@ useSetores: { type: Boolean, default: false },
 
 ## Completion Criteria
 
-- [ ] All three models updated as described
+- [ ] All five models updated as described (`WhatsappSession`, `Room`, `Licensee`, `Message`, `Body`)
 - [ ] Compound index added to `WhatsappSession`
 - [ ] All tests pass: `npx jest src/app/models/`
 - [ ] `npx eslint src/app/models/` passes


### PR DESCRIPTION
## Plan: Setores — Webhook Providers

Extend sector (Setor) routing to non-Baileys messenger plugins (utalk, dialog, ycloud, pabbly) by embedding a `setorToken` in the inbound webhook URL. The system reads the token in the auth middleware, looks up the Setor, and threads `setorId` through the Body → Message → Room pipeline.

**Type**: Type 1 (Product)
**Phases**: 2  **Tasks**: 3
**Assigned Dev**: Alan Costa Facchini

### Dependency graph

```
phase-1/task-01-setor-token          ← no deps, run first
        ↓              ↓
phase-2/task-02-auth-middleware      ← parallel
phase-2/task-03-ingest-pipeline      ← parallel
```

### Also includes (in this PR)

- `setores/overview.md` — out-of-scope section clarified (Baileys-only constraint, multiple numbers per sector)
- `setores/phase-1/task-02-schema-migrations/task.md` — scope expanded to include `Message` and `Body` schema fields

> **Prerequisite**: Merge `setores` plan to `main` before running `/execute-plan setores-webhook-providers` or any `/execute-task`.