### PR TITLE
plan(onboarding-wizard): Onboarding Wizard

### DIFF
--- a/.plans/README.md
+++ b/.plans/README.md
@@ -27,9 +27,10 @@ Git-native Markdown plans for multi-step work.
 | 3 | [Baileys Socket Monitor](./baileys-socket-monitor/overview.md) | `baileys-socket-monitor/` | complete | Replace webhook-only inbound flow with a persistent Baileys socket per licensee; captures messages.upsert and messages.update natively |
 | 4 | [Local Chat Infrastructure](./local-chat-infra/overview.md) | `local-chat-infra/` | complete | User role system (agent/supervisor/admin/super), LocalChat plugin, super licensee flow, route authorization — prerequisite for setores |
 | 5 | [Setores](./setores/overview.md) | `setores/` | not-started | Multiple WhatsApp numbers per licensee via sectors; sector-scoped message routing and agent access filtering |
-| 8 | [Setores — Webhook Providers](./setores-webhook-providers/overview.md) | `setores-webhook-providers/` | not-started | Extend sector routing to utalk/dialog/ycloud/pabbly via sector token in webhook URL; prerequisite: setores complete |
-| 6 | [Backend Type Narrowing](./type-backend/overview.md) | `type-backend/` | not-started | Replace `any` with interfaces across models, repositories, use cases, controllers, and plugins — 3 phases, 11 tasks |
-| 7 | [Client Type Narrowing](./type-client/overview.md) | `type-client/` | not-started | Replace `any` with interfaces across React services, contexts, pages, and components — 2 phases, 6 tasks |
+| 6 | [Setores — Webhook Providers](./setores-webhook-providers/overview.md) | `setores-webhook-providers/` | not-started | Extend sector routing to utalk/dialog/ycloud/pabbly via sector token in webhook URL; prerequisite: setores complete |
+| 7 | [Backend Type Narrowing](./type-backend/overview.md) | `type-backend/` | not-started | Replace `any` with interfaces across models, repositories, use cases, controllers, and plugins — 3 phases, 11 tasks |
+| 8 | [Client Type Narrowing](./type-client/overview.md) | `type-client/` | not-started | Replace `any` with interfaces across React services, contexts, pages, and components — 2 phases, 6 tasks |
+| 9 | [Onboarding Wizard](./onboarding-wizard/overview.md) | `onboarding-wizard/` | not-started | Public sign-up flow from the login screen: wizard modal collects licensee identity + user credentials and creates both via a single unauthenticated endpoint |
 
 ---
 

--- a/.plans/onboarding-wizard/overview.md
+++ b/.plans/onboarding-wizard/overview.md
@@ -1,0 +1,102 @@
+# Plan: Onboarding Wizard
+
+**Status**: not-started
+**Created**: 2026-06-05
+**Last Updated**: 2026-06-05
+**Estimated Demo Date**: TBD
+**Assigned Dev**: Alan Costa Facchini
+**Assigned QA**: unassigned
+
+## Objective
+
+Add a public self-service onboarding flow reachable from the login screen. A "Create your account" link opens a multi-step wizard modal over the login background; the user fills in licensee identity info and their own credentials, the backend creates both records in a single public endpoint, and the user is redirected to login to access the platform.
+
+## Scope
+
+### In Scope
+- Public `POST /onboarding` backend endpoint (no auth required, rate-limited) that creates a Licensee and an admin User in one request
+- `OnboardAccount` use case with cleanup if user creation fails after licensee creation
+- `OnboardingController` wired directly into `login-route.ts`
+- `OnboardingModal.tsx` — multi-step Bootstrap modal (Step 1: licensee identity; Step 2: user credentials)
+- `onboarding.ts` frontend service calling the public endpoint
+- "Criar conta" link on the Sign-In page that opens the modal
+- On success: modal closes and user lands on the login form with a success banner
+
+### Out of Scope
+- Integration (chat/chatbot/WhatsApp/cart/PagarMe/Pedidos10) wizard steps — those require admin configuration post-signup; excluded to keep onboarding minimal
+- Email verification flow — out of scope for this iteration
+- `licenseKind` locked to `'demo'` server-side — the frontend shows it as a read-only "Demo" label; plan/upgrade flow is future work
+- Any modification to existing `POST /licensees` or `POST /users` protected routes
+
+## Kill Criteria
+
+- If the team decides to require email verification before creating the account, halt and re-plan
+- If `POST /onboarding` is determined to require multi-tenant isolation logic not present in the current schema
+
+## Phases
+
+| Phase | Name | Tasks | Dependencies | Description |
+|-------|------|-------|--------------|-------------|
+| 1 | Backend | task-01 | None | Public use case, controller, and route for combined licensee+user creation |
+| 2 | Frontend Modal | task-02 | Phase 1 | Multi-step wizard component + API service layer |
+| 3 | Sign-in Integration | task-03 | Phase 2 | Wire the modal into the Sign-in page |
+
+## Task Summary
+
+| Task Path | Title | Phase | Status | Depends On |
+|-----------|-------|-------|--------|------------|
+| phase-1/task-01-backend-onboarding-endpoint | Backend Onboarding Endpoint | 1 | not-started | — |
+| phase-2/task-02-onboarding-modal | Onboarding Modal Component | 2 | not-started | phase-1/task-01-backend-onboarding-endpoint |
+| phase-3/task-03-signin-integration | Sign-in Page Integration | 3 | not-started | phase-2/task-02-onboarding-modal |
+
+## Branch Convention
+
+Pattern: `plan/onboarding-wizard/{task-path}`
+
+Example branches:
+- `plan/onboarding-wizard/phase-1/task-01-backend-onboarding-endpoint`
+- `plan/onboarding-wizard/phase-2/task-02-onboarding-modal`
+- `plan/onboarding-wizard/phase-3/task-03-signin-integration`
+
+Base branch: `main`
+
+## Key Files
+
+| File/Directory | Relevance |
+|----------------|-----------|
+| `src/app/routes/login-route.ts` | Public router — add `POST /onboarding` here (same public boundary as login) |
+| `src/app/usecases/licensees/CreateLicensee.ts` | Reference for field whitelist and `pickFields` helper pattern |
+| `src/app/usecases/users/CreateUser.ts` | Reference for user creation pattern |
+| `src/app/models/Licensee.ts` | Required fields: name (≥4), licenseKind (demo/free/paid), email, phone, document, kind (individual/company) |
+| `src/app/models/User.ts` | Required fields: name (≥4), email (unique), password (≥8); `licensee` optional when role=admin |
+| `client/src/pages/SignIn/index.tsx` | Login page — add "Criar conta" link + mount modal |
+| `client/src/pages/Licensees/scenes/New/LicenseeWizard.tsx` | Reference for wizard step structure, Formik setup, and field names |
+| `client/src/components/SelectLicenseeModal/index.tsx` | Reference for Bootstrap modal HTML pattern used in this codebase |
+| `client/src/services/licensee.ts` | Reference for frontend service pattern (api() wrapper, headers) |
+
+## Risks
+
+- `POST /onboarding` is unauthenticated — rate limiting is mandatory to prevent account spam; reuse the loginLimiter pattern from `login-route.ts`
+- User email uniqueness — if signup is attempted with an already-registered email, the backend must return a clear 409 error surfaced in the wizard
+- Licensee orphan on partial failure — if licensee creation succeeds but user creation fails, the use case must delete the orphaned licensee before returning an error
+
+## Success Criteria
+
+- [ ] `POST /onboarding` creates a Licensee and linked admin User; returns 201 with `{ licensee, user }` (password excluded)
+- [ ] `POST /onboarding` is rate-limited and requires no auth token
+- [ ] Wizard modal renders over the login gradient background, not a separate page
+- [ ] Step 1 collects: name, kind, document, email, phone (licenseKind fixed to 'demo' server-side, shown as read-only in UI)
+- [ ] Step 2 collects: user name, email, password, confirmPassword (confirmPassword is frontend-only)
+- [ ] On success: modal closes, Sign-in page shows a success message
+- [ ] On failure: wizard displays the server error message inline
+- [ ] All new backend specs pass (`npx jest`)
+- [ ] All new frontend specs pass (`npx vitest`)
+- [ ] `pre-commit-check` passes on all three task branches
+- [ ] No regressions in existing functionality
+
+## References
+
+- **JIRA Epic**: N/A
+- **Weekly Plan Brief**: N/A
+- **Related Plans**: None
+- **Rock Alignment**: N/A

--- a/.plans/onboarding-wizard/overview.md
+++ b/.plans/onboarding-wizard/overview.md
@@ -9,23 +9,28 @@
 
 ## Objective
 
-Add a public self-service onboarding flow reachable from the login screen. A "Create your account" link opens a multi-step wizard modal over the login background; the user fills in licensee identity info and their own credentials, the backend creates both records in a single public endpoint, and the user is redirected to login to access the platform.
+Add a public self-service onboarding flow reachable from the login screen. A "Criar conta" link opens a multi-step wizard modal over the login background; the user fills in licensee identity, chooses optional chat/WhatsApp integrations, configures chosen integrations, and finally sets their own credentials. The backend creates both records in a single public endpoint and the user is redirected to login.
 
 ## Scope
 
 ### In Scope
-- Public `POST /onboarding` backend endpoint (no auth required, rate-limited) that creates a Licensee and an admin User in one request
+- Public `POST /onboarding` backend endpoint (no auth required, rate-limited) that creates a Licensee and an admin User in one request — accepts licensee identity fields + optional chat/WhatsApp integration fields + user credentials
 - `OnboardAccount` use case with cleanup if user creation fails after licensee creation
 - `OnboardingController` wired directly into `login-route.ts`
-- `OnboardingModal.tsx` — multi-step Bootstrap modal (Step 1: licensee identity; Step 2: user credentials)
+- `OnboardingModal.tsx` — dynamic multi-step wizard modal:
+  - Step 1: Licensee identity (name, kind, document, email, phone)
+  - Step 2: Integration choices — two YesNo gates on same screen (Chat platform? / WhatsApp platform?)
+  - Step 3 (conditional): Chat platform fields — shown only if user chose "Sim" for chat
+  - Step 4 (conditional): WhatsApp platform fields — shown only if user chose "Sim" for WhatsApp
+  - Step 5 (always last): User credentials (name, email, password, confirmPassword)
 - `onboarding.ts` frontend service calling the public endpoint
 - "Criar conta" link on the Sign-In page that opens the modal
 - On success: modal closes and user lands on the login form with a success banner
 
 ### Out of Scope
-- Integration (chat/chatbot/WhatsApp/cart/PagarMe/Pedidos10) wizard steps — those require admin configuration post-signup; excluded to keep onboarding minimal
+- ChatBot integration step — out of scope for onboarding (admin can configure post-signup)
+- `licenseKind` is locked to `'demo'` server-side; not shown in wizard — plan/upgrade is future work
 - Email verification flow — out of scope for this iteration
-- `licenseKind` locked to `'demo'` server-side — the frontend shows it as a read-only "Demo" label; plan/upgrade flow is future work
 - Any modification to existing `POST /licensees` or `POST /users` protected routes
 
 ## Kill Criteria
@@ -38,7 +43,7 @@ Add a public self-service onboarding flow reachable from the login screen. A "Cr
 | Phase | Name | Tasks | Dependencies | Description |
 |-------|------|-------|--------------|-------------|
 | 1 | Backend | task-01 | None | Public use case, controller, and route for combined licensee+user creation |
-| 2 | Frontend Modal | task-02 | Phase 1 | Multi-step wizard component + API service layer |
+| 2 | Frontend Modal | task-02 | Phase 1 | Dynamic multi-step wizard component + API service layer |
 | 3 | Sign-in Integration | task-03 | Phase 2 | Wire the modal into the Sign-in page |
 
 ## Task Summary
@@ -65,28 +70,32 @@ Base branch: `main`
 | File/Directory | Relevance |
 |----------------|-----------|
 | `src/app/routes/login-route.ts` | Public router — add `POST /onboarding` here (same public boundary as login) |
-| `src/app/usecases/licensees/CreateLicensee.ts` | Reference for field whitelist and `pickFields` helper pattern |
-| `src/app/usecases/users/CreateUser.ts` | Reference for user creation pattern |
-| `src/app/models/Licensee.ts` | Required fields: name (≥4), licenseKind (demo/free/paid), email, phone, document, kind (individual/company) |
-| `src/app/models/User.ts` | Required fields: name (≥4), email (unique), password (≥8); `licensee` optional when role=admin |
+| `src/app/usecases/licensees/CreateLicensee.ts` | Reference for `pickFields` helper and field whitelist pattern |
+| `src/app/models/Licensee.ts` | Field constraints: name ≥4, licenseKind enum, chatDefault enum, whatsappDefault enum, conditional token/url requirements |
+| `src/app/models/User.ts` | Required: name ≥4, email (unique), password ≥8; role=admin makes licensee optional |
 | `client/src/pages/SignIn/index.tsx` | Login page — add "Criar conta" link + mount modal |
-| `client/src/pages/Licensees/scenes/New/LicenseeWizard.tsx` | Reference for wizard step structure, Formik setup, and field names |
-| `client/src/components/SelectLicenseeModal/index.tsx` | Reference for Bootstrap modal HTML pattern used in this codebase |
-| `client/src/services/licensee.ts` | Reference for frontend service pattern (api() wrapper, headers) |
+| `client/src/pages/Licensees/scenes/New/LicenseeWizard.tsx` | Reference for YesNoGate component, step progression, Formik + Yup per-step validation pattern |
+| `client/src/pages/Licensees/scenes/Form/panels/ChatPanel.tsx` | Reference for chat field set (chatDefault, chatUrl, chatIdentifier, chatKey) |
+| `client/src/pages/Licensees/scenes/Form/panels/WhatsAppPanel.tsx` | Reference for WhatsApp field set (whatsappDefault, whatsappToken, whatsappUrl) |
+| `client/src/components/SelectLicenseeModal/index.tsx` | Reference for Bootstrap modal HTML pattern |
+| `client/src/services/licensee.ts` | Reference for frontend service pattern (api() wrapper) |
 
 ## Risks
 
-- `POST /onboarding` is unauthenticated — rate limiting is mandatory to prevent account spam; reuse the loginLimiter pattern from `login-route.ts`
-- User email uniqueness — if signup is attempted with an already-registered email, the backend must return a clear 409 error surfaced in the wizard
+- `POST /onboarding` is unauthenticated — rate limiting is mandatory; reuse the loginLimiter pattern from `login-route.ts` with a tighter window (5 per hour)
+- User email uniqueness — duplicate email must surface as a 409 inline in the wizard
 - Licensee orphan on partial failure — if licensee creation succeeds but user creation fails, the use case must delete the orphaned licensee before returning an error
+- Dynamic step sequence — skipping integration steps based on yes/no choices requires careful "next/previous" logic; use a computed `steps` array derived from `wantsChat`/`wantsWhatsapp` state
 
 ## Success Criteria
 
 - [ ] `POST /onboarding` creates a Licensee and linked admin User; returns 201 with `{ licensee, user }` (password excluded)
 - [ ] `POST /onboarding` is rate-limited and requires no auth token
 - [ ] Wizard modal renders over the login gradient background, not a separate page
-- [ ] Step 1 collects: name, kind, document, email, phone (licenseKind fixed to 'demo' server-side, shown as read-only in UI)
-- [ ] Step 2 collects: user name, email, password, confirmPassword (confirmPassword is frontend-only)
+- [ ] Step 1 collects licensee identity (name, kind, document, email, phone)
+- [ ] Step 2 shows two YesNo gates (Chat / WhatsApp); choosing "Não" for both skips directly to user credentials
+- [ ] Steps 3/4 appear only when the user chose "Sim" for the respective integration
+- [ ] Last step always collects user credentials (name, email, password, confirmPassword)
 - [ ] On success: modal closes, Sign-in page shows a success message
 - [ ] On failure: wizard displays the server error message inline
 - [ ] All new backend specs pass (`npx jest`)

--- a/.plans/onboarding-wizard/phase-1/task-01-backend-onboarding-endpoint/status.md
+++ b/.plans/onboarding-wizard/phase-1/task-01-backend-onboarding-endpoint/status.md
@@ -1,0 +1,25 @@
+# Status: Backend Onboarding Endpoint
+
+**Current Status**: not-started
+**Last Updated**: 2026-06-05
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-06-05 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/onboarding-wizard/phase-1/task-01-backend-onboarding-endpoint/task.md
+++ b/.plans/onboarding-wizard/phase-1/task-01-backend-onboarding-endpoint/task.md
@@ -9,30 +9,51 @@
 
 ## Objective
 
-Create a public `POST /onboarding` endpoint that accepts licensee identity fields and user credentials, creates both records in sequence (with cleanup on partial failure), and returns the created pair. The endpoint requires no auth token and is rate-limited.
+Create a public `POST /onboarding` endpoint that accepts licensee identity + optional chat/WhatsApp integration fields + user credentials, creates both records in sequence (with cleanup on partial failure), and returns the created pair. The endpoint requires no auth token and is rate-limited.
 
 ## Context
 
-Both `POST /resources/licensees` and `POST /resources/users` require `authorize('super')` (see `src/app/routes/resources-routes.ts` lines 127 and 132), so onboarding cannot call those routes. This task introduces a parallel public endpoint on the same public router as login (`src/app/routes/login-route.ts`).
+Both `POST /resources/licensees` and `POST /resources/users` require `authorize('super')` (`src/app/routes/resources-routes.ts` lines 127, 132) — onboarding cannot call those. This task introduces a new public route on the same router as login (`src/app/routes/login-route.ts`).
 
 **Field constraints (from Mongoose models)**:
-- Licensee required: `name` (≥4 chars), `licenseKind` ('demo'|'free'|'paid'), `email`, `phone`, `document`, `kind` ('individual'|'company'|'')
-- User required: `name` (≥4 chars), `email` (unique), `password` (≥8 chars); `licensee` optional when `role='admin'`
+- Licensee required: `name` (≥4 chars), `licenseKind` (forced `'demo'` server-side), `email`, `phone`, `document`, `kind` ('individual'|'company')
+- Licensee optional integration fields: `chatDefault`, `chatUrl`, `chatIdentifier`, `chatKey`, `whatsappDefault`, `whatsappToken`, `whatsappUrl`
+- User required: `name` (≥4 chars), `email` (unique), `password` (≥8 chars); role forced to `'admin'`
 
-**DI pattern**: Use cases take repositories as constructor dependencies. See `src/app/usecases/licensees/CreateLicensee.ts` and `src/app/usecases/auth/AuthenticateUser.ts` for the established pattern.
+**Request body shape (flat, to avoid name collisions)**:
+```json
+{
+  "licenseeName": "string",
+  "kind": "individual|company",
+  "document": "string",
+  "licenseeEmail": "string",
+  "phone": "string",
+  "chatDefault": "string (optional)",
+  "chatUrl": "string (optional)",
+  "chatIdentifier": "string (optional)",
+  "chatKey": "string (optional)",
+  "whatsappDefault": "string (optional)",
+  "whatsappToken": "string (optional)",
+  "whatsappUrl": "string (optional)",
+  "userName": "string",
+  "userEmail": "string",
+  "password": "string"
+}
+```
 
-**Rate limiting**: Reuse the `rateLimit` + `RedisStore` pattern from `login-route.ts` lines 12–25.
+The use case maps `licenseeName → name`, `licenseeEmail → email`, `userName → name`, `userEmail → email` internally.
 
-**licenseKind**: Lock to `'demo'` inside the use case regardless of what the client sends. The frontend will display it as read-only.
+**DI pattern**: constructor-injected repositories. See `src/app/usecases/auth/AuthenticateUser.ts`.
+
+**Rate limiting**: 5 attempts per hour (tighter than login) using `rateLimit` + `RedisStore` from `login-route.ts` lines 12–25.
 
 ## Before You Start
 
-- [ ] `git switch main && git pull --rebase origin main`
-- [ ] Verify no existing `/onboarding` route exists: `grep -r "onboarding" src/app/routes/`
-- [ ] Read `src/app/usecases/licensees/CreateLicensee.ts` — understand `pickFields` helper and field whitelist
-- [ ] Read `src/app/usecases/users/CreateUser.ts` — understand user creation pattern
-- [ ] Read `src/app/routes/login-route.ts` — understand public router and rate limiter setup
-- [ ] Read `src/app/usecases/auth/AuthenticateUser.spec.ts` — understand backend spec patterns (factories, memory repos, describe/it structure)
+- [ ] `git switch main && git pull --rebase origin main`; branch `plan/onboarding-wizard/phase-1/task-01-backend-onboarding-endpoint`
+- [ ] Verify no `/onboarding` route exists: `grep -r "onboarding" src/app/routes/`
+- [ ] Read `src/app/usecases/licensees/CreateLicensee.ts` — note `pickFields` helper (reuse it)
+- [ ] Read `src/app/routes/login-route.ts` — note rate limiter setup
+- [ ] Read `src/app/usecases/auth/AuthenticateUser.spec.ts` — note spec pattern (factories, memory repos)
 - [ ] Mark this task `in-progress` in `status.md` before proceeding
 
 ## File Ownership
@@ -41,14 +62,14 @@ Both `POST /resources/licensees` and `POST /resources/users` require `authorize(
 |------|--------|-------|
 | `src/app/usecases/onboarding/OnboardAccount.ts` | create | Core use case |
 | `src/app/usecases/onboarding/OnboardAccount.spec.ts` | create | Unit tests using memory repos and factories |
-| `src/app/controllers/OnboardingController.ts` | create | Thin HTTP adapter; validates required fields, calls use case |
-| `src/app/routes/login-route.ts` | modify | Add `POST /onboarding` with its own rate limiter |
+| `src/app/controllers/OnboardingController.ts` | create | Thin HTTP adapter |
+| `src/app/routes/login-route.ts` | modify | Add rate limiter + `POST /onboarding` |
 
 ### Do NOT Modify
 
 - `src/app/routes/resources-routes.ts` — protected routes, no changes needed
-- `src/app/usecases/licensees/CreateLicensee.ts` — reuse pattern only, do not modify
-- `src/app/usecases/users/CreateUser.ts` — reuse pattern only, do not modify
+- `src/app/usecases/licensees/CreateLicensee.ts` — reference only
+- `src/app/usecases/users/CreateUser.ts` — reference only
 
 ## Implementation Steps
 
@@ -56,83 +77,85 @@ Both `POST /resources/licensees` and `POST /resources/users` require `authorize(
 
 Create `src/app/usecases/onboarding/OnboardAccount.ts`.
 
-The use case:
-- Receives `{ licensee: LicenseeFields, user: UserFields }` (or flat fields — choose flat for simplicity, mirroring `CreateLicensee`)
-- Whitelists licensee fields: `name`, `email`, `phone`, `document`, `kind`; forces `licenseKind: 'demo'` and `active: true`
-- Creates the licensee via `this.licenseeRepository.create(licenseePayload)`
-- If licensee creation throws, re-throws immediately
-- Whitelists user fields: `name`, `email`, `password`; forces `role: 'admin'`, `active: true`, sets `licensee: createdLicensee._id`
-- Creates the user via `this.userRepository.create(userPayload)`
-- If user creation throws, deletes the orphaned licensee (`await this.licenseeRepository.delete(createdLicensee._id)`), then re-throws
-- Returns `{ licensee: createdLicensee, user: createdUser }`
-
-Constructor signature:
 ```ts
-constructor({ licenseeRepository, userRepository }: { licenseeRepository: any; userRepository: any })
+const ONBOARD_LICENSEE_FIELDS = [
+  'name', 'email', 'phone', 'document', 'kind',
+  'chatDefault', 'chatUrl', 'chatIdentifier', 'chatKey',
+  'whatsappDefault', 'whatsappToken', 'whatsappUrl',
+]
+
+const ONBOARD_USER_FIELDS = ['name', 'email', 'password']
 ```
+
+Logic:
+1. Map flat request fields to licensee payload: `name ← licenseeName`, `email ← licenseeEmail`, pick remaining from `ONBOARD_LICENSEE_FIELDS`; force `licenseKind: 'demo'`, `active: true`
+2. `createdLicensee = await this.licenseeRepository.create(licenseePayload)`
+3. If licensee creation throws → re-throw immediately
+4. Map flat request fields to user payload: `name ← userName`, `email ← userEmail`, pick `password`; force `role: 'admin'`, `active: true`, set `licensee: createdLicensee._id`
+5. Try `createdUser = await this.userRepository.create(userPayload)`
+6. If user creation throws → `await this.licenseeRepository.delete(createdLicensee._id)` then re-throw
+7. Return `{ licensee: createdLicensee, user: createdUser }`
+
+Constructor: `constructor({ licenseeRepository, userRepository })`
 
 ### Step 2: Create `OnboardingController`
 
 Create `src/app/controllers/OnboardingController.ts`.
 
-The controller:
-- `validations()` method returns an array of express-validator checks for required fields:
-  - `name` (not empty), `email` (is email), `phone` (not empty), `document` (not empty), `kind` (not empty)
-  - `userName` (not empty), `userEmail` (is email), `password` (length ≥ 8)
-  - Or keep field names separate per object: `licensee.name`, `user.name`, etc. — choose the flat naming approach for simplicity
-- `onboard` handler:
-  - Checks `validationResult(req)` and returns 400 on validation errors
-  - Calls `this.onboardAccount.execute(req.body)`
-  - On success, returns 201 with `{ licensee, user: { ...user, password: undefined } }`
-  - Catches errors and returns 400 with `{ message: error.message }`
+`validations()` — express-validator checks:
+- `licenseeName`: not empty
+- `licenseeEmail`: is email
+- `phone`: not empty
+- `document`: not empty
+- `kind`: not empty
+- `userName`: not empty
+- `userEmail`: is email
+- `password`: length ≥ 8
 
-Field naming on the request body (flat):
-```json
-{
-  "licenseeName": "...", "kind": "...", "document": "...", "licenseeEmail": "...", "phone": "...",
-  "userName": "...", "userEmail": "...", "password": "..."
-}
-```
-The use case unpacks `licenseeName → name`, `licenseeEmail → email`, `userName → name`, `userEmail → email` internally to avoid field collisions.
+`onboard` handler:
+1. Check `validationResult(req)` → 400 on errors
+2. Call `this.onboardAccount.execute(req.body)`
+3. On success → 201 with `{ licensee, user: { ...omit password from user } }`
+4. Catch → 400 with `{ message: error.message }`
 
 ### Step 3: Wire into `login-route.ts`
 
-Add to `src/app/routes/login-route.ts`:
-
-1. Import `OnboardingController`, `LicenseeRepositoryDatabase`, `UserRepositoryDatabase`
-2. Create a second rate limiter `onboardingLimiter` with `limit: 5` and `windowMs: 60 * 60 * 1000` (5 per hour, tighter than login)
-3. Instantiate the use case and controller
-4. Add: `router.post('/onboarding', onboardingLimiter, onboardingController.validations(), onboardingController.onboard)`
+1. Import `OnboardingController`, `LicenseeRepositoryDatabase`, `UserRepositoryDatabase`, `OnboardAccount`
+2. Create `onboardingLimiter`: `limit: 5`, `windowMs: 60 * 60 * 1000`, prefix `'rl:onboarding:'`
+3. Instantiate use case and controller
+4. Add: `router.post('/onboarding', onboardingLimiter, ...onboardingController.validations(), onboardingController.onboard)`
 
 ### Step 4: Write unit tests
 
 Create `src/app/usecases/onboarding/OnboardAccount.spec.ts`.
 
-Tests (use `LicenseeRepositoryMemory` and `UserRepositoryMemory`, and existing factories):
-- Successfully creates both licensee and user; returns `{ licensee, user }`
-- Forces `licenseKind: 'demo'` regardless of input
-- Forces user `role: 'admin'`; links `user.licensee` to `createdLicensee._id`
-- If user creation fails, deletes the orphaned licensee and re-throws
-- Strips password from returned user (if use case handles this — otherwise this is a controller concern)
+Required test cases:
+- Happy path: creates licensee and user, returns `{ licensee, user }`
+- Forces `licenseKind: 'demo'` regardless of any field sent
+- Forces user `role: 'admin'`; sets `user.licensee` to `createdLicensee._id`
+- Maps flat field names correctly (`licenseeName → name`, `licenseeEmail → email`, etc.)
+- Includes optional chat/WhatsApp fields in licensee when present in input
+- If user creation fails → calls `licenseeRepository.delete` with `createdLicensee._id` and re-throws
+
+**Note**: if `LicenseeRepositoryMemory` or `UserRepositoryMemory` lacks a `delete` method, add it to the memory repository before writing tests — this is a prerequisite for the orphan-cleanup test.
 
 ## Testing
 
-- [ ] `OnboardAccount.spec.ts` passes: happy path, forced licenseKind, forced admin role, orphan cleanup on user failure
-- [ ] Manual curl test: `curl -X POST http://localhost:5001/login/onboarding -H "Content-Type: application/json" -d '{...}'` returns 201
-- [ ] Rate limiter: 6th request within 1 hour returns 429
+- [ ] `OnboardAccount.spec.ts` passes all cases above
+- [ ] Manual curl: `curl -X POST http://localhost:5001/login/onboarding -H "Content-Type: application/json" -d '{...}'` returns 201
+- [ ] Rate limit: 6th request within 1 hour returns 429
 - [ ] `npx jest src/app/usecases/onboarding` passes
 - [ ] `pre-commit-check` passes
 
 ## Documentation / KB Updates
 
-- [ ] No KB/doc updates required — pattern mirrors existing use cases; nothing non-obvious introduced
-- [ ] If `delete` method is missing on any repository memory implementation (needed for orphan cleanup), add it and note in status.md
+- [ ] No KB/doc updates required — pattern mirrors existing use cases
 
 ## Completion Criteria
 
-- [ ] `POST /onboarding` route exists and responds correctly
+- [ ] `POST /onboarding` route exists and responds correctly with chat/WhatsApp fields forwarded to licensee
 - [ ] Use case cleans up orphaned licensee on user creation failure
-- [ ] `licenseKind` is always `'demo'`; user is always `role: 'admin'`
+- [ ] `licenseKind` always `'demo'`; user always `role: 'admin'`
 - [ ] All specs pass
 - [ ] `pre-commit-check` passes
 - [ ] Changes committed to `plan/onboarding-wizard/phase-1/task-01-backend-onboarding-endpoint`

--- a/.plans/onboarding-wizard/phase-1/task-01-backend-onboarding-endpoint/task.md
+++ b/.plans/onboarding-wizard/phase-1/task-01-backend-onboarding-endpoint/task.md
@@ -1,0 +1,143 @@
+# Task: Backend Onboarding Endpoint
+
+**Plan**: Onboarding Wizard
+**Phase**: 1
+**Task ID (phase-local)**: task-01
+**Task Path**: phase-1/task-01-backend-onboarding-endpoint
+**Depends On**: None
+**JIRA**: N/A
+
+## Objective
+
+Create a public `POST /onboarding` endpoint that accepts licensee identity fields and user credentials, creates both records in sequence (with cleanup on partial failure), and returns the created pair. The endpoint requires no auth token and is rate-limited.
+
+## Context
+
+Both `POST /resources/licensees` and `POST /resources/users` require `authorize('super')` (see `src/app/routes/resources-routes.ts` lines 127 and 132), so onboarding cannot call those routes. This task introduces a parallel public endpoint on the same public router as login (`src/app/routes/login-route.ts`).
+
+**Field constraints (from Mongoose models)**:
+- Licensee required: `name` (≥4 chars), `licenseKind` ('demo'|'free'|'paid'), `email`, `phone`, `document`, `kind` ('individual'|'company'|'')
+- User required: `name` (≥4 chars), `email` (unique), `password` (≥8 chars); `licensee` optional when `role='admin'`
+
+**DI pattern**: Use cases take repositories as constructor dependencies. See `src/app/usecases/licensees/CreateLicensee.ts` and `src/app/usecases/auth/AuthenticateUser.ts` for the established pattern.
+
+**Rate limiting**: Reuse the `rateLimit` + `RedisStore` pattern from `login-route.ts` lines 12–25.
+
+**licenseKind**: Lock to `'demo'` inside the use case regardless of what the client sends. The frontend will display it as read-only.
+
+## Before You Start
+
+- [ ] `git switch main && git pull --rebase origin main`
+- [ ] Verify no existing `/onboarding` route exists: `grep -r "onboarding" src/app/routes/`
+- [ ] Read `src/app/usecases/licensees/CreateLicensee.ts` — understand `pickFields` helper and field whitelist
+- [ ] Read `src/app/usecases/users/CreateUser.ts` — understand user creation pattern
+- [ ] Read `src/app/routes/login-route.ts` — understand public router and rate limiter setup
+- [ ] Read `src/app/usecases/auth/AuthenticateUser.spec.ts` — understand backend spec patterns (factories, memory repos, describe/it structure)
+- [ ] Mark this task `in-progress` in `status.md` before proceeding
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/app/usecases/onboarding/OnboardAccount.ts` | create | Core use case |
+| `src/app/usecases/onboarding/OnboardAccount.spec.ts` | create | Unit tests using memory repos and factories |
+| `src/app/controllers/OnboardingController.ts` | create | Thin HTTP adapter; validates required fields, calls use case |
+| `src/app/routes/login-route.ts` | modify | Add `POST /onboarding` with its own rate limiter |
+
+### Do NOT Modify
+
+- `src/app/routes/resources-routes.ts` — protected routes, no changes needed
+- `src/app/usecases/licensees/CreateLicensee.ts` — reuse pattern only, do not modify
+- `src/app/usecases/users/CreateUser.ts` — reuse pattern only, do not modify
+
+## Implementation Steps
+
+### Step 1: Create `OnboardAccount` use case
+
+Create `src/app/usecases/onboarding/OnboardAccount.ts`.
+
+The use case:
+- Receives `{ licensee: LicenseeFields, user: UserFields }` (or flat fields — choose flat for simplicity, mirroring `CreateLicensee`)
+- Whitelists licensee fields: `name`, `email`, `phone`, `document`, `kind`; forces `licenseKind: 'demo'` and `active: true`
+- Creates the licensee via `this.licenseeRepository.create(licenseePayload)`
+- If licensee creation throws, re-throws immediately
+- Whitelists user fields: `name`, `email`, `password`; forces `role: 'admin'`, `active: true`, sets `licensee: createdLicensee._id`
+- Creates the user via `this.userRepository.create(userPayload)`
+- If user creation throws, deletes the orphaned licensee (`await this.licenseeRepository.delete(createdLicensee._id)`), then re-throws
+- Returns `{ licensee: createdLicensee, user: createdUser }`
+
+Constructor signature:
+```ts
+constructor({ licenseeRepository, userRepository }: { licenseeRepository: any; userRepository: any })
+```
+
+### Step 2: Create `OnboardingController`
+
+Create `src/app/controllers/OnboardingController.ts`.
+
+The controller:
+- `validations()` method returns an array of express-validator checks for required fields:
+  - `name` (not empty), `email` (is email), `phone` (not empty), `document` (not empty), `kind` (not empty)
+  - `userName` (not empty), `userEmail` (is email), `password` (length ≥ 8)
+  - Or keep field names separate per object: `licensee.name`, `user.name`, etc. — choose the flat naming approach for simplicity
+- `onboard` handler:
+  - Checks `validationResult(req)` and returns 400 on validation errors
+  - Calls `this.onboardAccount.execute(req.body)`
+  - On success, returns 201 with `{ licensee, user: { ...user, password: undefined } }`
+  - Catches errors and returns 400 with `{ message: error.message }`
+
+Field naming on the request body (flat):
+```json
+{
+  "licenseeName": "...", "kind": "...", "document": "...", "licenseeEmail": "...", "phone": "...",
+  "userName": "...", "userEmail": "...", "password": "..."
+}
+```
+The use case unpacks `licenseeName → name`, `licenseeEmail → email`, `userName → name`, `userEmail → email` internally to avoid field collisions.
+
+### Step 3: Wire into `login-route.ts`
+
+Add to `src/app/routes/login-route.ts`:
+
+1. Import `OnboardingController`, `LicenseeRepositoryDatabase`, `UserRepositoryDatabase`
+2. Create a second rate limiter `onboardingLimiter` with `limit: 5` and `windowMs: 60 * 60 * 1000` (5 per hour, tighter than login)
+3. Instantiate the use case and controller
+4. Add: `router.post('/onboarding', onboardingLimiter, onboardingController.validations(), onboardingController.onboard)`
+
+### Step 4: Write unit tests
+
+Create `src/app/usecases/onboarding/OnboardAccount.spec.ts`.
+
+Tests (use `LicenseeRepositoryMemory` and `UserRepositoryMemory`, and existing factories):
+- Successfully creates both licensee and user; returns `{ licensee, user }`
+- Forces `licenseKind: 'demo'` regardless of input
+- Forces user `role: 'admin'`; links `user.licensee` to `createdLicensee._id`
+- If user creation fails, deletes the orphaned licensee and re-throws
+- Strips password from returned user (if use case handles this — otherwise this is a controller concern)
+
+## Testing
+
+- [ ] `OnboardAccount.spec.ts` passes: happy path, forced licenseKind, forced admin role, orphan cleanup on user failure
+- [ ] Manual curl test: `curl -X POST http://localhost:5001/login/onboarding -H "Content-Type: application/json" -d '{...}'` returns 201
+- [ ] Rate limiter: 6th request within 1 hour returns 429
+- [ ] `npx jest src/app/usecases/onboarding` passes
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] No KB/doc updates required — pattern mirrors existing use cases; nothing non-obvious introduced
+- [ ] If `delete` method is missing on any repository memory implementation (needed for orphan cleanup), add it and note in status.md
+
+## Completion Criteria
+
+- [ ] `POST /onboarding` route exists and responds correctly
+- [ ] Use case cleans up orphaned licensee on user creation failure
+- [ ] `licenseKind` is always `'demo'`; user is always `role: 'admin'`
+- [ ] All specs pass
+- [ ] `pre-commit-check` passes
+- [ ] Changes committed to `plan/onboarding-wizard/phase-1/task-01-backend-onboarding-endpoint`
+- [ ] Status updated in `status.md`
+
+## Conflict Avoidance Notes
+
+No parallel tasks in this phase.

--- a/.plans/onboarding-wizard/phase-2/task-02-onboarding-modal/status.md
+++ b/.plans/onboarding-wizard/phase-2/task-02-onboarding-modal/status.md
@@ -1,0 +1,25 @@
+# Status: Onboarding Modal Component
+
+**Current Status**: not-started
+**Last Updated**: 2026-06-05
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-06-05 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/onboarding-wizard/phase-2/task-02-onboarding-modal/task.md
+++ b/.plans/onboarding-wizard/phase-2/task-02-onboarding-modal/task.md
@@ -9,90 +9,107 @@
 
 ## Objective
 
-Create `OnboardingModal.tsx` — a two-step Formik wizard rendered as a Bootstrap modal over the login page gradient background — and `onboarding.ts` — the frontend service that calls `POST /onboarding`. The modal receives `isOpen` and `onClose`/`onSuccess` props from its parent; it owns all form state internally.
+Create `OnboardingModal.tsx` — a dynamic multi-step Formik wizard rendered as a Bootstrap modal over the login gradient — and `onboarding.ts` — the frontend service that calls `POST /onboarding`. Step sequence adjusts at runtime based on integration choices (chat/WhatsApp); the last step always collects user credentials.
 
 ## Context
 
-**Modal pattern in this codebase**: Raw HTML with Bootstrap CSS classes — no react-bootstrap library. See `client/src/components/SelectLicenseeModal/index.tsx` (lines 12–41) and `client/src/pages/Dashboard/cards/FailedMessagesModal.tsx` (lines 54–117). Key pattern: `if (!isOpen) return null`; use `d-block` + `modal fade show`; overlay with `rgba(0,0,0,0.5)`.
+**Modal pattern**: Raw Bootstrap HTML, no react-bootstrap. See `client/src/components/SelectLicenseeModal/index.tsx` (lines 12–41). Key: `if (!isOpen) return null`; `className="modal d-block"` + `backgroundColor: 'rgba(0,0,0,0.5)'` overlay.
 
-**Wizard pattern**: See `client/src/pages/Licensees/scenes/New/LicenseeWizard.tsx`. Uses Formik with per-step Yup validation schemas and a `currentStep` state integer. Step validation (`validateForm()` or Yup `validate`) runs before advancing.
+**YesNoGate component**: Already exists in `LicenseeWizard.tsx` (lines 204–226). Copy it directly — do not import from the wizard.
 
-**Frontend service pattern**: See `client/src/services/licensee.ts`. Uses `api()` wrapper from `../../services/api`. The onboarding endpoint is public so no `x-access-token` header is needed.
+**Step progression (dynamic)**:
+```ts
+type StepId = 'identity' | 'integrations' | 'chat' | 'whatsapp' | 'user'
 
-**Backend request body (flat fields, from task-01)**:
-```json
-{
-  "licenseeName": "string",
-  "kind": "individual|company",
-  "document": "string",
-  "licenseeEmail": "string",
-  "phone": "string",
-  "userName": "string",
-  "userEmail": "string",
-  "password": "string"
+function buildSteps(wantsChat: boolean | null, wantsWhatsapp: boolean | null): StepId[] {
+  return [
+    'identity',
+    'integrations',
+    ...(wantsChat  === true ? ['chat'     as StepId] : []),
+    ...(wantsWhatsapp === true ? ['whatsapp' as StepId] : []),
+    'user',
+  ]
 }
 ```
-`licenseKind` is NOT sent — the backend forces `'demo'`.
+Recompute whenever `wantsChat` or `wantsWhatsapp` changes. `currentStepIndex` always stays within bounds after recomputation (the "integrations" step is never skipped so no index gap can occur mid-wizard).
 
-**Wizard steps**:
-- Step 1 — Licensee: `licenseeName`, `kind` (select: individual/company), `document`, `licenseeEmail`, `phone`
-- Step 2 — User: `userName`, `userEmail`, `password`, `confirmPassword` (confirmPassword is frontend-only; strip before submit)
+**Chat fields** (from `ChatPanel.tsx`): `chatDefault` (select: rocketchat/crisp/cuboup/chatwoot/local), `chatUrl`, `chatIdentifier` (required for crisp/chatwoot), `chatKey` (required for crisp/chatwoot).
 
-**Success flow**: on 201 → call `onSuccess()` prop (parent handles redirect/banner). On error → display `response.data.message` inline in the modal footer.
+**WhatsApp fields** (from `WhatsAppPanel.tsx`): `whatsappDefault` (select: utalk/dialog/ycloud/pabbly/baileys), `whatsappToken` (required unless baileys), `whatsappUrl` (required unless baileys).
+
+**Frontend service**: Public endpoint — no `x-access-token` header. Pattern: `api().post('/onboarding', { body: fields })`.
+
+**Request body sent on submit**: flat object; omit `confirmPassword`; omit chat fields if `wantsChat !== true`; omit WhatsApp fields if `wantsWhatsapp !== true`.
 
 ## Before You Start
 
-- [ ] `git switch main && git pull --rebase origin main`
-- [ ] Verify task-01 status.md shows `complete`
+- [ ] `git switch main && git pull --rebase origin main`; branch `plan/onboarding-wizard/phase-2/task-02-onboarding-modal`
+- [ ] Verify task-01 `status.md` shows `complete`
 - [ ] Read `client/src/components/SelectLicenseeModal/index.tsx` — note exact Bootstrap classes
-- [ ] Read `client/src/pages/Licensees/scenes/New/LicenseeWizard.tsx` lines 65–264 — note Formik + Yup step validation pattern
-- [ ] Read `client/src/services/licensee.ts` — note `api()` wrapper and header pattern
-- [ ] Read `client/src/services/licensee.spec.ts` lines 1–50 — note Vitest mock pattern (`vi.mock`, `apiModule.default.mockReturnValue`)
+- [ ] Read `client/src/pages/Licensees/scenes/New/LicenseeWizard.tsx` lines 204–264 — note `YesNoGate` and `validateStep` pattern
+- [ ] Read `client/src/pages/Licensees/scenes/Form/panels/ChatPanel.tsx` — note field set
+- [ ] Read `client/src/pages/Licensees/scenes/Form/panels/WhatsAppPanel.tsx` — note field set
+- [ ] Read `client/src/services/licensee.ts` — note `api()` wrapper usage
+- [ ] Read `client/src/services/licensee.spec.ts` lines 1–50 — note Vitest mock pattern
 - [ ] Mark this task `in-progress` in `status.md` before proceeding
 
 ## File Ownership
 
 | File | Action | Notes |
 |------|--------|-------|
-| `client/src/pages/SignIn/OnboardingModal.tsx` | create | Two-step wizard modal component |
-| `client/src/services/onboarding.ts` | create | `createAccount(fields)` function; calls `POST /onboarding` |
-| `client/src/services/onboarding.spec.ts` | create | Vitest tests mirroring `licensee.spec.ts` structure |
+| `client/src/pages/SignIn/OnboardingModal.tsx` | create | Full dynamic wizard modal |
+| `client/src/services/onboarding.ts` | create | `createAccount(fields)` — calls `POST /onboarding` |
+| `client/src/services/onboarding.spec.ts` | create | Vitest tests for the service |
 
 ### Do NOT Modify
 
 - `client/src/pages/SignIn/index.tsx` — owned by phase-3/task-03-signin-integration
-- `client/src/services/licensee.ts` — reference only, do not modify
+- `client/src/services/licensee.ts` — reference only
+- `client/src/pages/Licensees/scenes/Form/panels/ChatPanel.tsx` — reference only
+- `client/src/pages/Licensees/scenes/Form/panels/WhatsAppPanel.tsx` — reference only
 
 ## Implementation Steps
 
 ### Step 1: Create `onboarding.ts` service
 
-Create `client/src/services/onboarding.ts`.
-
 ```ts
-// Call public POST /onboarding — no auth token required
+import api from './api'
+
+export interface OnboardingFields {
+  licenseeName: string
+  kind: string
+  document: string
+  licenseeEmail: string
+  phone: string
+  chatDefault?: string
+  chatUrl?: string
+  chatIdentifier?: string
+  chatKey?: string
+  whatsappDefault?: string
+  whatsappToken?: string
+  whatsappUrl?: string
+  userName: string
+  userEmail: string
+  password: string
+}
+
 export async function createAccount(fields: OnboardingFields) {
-  const response = await api().post('/onboarding', { body: fields })
-  return response
+  return api().post('/onboarding', { body: fields })
 }
 ```
 
-Define an `OnboardingFields` interface matching the flat request body shape.
+No auth header — the endpoint is public.
 
 ### Step 2: Create `onboarding.spec.ts`
 
-Create `client/src/services/onboarding.spec.ts`.
-
-Mirror the pattern in `licensee.spec.ts`:
-- `vi.mock('./api')`; mock `apiModule.default.mockReturnValue({ post: mockPost })`
-- Test: `createAccount(fields)` calls `POST /onboarding` with correct body
-- Test: no `x-access-token` header is sent (service should not call `getToken`)
+Mirror `licensee.spec.ts` structure:
+- `vi.mock('./api')`; `vi.mock('./auth')` (so no accidental token import)
+- Test: `createAccount(fields)` calls `api().post('/onboarding', { body: fields })`
+- Test: no `x-access-token` header is passed
 
 ### Step 3: Create `OnboardingModal.tsx`
 
-Create `client/src/pages/SignIn/OnboardingModal.tsx`.
-
-**Structure**:
+**Props interface**:
 ```tsx
 interface Props {
   isOpen: boolean
@@ -101,67 +118,184 @@ interface Props {
 }
 ```
 
-**Modal skeleton** (follow SelectLicenseeModal pattern):
+**State**:
+```tsx
+const [currentStepIndex, setCurrentStepIndex] = useState(0)
+const [wantsChat, setWantsChat]         = useState<boolean | null>(null)
+const [wantsWhatsapp, setWantsWhatsapp] = useState<boolean | null>(null)
+const [stepErrors, setStepErrors]       = useState<string[] | null>(null)
+const [submitError, setSubmitError]     = useState('')
+```
+
+**Step sequence**: use `buildSteps(wantsChat, wantsWhatsapp)` (see Context). Always recompute from state.
+
+**Formik initial values**:
+```ts
+{
+  licenseeName: '', kind: '', document: '', licenseeEmail: '', phone: '',
+  chatDefault: '', chatUrl: '', chatIdentifier: '', chatKey: '',
+  whatsappDefault: '', whatsappToken: '', whatsappUrl: '',
+  userName: '', userEmail: '', password: '', confirmPassword: '',
+}
+```
+
+**Yup schemas per step**:
+- `identity`: licenseeName required, licenseeEmail isEmail, phone/document/kind required
+- `integrations`: no validation (YesNo gates are not Formik fields)
+- `chat`: chatDefault required, chatUrl required; chatIdentifier/chatKey required when chatDefault is 'crisp'/'chatwoot'
+- `whatsapp`: whatsappDefault required; whatsappToken/whatsappUrl required when whatsappDefault is not 'baileys'
+- `user`: userName required (min 4), userEmail isEmail, password min(8), confirmPassword must match password
+
+**`validateCurrentStep` helper**:
+```ts
+async function validateCurrentStep(values: any): Promise<boolean> {
+  const stepId = buildSteps(wantsChat, wantsWhatsapp)[currentStepIndex]
+  const schema = schemaMap[stepId]
+  if (!schema) return true  // integrations step has no Yup schema
+  try {
+    await schema.validate(values, { abortEarly: false })
+    setStepErrors(null)
+    return true
+  } catch (err: any) {
+    setStepErrors(err.errors)
+    return false
+  }
+}
+```
+
+**`handleNext`**:
+1. Validate current step
+2. If valid: `setStepErrors(null); setCurrentStepIndex(i => i + 1)`
+
+**`handleBack`**:
+- `setStepErrors(null); setCurrentStepIndex(i => i - 1)`
+
+**Formik `onSubmit`** (only called when on the last step):
+```ts
+async function handleSubmit(values: any) {
+  const valid = await validateCurrentStep(values)
+  if (!valid) return
+
+  const payload: OnboardingFields = {
+    licenseeName: values.licenseeName,
+    kind: values.kind,
+    document: values.document,
+    licenseeEmail: values.licenseeEmail,
+    phone: values.phone,
+    userName: values.userName,
+    userEmail: values.userEmail,
+    password: values.password,
+    ...(wantsChat ? {
+      chatDefault: values.chatDefault,
+      chatUrl: values.chatUrl,
+      chatIdentifier: values.chatIdentifier,
+      chatKey: values.chatKey,
+    } : {}),
+    ...(wantsWhatsapp ? {
+      whatsappDefault: values.whatsappDefault,
+      whatsappToken: values.whatsappToken,
+      whatsappUrl: values.whatsappUrl,
+    } : {}),
+  }
+
+  const response = await createAccount(payload)
+  if (response.status === 201) {
+    onSuccess()
+  } else {
+    setSubmitError(response.data?.message || 'Erro ao criar conta')
+  }
+}
+```
+
+**Modal JSX skeleton**:
 ```tsx
 if (!isOpen) return null
+const steps = buildSteps(wantsChat, wantsWhatsapp)
+const stepId = steps[currentStepIndex]
+const isLast = currentStepIndex === steps.length - 1
+
 return (
   <div className="modal d-block" style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}>
     <div className="modal-dialog modal-dialog-centered modal-lg">
       <div className="modal-content">
-        <div className="modal-header">...</div>
-        <div className="modal-body">...</div>
-        <div className="modal-footer">...</div>
+        <div className="modal-header">
+          <h5 className="modal-title">Criar conta</h5>
+          <p className="text-muted mb-0 ms-2 small">Passo {currentStepIndex + 1} de {steps.length}</p>
+          <button type="button" className="btn-close" onClick={onClose} />
+        </div>
+        <div className="modal-body">
+          {/* render step content based on stepId */}
+        </div>
+        <div className="modal-footer flex-column align-items-stretch">
+          {(stepErrors || submitError) && (
+            <div className="alert alert-danger mb-2">
+              {stepErrors?.map(e => <div key={e}>{e}</div>)}
+              {submitError && <div>{submitError}</div>}
+            </div>
+          )}
+          <div className="d-flex justify-content-between">
+            {currentStepIndex === 0
+              ? <button className="btn btn-secondary" onClick={onClose}>Cancelar</button>
+              : <button className="btn btn-outline-secondary" onClick={handleBack}>← Voltar</button>
+            }
+            {isLast
+              ? <button className="btn btn-success" onClick={() => formik.submitForm()}>Criar conta</button>
+              : <button className="btn btn-primary" onClick={() => handleNext(formik.values)}>Próximo →</button>
+            }
+          </div>
+        </div>
       </div>
     </div>
   </div>
 )
 ```
 
-**Formik setup**:
-- Single `useFormik` instance wrapping both steps
-- Initial values: all fields as empty strings
-- `currentStep` state: `useState(1)`
-- Validation: two Yup schemas (step-1 and step-2); validate only the current step's fields before advancing
-- `onSubmit`: call `createAccount(strippedFields)` (omit `confirmPassword`); call `onSuccess()` on 201; set inline error on failure
+**Step content per `stepId`**:
 
-**Step 1 fields** (in the modal body when `currentStep === 1`):
-- `licenseeName` — text, label "Nome da empresa"
-- `kind` — select: `''` (select…) / `individual` (Pessoa Física) / `company` (Empresa)
-- `document` — text, label "CPF / CNPJ"
-- `licenseeEmail` — email, label "Email da empresa"
-- `phone` — text, label "Telefone"
+- `identity`: render five form fields (licenseeName, kind select, document, licenseeEmail, phone) using Bootstrap form classes (no `FieldWithError` — that component is for the admin area)
+- `integrations`: render two `YesNoGate` blocks stacked — one for chat, one for WhatsApp; update `wantsChat`/`wantsWhatsapp` state via `onChange`
+- `chat`: render chatDefault select (rocketchat/crisp/cuboup/chatwoot/local), chatUrl text; conditionally render chatIdentifier and chatKey when chatDefault is 'crisp' or 'chatwoot'
+- `whatsapp`: render whatsappDefault select (utalk/dialog/ycloud/pabbly/baileys), whatsappToken and whatsappUrl inputs conditionally hidden when whatsappDefault is 'baileys'
+- `user`: render userName, userEmail, password (type=password), confirmPassword (type=password)
 
-**Step 2 fields** (in the modal body when `currentStep === 2`):
-- `userName` — text, label "Seu nome"
-- `userEmail` — email, label "Seu email"
-- `password` — password, label "Senha" (min 8 chars)
-- `confirmPassword` — password, label "Confirmar senha"
+All inputs use `formik.values`, `formik.handleChange`, `formik.handleBlur`. Display inline `text-danger small` messages for field-level errors from `formik.errors` where available.
 
-**Footer**:
-- Step 1: "Próximo" button (validates step-1 then advances) + "Cancelar" (calls `onClose`)
-- Step 2: "Anterior" button (goes back to step 1) + "Criar conta" submit button
-- Error message displayed above buttons when present
-
-**Step indicator**: Simple "Passo 1 de 2" / "Passo 2 de 2" text in the modal header subtitle.
+**`YesNoGate`** (copy from LicenseeWizard — do not import):
+```tsx
+function YesNoGate({ label, isYes, onChange }: { label: string; isYes: boolean | null; onChange: (v: boolean) => void }) {
+  return (
+    <div className="mb-3">
+      <p className="fw-semibold">{label}</p>
+      <div className="btn-group" role="group">
+        <button type="button" className={`btn ${isYes === true ? 'btn-primary' : 'btn-outline-primary'}`} onClick={() => onChange(true)}>Sim</button>
+        <button type="button" className={`btn ${isYes === false ? 'btn-secondary' : 'btn-outline-secondary'}`} onClick={() => onChange(false)}>Não</button>
+      </div>
+    </div>
+  )
+}
+```
 
 ## Testing
 
-- [ ] `onboarding.spec.ts` passes: correct POST URL, no auth header sent
-- [ ] Manual: open modal, fill step 1, click Próximo — form only advances when all step-1 fields are valid
-- [ ] Manual: click Anterior on step 2 — goes back with values preserved
-- [ ] Manual: submit with duplicate email — inline error displayed
+- [ ] `onboarding.spec.ts` passes: correct POST URL, no auth header
+- [ ] Manual: open modal; fill identity step; "Próximo" blocked when any required field is empty
+- [ ] Manual: integrations step — choose "Sim" for chat only → chat step appears; whatsapp step is skipped; user step is last
+- [ ] Manual: integrations step — choose "Não" for both → jumps directly to user step
+- [ ] Manual: "← Voltar" on user step returns to integrations step (or chat/whatsapp if chosen)
+- [ ] Manual: submit with duplicate email → inline submit error displayed
+- [ ] Manual: happy path end-to-end → `onSuccess()` called (parent handles banner)
 - [ ] `npx vitest run client/src/services/onboarding.spec.ts` passes
 - [ ] `pre-commit-check` passes
 
 ## Documentation / KB Updates
 
-- [ ] No KB/doc updates required — pattern mirrors existing modals and services; nothing non-obvious introduced
+- [ ] No KB/doc updates required — pattern mirrors existing modals and services
 
 ## Completion Criteria
 
-- [ ] `OnboardingModal.tsx` renders a two-step wizard in a Bootstrap modal
+- [ ] `OnboardingModal.tsx` renders a dynamic step wizard; integration steps appear/skip based on yes/no choices
 - [ ] `onboarding.ts` calls the correct endpoint without an auth token
-- [ ] Formik validation blocks step advancement when fields are invalid
+- [ ] Formik validation blocks step advancement when fields are invalid; integration step passes immediately
 - [ ] Error from API displayed inline in modal footer
 - [ ] All new specs pass
 - [ ] `pre-commit-check` passes

--- a/.plans/onboarding-wizard/phase-2/task-02-onboarding-modal/task.md
+++ b/.plans/onboarding-wizard/phase-2/task-02-onboarding-modal/task.md
@@ -1,0 +1,173 @@
+# Task: Onboarding Modal Component
+
+**Plan**: Onboarding Wizard
+**Phase**: 2
+**Task ID (phase-local)**: task-02
+**Task Path**: phase-2/task-02-onboarding-modal
+**Depends On**: phase-1/task-01-backend-onboarding-endpoint
+**JIRA**: N/A
+
+## Objective
+
+Create `OnboardingModal.tsx` — a two-step Formik wizard rendered as a Bootstrap modal over the login page gradient background — and `onboarding.ts` — the frontend service that calls `POST /onboarding`. The modal receives `isOpen` and `onClose`/`onSuccess` props from its parent; it owns all form state internally.
+
+## Context
+
+**Modal pattern in this codebase**: Raw HTML with Bootstrap CSS classes — no react-bootstrap library. See `client/src/components/SelectLicenseeModal/index.tsx` (lines 12–41) and `client/src/pages/Dashboard/cards/FailedMessagesModal.tsx` (lines 54–117). Key pattern: `if (!isOpen) return null`; use `d-block` + `modal fade show`; overlay with `rgba(0,0,0,0.5)`.
+
+**Wizard pattern**: See `client/src/pages/Licensees/scenes/New/LicenseeWizard.tsx`. Uses Formik with per-step Yup validation schemas and a `currentStep` state integer. Step validation (`validateForm()` or Yup `validate`) runs before advancing.
+
+**Frontend service pattern**: See `client/src/services/licensee.ts`. Uses `api()` wrapper from `../../services/api`. The onboarding endpoint is public so no `x-access-token` header is needed.
+
+**Backend request body (flat fields, from task-01)**:
+```json
+{
+  "licenseeName": "string",
+  "kind": "individual|company",
+  "document": "string",
+  "licenseeEmail": "string",
+  "phone": "string",
+  "userName": "string",
+  "userEmail": "string",
+  "password": "string"
+}
+```
+`licenseKind` is NOT sent — the backend forces `'demo'`.
+
+**Wizard steps**:
+- Step 1 — Licensee: `licenseeName`, `kind` (select: individual/company), `document`, `licenseeEmail`, `phone`
+- Step 2 — User: `userName`, `userEmail`, `password`, `confirmPassword` (confirmPassword is frontend-only; strip before submit)
+
+**Success flow**: on 201 → call `onSuccess()` prop (parent handles redirect/banner). On error → display `response.data.message` inline in the modal footer.
+
+## Before You Start
+
+- [ ] `git switch main && git pull --rebase origin main`
+- [ ] Verify task-01 status.md shows `complete`
+- [ ] Read `client/src/components/SelectLicenseeModal/index.tsx` — note exact Bootstrap classes
+- [ ] Read `client/src/pages/Licensees/scenes/New/LicenseeWizard.tsx` lines 65–264 — note Formik + Yup step validation pattern
+- [ ] Read `client/src/services/licensee.ts` — note `api()` wrapper and header pattern
+- [ ] Read `client/src/services/licensee.spec.ts` lines 1–50 — note Vitest mock pattern (`vi.mock`, `apiModule.default.mockReturnValue`)
+- [ ] Mark this task `in-progress` in `status.md` before proceeding
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `client/src/pages/SignIn/OnboardingModal.tsx` | create | Two-step wizard modal component |
+| `client/src/services/onboarding.ts` | create | `createAccount(fields)` function; calls `POST /onboarding` |
+| `client/src/services/onboarding.spec.ts` | create | Vitest tests mirroring `licensee.spec.ts` structure |
+
+### Do NOT Modify
+
+- `client/src/pages/SignIn/index.tsx` — owned by phase-3/task-03-signin-integration
+- `client/src/services/licensee.ts` — reference only, do not modify
+
+## Implementation Steps
+
+### Step 1: Create `onboarding.ts` service
+
+Create `client/src/services/onboarding.ts`.
+
+```ts
+// Call public POST /onboarding — no auth token required
+export async function createAccount(fields: OnboardingFields) {
+  const response = await api().post('/onboarding', { body: fields })
+  return response
+}
+```
+
+Define an `OnboardingFields` interface matching the flat request body shape.
+
+### Step 2: Create `onboarding.spec.ts`
+
+Create `client/src/services/onboarding.spec.ts`.
+
+Mirror the pattern in `licensee.spec.ts`:
+- `vi.mock('./api')`; mock `apiModule.default.mockReturnValue({ post: mockPost })`
+- Test: `createAccount(fields)` calls `POST /onboarding` with correct body
+- Test: no `x-access-token` header is sent (service should not call `getToken`)
+
+### Step 3: Create `OnboardingModal.tsx`
+
+Create `client/src/pages/SignIn/OnboardingModal.tsx`.
+
+**Structure**:
+```tsx
+interface Props {
+  isOpen: boolean
+  onClose: () => void
+  onSuccess: () => void
+}
+```
+
+**Modal skeleton** (follow SelectLicenseeModal pattern):
+```tsx
+if (!isOpen) return null
+return (
+  <div className="modal d-block" style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}>
+    <div className="modal-dialog modal-dialog-centered modal-lg">
+      <div className="modal-content">
+        <div className="modal-header">...</div>
+        <div className="modal-body">...</div>
+        <div className="modal-footer">...</div>
+      </div>
+    </div>
+  </div>
+)
+```
+
+**Formik setup**:
+- Single `useFormik` instance wrapping both steps
+- Initial values: all fields as empty strings
+- `currentStep` state: `useState(1)`
+- Validation: two Yup schemas (step-1 and step-2); validate only the current step's fields before advancing
+- `onSubmit`: call `createAccount(strippedFields)` (omit `confirmPassword`); call `onSuccess()` on 201; set inline error on failure
+
+**Step 1 fields** (in the modal body when `currentStep === 1`):
+- `licenseeName` — text, label "Nome da empresa"
+- `kind` — select: `''` (select…) / `individual` (Pessoa Física) / `company` (Empresa)
+- `document` — text, label "CPF / CNPJ"
+- `licenseeEmail` — email, label "Email da empresa"
+- `phone` — text, label "Telefone"
+
+**Step 2 fields** (in the modal body when `currentStep === 2`):
+- `userName` — text, label "Seu nome"
+- `userEmail` — email, label "Seu email"
+- `password` — password, label "Senha" (min 8 chars)
+- `confirmPassword` — password, label "Confirmar senha"
+
+**Footer**:
+- Step 1: "Próximo" button (validates step-1 then advances) + "Cancelar" (calls `onClose`)
+- Step 2: "Anterior" button (goes back to step 1) + "Criar conta" submit button
+- Error message displayed above buttons when present
+
+**Step indicator**: Simple "Passo 1 de 2" / "Passo 2 de 2" text in the modal header subtitle.
+
+## Testing
+
+- [ ] `onboarding.spec.ts` passes: correct POST URL, no auth header sent
+- [ ] Manual: open modal, fill step 1, click Próximo — form only advances when all step-1 fields are valid
+- [ ] Manual: click Anterior on step 2 — goes back with values preserved
+- [ ] Manual: submit with duplicate email — inline error displayed
+- [ ] `npx vitest run client/src/services/onboarding.spec.ts` passes
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] No KB/doc updates required — pattern mirrors existing modals and services; nothing non-obvious introduced
+
+## Completion Criteria
+
+- [ ] `OnboardingModal.tsx` renders a two-step wizard in a Bootstrap modal
+- [ ] `onboarding.ts` calls the correct endpoint without an auth token
+- [ ] Formik validation blocks step advancement when fields are invalid
+- [ ] Error from API displayed inline in modal footer
+- [ ] All new specs pass
+- [ ] `pre-commit-check` passes
+- [ ] Changes committed to `plan/onboarding-wizard/phase-2/task-02-onboarding-modal`
+- [ ] Status updated in `status.md`
+
+## Conflict Avoidance Notes
+
+No parallel tasks in this phase.

--- a/.plans/onboarding-wizard/phase-3/task-03-signin-integration/status.md
+++ b/.plans/onboarding-wizard/phase-3/task-03-signin-integration/status.md
@@ -1,0 +1,25 @@
+# Status: Sign-in Page Integration
+
+**Current Status**: not-started
+**Last Updated**: 2026-06-05
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-06-05 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/onboarding-wizard/phase-3/task-03-signin-integration/task.md
+++ b/.plans/onboarding-wizard/phase-3/task-03-signin-integration/task.md
@@ -1,0 +1,138 @@
+# Task: Sign-in Page Integration
+
+**Plan**: Onboarding Wizard
+**Phase**: 3
+**Task ID (phase-local)**: task-03
+**Task Path**: phase-3/task-03-signin-integration
+**Depends On**: phase-2/task-02-onboarding-modal
+**JIRA**: N/A
+
+## Objective
+
+Update `client/src/pages/SignIn/index.tsx` to add a "Criar conta" link below the login button, manage `isOpen` state for `OnboardingModal`, display a success banner after successful onboarding, and redirect the user to the login form so they can sign in immediately.
+
+## Context
+
+`SignIn/index.tsx` is a functional React component (98 lines) with local `useState` hooks for `email`, `password`, and `error`. The background is an inline gradient `linear-gradient(135deg, #2c3e50, #3498db)`.
+
+The `OnboardingModal` (created in task-02) accepts `isOpen`, `onClose`, and `onSuccess` props. `onSuccess` should:
+1. Set `isOpen` to `false`
+2. Set a `successMessage` state (e.g., "Conta criada com sucesso! Faça login para continuar.")
+3. Clear `successMessage` after 8 seconds or leave it persistent — keep it persistent (user needs to read it and then log in)
+
+The "Criar conta" link sits below the login button and is styled as a subtle text link (`btn btn-link` or plain `<a>` tag) matching the page's light-text-on-dark aesthetic.
+
+**Important**: `OnboardingModal` renders itself over the sign-in page background — it must be mounted inside the `SignIn` component's JSX (not in a portal) so the gradient background shows through the modal overlay.
+
+## Before You Start
+
+- [ ] `git switch main && git pull --rebase origin main`
+- [ ] Verify task-02 status.md shows `complete`
+- [ ] Read `client/src/pages/SignIn/index.tsx` in full — know the existing state hooks and JSX structure before touching it
+- [ ] Confirm `OnboardingModal.tsx` exists at `client/src/pages/SignIn/OnboardingModal.tsx`
+- [ ] Mark this task `in-progress` in `status.md` before proceeding
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `client/src/pages/SignIn/index.tsx` | modify | Add modal state, success banner, "Criar conta" link, and modal mount |
+
+### Do NOT Modify
+
+- `client/src/pages/SignIn/OnboardingModal.tsx` — owned by phase-2/task-02-onboarding-modal
+- `client/src/services/onboarding.ts` — owned by phase-2/task-02-onboarding-modal
+
+## Implementation Steps
+
+### Step 1: Add state and handlers
+
+Add to the `SignIn` component:
+```tsx
+const [isOnboardingOpen, setIsOnboardingOpen] = useState(false)
+const [successMessage, setSuccessMessage] = useState('')
+```
+
+Add handlers:
+```tsx
+function handleOnboardingSuccess() {
+  setIsOnboardingOpen(false)
+  setSuccessMessage('Conta criada com sucesso! Faça login para continuar.')
+}
+```
+
+### Step 2: Add success banner in JSX
+
+Below the `error` display and above the login button, add:
+```tsx
+{successMessage && (
+  <div className="alert alert-success mt-3">{successMessage}</div>
+)}
+```
+
+### Step 3: Add "Criar conta" link
+
+Below the existing login `<button>` (line 82–86 of current file), add:
+```tsx
+<div className="text-center mt-3">
+  <button
+    type="button"
+    className="btn btn-link text-white p-0"
+    onClick={() => setIsOnboardingOpen(true)}
+  >
+    Criar conta
+  </button>
+</div>
+```
+
+### Step 4: Mount the modal
+
+At the bottom of the returned JSX (still inside the outer `<>` fragment), add:
+```tsx
+<OnboardingModal
+  isOpen={isOnboardingOpen}
+  onClose={() => setIsOnboardingOpen(false)}
+  onSuccess={handleOnboardingSuccess}
+/>
+```
+
+Import `OnboardingModal` at the top of the file:
+```tsx
+import OnboardingModal from './OnboardingModal'
+```
+
+### Step 5: Verify rendering
+
+Run `yarn run dev` (backend on port 5001, frontend on Vite default). Navigate to `/signin`, confirm:
+- "Criar conta" link appears
+- Clicking it opens the modal over the gradient background
+- Completing the wizard closes the modal and shows the success alert
+- The success alert is visible and the login form is ready to use
+
+## Testing
+
+- [ ] Manual walkthrough: full happy path — fill both steps, submit, see success banner, log in with created credentials
+- [ ] Manual: close button (X) in modal header dismisses modal without submitting
+- [ ] Manual: step-1 validation — try to advance with empty fields; form should not advance
+- [ ] Manual: duplicate email — server returns error; modal displays it inline
+- [ ] No existing tests in `client/src/pages/SignIn/` to preserve or update
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] No KB/doc updates required — change is a simple component composition
+- [ ] If onboarding pattern is later extended, run `document-solution` at that point
+
+## Completion Criteria
+
+- [ ] "Criar conta" link visible on the sign-in page
+- [ ] Clicking link opens `OnboardingModal` over the gradient background
+- [ ] On successful onboarding, modal closes and success banner appears
+- [ ] Login form remains functional (no regressions)
+- [ ] `pre-commit-check` passes
+- [ ] Changes committed to `plan/onboarding-wizard/phase-3/task-03-signin-integration`
+- [ ] Status updated in `status.md`
+
+## Conflict Avoidance Notes
+
+No parallel tasks in this phase.


### PR DESCRIPTION
## Plan: Onboarding Wizard

Public self-service sign-up flow reachable from the login screen. A \"Criar conta\" link opens a two-step wizard modal over the login gradient background; the wizard collects licensee identity info and user credentials, the backend creates both records via a single unauthenticated endpoint, and the user is redirected to log in.

**Type**: Type 1 (Product)
**Phases**: 3  **Tasks**: 3
**Assigned Dev**: Alan Costa Facchini

### Task breakdown

| Phase | Task | Description |
|-------|------|-------------|
| 1 | task-01-backend-onboarding-endpoint | `OnboardAccount` use case + `OnboardingController` + public `POST /onboarding` route (rate-limited, no auth) |
| 2 | task-02-onboarding-modal | `OnboardingModal.tsx` two-step Formik wizard + `onboarding.ts` frontend service |
| 3 | task-03-signin-integration | Add "Criar conta" link and mount modal in `SignIn/index.tsx` |

> Merge this PR before running `/execute-plan onboarding-wizard` or any `/execute-task`.