### PR TITLE
feat(onboarding): wire wizard modal into Sign-in page

### DIFF
--- a/.plans/README.md
+++ b/.plans/README.md
@@ -30,7 +30,7 @@ Git-native Markdown plans for multi-step work.
 | 6 | [Setores — Webhook Providers](./setores-webhook-providers/overview.md) | `setores-webhook-providers/` | not-started | Extend sector routing to utalk/dialog/ycloud/pabbly via sector token in webhook URL; prerequisite: setores complete |
 | 7 | [Backend Type Narrowing](./type-backend/overview.md) | `type-backend/` | not-started | Replace `any` with interfaces across models, repositories, use cases, controllers, and plugins — 3 phases, 11 tasks |
 | 8 | [Client Type Narrowing](./type-client/overview.md) | `type-client/` | not-started | Replace `any` with interfaces across React services, contexts, pages, and components — 2 phases, 6 tasks |
-| 9 | [Onboarding Wizard](./onboarding-wizard/overview.md) | `onboarding-wizard/` | not-started | Public sign-up flow from the login screen: wizard modal collects licensee identity + user credentials and creates both via a single unauthenticated endpoint |
+| 9 | [Onboarding Wizard](./onboarding-wizard/overview.md) | `onboarding-wizard/` | complete | Public sign-up flow from the login screen: wizard modal collects licensee identity + user credentials and creates both via a single unauthenticated endpoint |
 
 ---
 

--- a/.plans/onboarding-wizard/overview.md
+++ b/.plans/onboarding-wizard/overview.md
@@ -50,8 +50,8 @@ Add a public self-service onboarding flow reachable from the login screen. A "Cr
 
 | Task Path | Title | Phase | Status | Depends On |
 |-----------|-------|-------|--------|------------|
-| phase-1/task-01-backend-onboarding-endpoint | Backend Onboarding Endpoint | 1 | not-started | — |
-| phase-2/task-02-onboarding-modal | Onboarding Modal Component | 2 | not-started | phase-1/task-01-backend-onboarding-endpoint |
+| phase-1/task-01-backend-onboarding-endpoint | Backend Onboarding Endpoint | 1 | complete | — |
+| phase-2/task-02-onboarding-modal | Onboarding Modal Component | 2 | complete | phase-1/task-01-backend-onboarding-endpoint |
 | phase-3/task-03-signin-integration | Sign-in Page Integration | 3 | not-started | phase-2/task-02-onboarding-modal |
 
 ## Branch Convention

--- a/.plans/onboarding-wizard/overview.md
+++ b/.plans/onboarding-wizard/overview.md
@@ -1,6 +1,6 @@
 # Plan: Onboarding Wizard
 
-**Status**: not-started
+**Status**: complete
 **Created**: 2026-06-05
 **Last Updated**: 2026-06-05
 **Estimated Demo Date**: TBD
@@ -52,7 +52,7 @@ Add a public self-service onboarding flow reachable from the login screen. A "Cr
 |-----------|-------|-------|--------|------------|
 | phase-1/task-01-backend-onboarding-endpoint | Backend Onboarding Endpoint | 1 | complete | — |
 | phase-2/task-02-onboarding-modal | Onboarding Modal Component | 2 | complete | phase-1/task-01-backend-onboarding-endpoint |
-| phase-3/task-03-signin-integration | Sign-in Page Integration | 3 | not-started | phase-2/task-02-onboarding-modal |
+| phase-3/task-03-signin-integration | Sign-in Page Integration | 3 | complete | phase-2/task-02-onboarding-modal |
 
 ## Branch Convention
 

--- a/.plans/onboarding-wizard/phase-2/task-02-onboarding-modal/status.md
+++ b/.plans/onboarding-wizard/phase-2/task-02-onboarding-modal/status.md
@@ -1,9 +1,9 @@
 # Status: Onboarding Modal Component
 
-**Current Status**: not-started
+**Current Status**: complete
 **Last Updated**: 2026-06-05
-**Agent**: —
-**Branch**: —
+**Agent**: claude-sonnet-4-6
+**Branch**: plan/onboarding-wizard/phase-2/task-02-onboarding-modal
 **PR**: —
 
 ## Status History
@@ -11,6 +11,8 @@
 | Timestamp | Status | Agent | Notes |
 |-----------|--------|-------|-------|
 | 2026-06-05 | not-started | — | Task created |
+| 2026-06-05 | in-progress | claude-sonnet-4-6 | Implementing OnboardingModal.tsx and onboarding.ts service |
+| 2026-06-05 | complete | claude-sonnet-4-6 | 245/245 client tests pass, 2/2 onboarding.spec.ts pass |
 
 ## Blockers
 

--- a/.plans/onboarding-wizard/phase-3/task-03-signin-integration/status.md
+++ b/.plans/onboarding-wizard/phase-3/task-03-signin-integration/status.md
@@ -1,9 +1,9 @@
 # Status: Sign-in Page Integration
 
-**Current Status**: not-started
+**Current Status**: complete
 **Last Updated**: 2026-06-05
-**Agent**: —
-**Branch**: —
+**Agent**: claude-sonnet-4-6
+**Branch**: plan/onboarding-wizard/phase-3/task-03-signin-integration
 **PR**: —
 
 ## Status History
@@ -11,6 +11,8 @@
 | Timestamp | Status | Agent | Notes |
 |-----------|--------|-------|-------|
 | 2026-06-05 | not-started | — | Task created |
+| 2026-06-05 | in-progress | claude-sonnet-4-6 | Wiring OnboardingModal into SignIn page |
+| 2026-06-05 | complete | claude-sonnet-4-6 | 245/245 client tests pass |
 
 ## Blockers
 
@@ -22,4 +24,4 @@ None
 
 ## Adaptations
 
-None
+Branched from task-02 (not main) so OnboardingModal.tsx is available before PRs merge.

--- a/client/src/pages/SignIn/OnboardingModal.tsx
+++ b/client/src/pages/SignIn/OnboardingModal.tsx
@@ -1,0 +1,604 @@
+import React, { useState } from 'react'
+import { Formik } from 'formik'
+import * as Yup from 'yup'
+import { createAccount, OnboardingFields } from '../../services/onboarding'
+
+type StepId = 'identity' | 'integrations' | 'chat' | 'whatsapp' | 'user'
+
+function buildSteps(wantsChat: boolean | null, wantsWhatsapp: boolean | null): StepId[] {
+  return [
+    'identity',
+    'integrations',
+    ...(wantsChat === true ? ['chat' as StepId] : []),
+    ...(wantsWhatsapp === true ? ['whatsapp' as StepId] : []),
+    'user',
+  ]
+}
+
+const identitySchema = Yup.object().shape({
+  licenseeName: Yup.string().required('Nome da empresa é obrigatório'),
+  kind:         Yup.string().required('Tipo é obrigatório'),
+  document:     Yup.string().required('Documento é obrigatório'),
+  licenseeEmail: Yup.string().email('E-mail inválido').required('E-mail da empresa é obrigatório'),
+  phone:        Yup.string().required('Telefone é obrigatório'),
+})
+
+const chatSchema = Yup.object().shape({
+  chatDefault: Yup.string().required('Chat padrão é obrigatório'),
+  chatUrl:     Yup.string().required('URL do chat é obrigatória'),
+  chatIdentifier: Yup.string().when('chatDefault', {
+    is: (v: string) => ['crisp', 'chatwoot'].includes(v),
+    then: (s) => s.required('Identifier é obrigatório'),
+  }),
+  chatKey: Yup.string().when('chatDefault', {
+    is: (v: string) => ['crisp', 'chatwoot'].includes(v),
+    then: (s) => s.required('Key é obrigatória'),
+  }),
+})
+
+const whatsappSchema = Yup.object().shape({
+  whatsappDefault: Yup.string().required('WhatsApp padrão é obrigatório'),
+  whatsappToken: Yup.string().when('whatsappDefault', {
+    is: (v: string) => v && v !== 'baileys',
+    then: (s) => s.required('Token do WhatsApp é obrigatório'),
+  }),
+  whatsappUrl: Yup.string().when('whatsappDefault', {
+    is: (v: string) => v && v !== 'baileys',
+    then: (s) => s.required('URL do WhatsApp é obrigatória'),
+  }),
+})
+
+const userSchema = Yup.object().shape({
+  userName:        Yup.string().min(4, 'Nome deve ter no mínimo 4 caracteres').required('Nome é obrigatório'),
+  userEmail:       Yup.string().email('E-mail inválido').required('E-mail é obrigatório'),
+  password:        Yup.string().min(8, 'Senha deve ter no mínimo 8 caracteres').required('Senha é obrigatória'),
+  confirmPassword: Yup.string()
+    .oneOf([Yup.ref('password')], 'Senhas não conferem')
+    .required('Confirmação de senha é obrigatória'),
+})
+
+const schemaMap: Partial<Record<StepId, Yup.ObjectSchema<any>>> = {
+  identity:    identitySchema,
+  chat:        chatSchema,
+  whatsapp:    whatsappSchema,
+  user:        userSchema,
+}
+
+const initialValues = {
+  licenseeName: '',
+  kind: '',
+  document: '',
+  licenseeEmail: '',
+  phone: '',
+  chatDefault: '',
+  chatUrl: '',
+  chatIdentifier: '',
+  chatKey: '',
+  whatsappDefault: '',
+  whatsappToken: '',
+  whatsappUrl: '',
+  userName: '',
+  userEmail: '',
+  password: '',
+  confirmPassword: '',
+}
+
+function YesNoGate({ label, isYes, onChange }: { label: string; isYes: boolean | null; onChange: (v: boolean) => void }) {
+  return (
+    <div className='mb-3'>
+      <p className='fw-semibold'>{label}</p>
+      <div className='btn-group' role='group'>
+        <button
+          type='button'
+          className={`btn ${isYes === true ? 'btn-primary' : 'btn-outline-primary'}`}
+          onClick={() => onChange(true)}
+        >
+          Sim
+        </button>
+        <button
+          type='button'
+          className={`btn ${isYes === false ? 'btn-secondary' : 'btn-outline-secondary'}`}
+          onClick={() => onChange(false)}
+        >
+          Não
+        </button>
+      </div>
+    </div>
+  )
+}
+
+interface Props {
+  isOpen: boolean
+  onClose: () => void
+  onSuccess: () => void
+}
+
+function OnboardingModal({ isOpen, onClose, onSuccess }: Props) {
+  const [currentStepIndex, setCurrentStepIndex] = useState(0)
+  const [wantsChat, setWantsChat]               = useState<boolean | null>(null)
+  const [wantsWhatsapp, setWantsWhatsapp]       = useState<boolean | null>(null)
+  const [stepErrors, setStepErrors]             = useState<string[] | null>(null)
+  const [submitError, setSubmitError]           = useState('')
+
+  if (!isOpen) return null
+
+  const steps = buildSteps(wantsChat, wantsWhatsapp)
+  const stepId = steps[currentStepIndex]
+  const isLast = currentStepIndex === steps.length - 1
+
+  async function validateCurrentStep(values: any): Promise<boolean> {
+    const schema = schemaMap[stepId]
+    if (!schema) return true
+    try {
+      await schema.validate(values, { abortEarly: false })
+      setStepErrors(null)
+      return true
+    } catch (err: any) {
+      setStepErrors(err.errors)
+      return false
+    }
+  }
+
+  async function handleNext(values: any) {
+    const valid = await validateCurrentStep(values)
+    if (valid) {
+      setStepErrors(null)
+      setCurrentStepIndex((i) => i + 1)
+    }
+  }
+
+  function handleBack() {
+    setStepErrors(null)
+    setCurrentStepIndex((i) => i - 1)
+  }
+
+  async function handleSubmit(values: any, { setSubmitting }: any) {
+    const valid = await validateCurrentStep(values)
+    if (!valid) {
+      setSubmitting(false)
+      return
+    }
+
+    const payload: OnboardingFields = {
+      licenseeName:  values.licenseeName,
+      kind:          values.kind,
+      document:      values.document,
+      licenseeEmail: values.licenseeEmail,
+      phone:         values.phone,
+      userName:      values.userName,
+      userEmail:     values.userEmail,
+      password:      values.password,
+      ...(wantsChat ? {
+        chatDefault:    values.chatDefault,
+        chatUrl:        values.chatUrl,
+        chatIdentifier: values.chatIdentifier,
+        chatKey:        values.chatKey,
+      } : {}),
+      ...(wantsWhatsapp ? {
+        whatsappDefault: values.whatsappDefault,
+        whatsappToken:   values.whatsappToken,
+        whatsappUrl:     values.whatsappUrl,
+      } : {}),
+    }
+
+    const response = await createAccount(payload)
+    setSubmitting(false)
+
+    if (response.status === 201) {
+      onSuccess()
+    } else {
+      const errors = response.data?.errors
+      if (errors && typeof errors === 'object') {
+        const messages = Object.values(errors).map((e: any) => e.message || String(e))
+        setSubmitError(messages.join(', '))
+      } else {
+        setSubmitError(response.data?.message || 'Erro ao criar conta')
+      }
+    }
+  }
+
+  function renderStepContent(formik: any) {
+    if (stepId === 'identity') {
+      return (
+        <>
+          <div className='mb-3'>
+            <label htmlFor='licenseeName' className='form-label'>Nome da empresa</label>
+            <input
+              id='licenseeName'
+              name='licenseeName'
+              type='text'
+              className='form-control'
+              value={formik.values.licenseeName}
+              onChange={formik.handleChange}
+              onBlur={formik.handleBlur}
+            />
+            {formik.touched.licenseeName && formik.errors.licenseeName && (
+              <div className='text-danger small'>{formik.errors.licenseeName as string}</div>
+            )}
+          </div>
+
+          <div className='mb-3'>
+            <label htmlFor='kind' className='form-label'>Tipo</label>
+            <select
+              id='kind'
+              name='kind'
+              className='form-select'
+              value={formik.values.kind}
+              onChange={formik.handleChange}
+              onBlur={formik.handleBlur}
+            >
+              <option value=''></option>
+              <option value='company'>Jurídica</option>
+              <option value='individual'>Física</option>
+            </select>
+            {formik.touched.kind && formik.errors.kind && (
+              <div className='text-danger small'>{formik.errors.kind as string}</div>
+            )}
+          </div>
+
+          <div className='mb-3'>
+            <label htmlFor='document' className='form-label'>Documento</label>
+            <input
+              id='document'
+              name='document'
+              type='text'
+              className='form-control'
+              value={formik.values.document}
+              onChange={formik.handleChange}
+              onBlur={formik.handleBlur}
+            />
+            {formik.touched.document && formik.errors.document && (
+              <div className='text-danger small'>{formik.errors.document as string}</div>
+            )}
+          </div>
+
+          <div className='mb-3'>
+            <label htmlFor='licenseeEmail' className='form-label'>E-mail da empresa</label>
+            <input
+              id='licenseeEmail'
+              name='licenseeEmail'
+              type='text'
+              className='form-control'
+              value={formik.values.licenseeEmail}
+              onChange={formik.handleChange}
+              onBlur={formik.handleBlur}
+            />
+            {formik.touched.licenseeEmail && formik.errors.licenseeEmail && (
+              <div className='text-danger small'>{formik.errors.licenseeEmail as string}</div>
+            )}
+          </div>
+
+          <div className='mb-3'>
+            <label htmlFor='phone' className='form-label'>Telefone</label>
+            <input
+              id='phone'
+              name='phone'
+              type='text'
+              className='form-control'
+              value={formik.values.phone}
+              onChange={formik.handleChange}
+              onBlur={formik.handleBlur}
+            />
+            {formik.touched.phone && formik.errors.phone && (
+              <div className='text-danger small'>{formik.errors.phone as string}</div>
+            )}
+          </div>
+        </>
+      )
+    }
+
+    if (stepId === 'integrations') {
+      return (
+        <>
+          <YesNoGate
+            label='Deseja integrar com uma Plataforma de Chat?'
+            isYes={wantsChat}
+            onChange={setWantsChat}
+          />
+          <YesNoGate
+            label='Deseja integrar com uma Plataforma de WhatsApp?'
+            isYes={wantsWhatsapp}
+            onChange={setWantsWhatsapp}
+          />
+        </>
+      )
+    }
+
+    if (stepId === 'chat') {
+      return (
+        <>
+          <div className='mb-3'>
+            <label htmlFor='chatDefault' className='form-label'>Chat padrão</label>
+            <select
+              id='chatDefault'
+              name='chatDefault'
+              className='form-select'
+              value={formik.values.chatDefault}
+              onChange={formik.handleChange}
+              onBlur={formik.handleBlur}
+            >
+              <option value=''></option>
+              <option value='rocketchat'>Rocketchat</option>
+              <option value='crisp'>Crisp</option>
+              <option value='cuboup'>CuboUp</option>
+              <option value='chatwoot'>Chatwoot</option>
+              <option value='local'>Local</option>
+            </select>
+            {formik.touched.chatDefault && formik.errors.chatDefault && (
+              <div className='text-danger small'>{formik.errors.chatDefault as string}</div>
+            )}
+          </div>
+
+          {['rocketchat', 'crisp', 'chatwoot', 'cuboup'].includes(formik.values.chatDefault) && (
+            <div className='mb-3'>
+              <label htmlFor='chatUrl' className='form-label'>URL do chat</label>
+              <input
+                id='chatUrl'
+                name='chatUrl'
+                type='text'
+                className='form-control'
+                value={formik.values.chatUrl}
+                onChange={formik.handleChange}
+                onBlur={formik.handleBlur}
+              />
+              {formik.touched.chatUrl && formik.errors.chatUrl && (
+                <div className='text-danger small'>{formik.errors.chatUrl as string}</div>
+              )}
+            </div>
+          )}
+
+          {['crisp', 'chatwoot'].includes(formik.values.chatDefault) && (
+            <>
+              <div className='mb-3'>
+                <label htmlFor='chatIdentifier' className='form-label'>Identifier</label>
+                <input
+                  id='chatIdentifier'
+                  name='chatIdentifier'
+                  type='text'
+                  className='form-control'
+                  value={formik.values.chatIdentifier}
+                  onChange={formik.handleChange}
+                  onBlur={formik.handleBlur}
+                />
+                {formik.touched.chatIdentifier && formik.errors.chatIdentifier && (
+                  <div className='text-danger small'>{formik.errors.chatIdentifier as string}</div>
+                )}
+              </div>
+
+              <div className='mb-3'>
+                <label htmlFor='chatKey' className='form-label'>Key</label>
+                <input
+                  id='chatKey'
+                  name='chatKey'
+                  type='text'
+                  className='form-control'
+                  value={formik.values.chatKey}
+                  onChange={formik.handleChange}
+                  onBlur={formik.handleBlur}
+                />
+                {formik.touched.chatKey && formik.errors.chatKey && (
+                  <div className='text-danger small'>{formik.errors.chatKey as string}</div>
+                )}
+              </div>
+            </>
+          )}
+        </>
+      )
+    }
+
+    if (stepId === 'whatsapp') {
+      return (
+        <>
+          <div className='mb-3'>
+            <label htmlFor='whatsappDefault' className='form-label'>WhatsApp padrão</label>
+            <select
+              id='whatsappDefault'
+              name='whatsappDefault'
+              className='form-select'
+              value={formik.values.whatsappDefault}
+              onChange={formik.handleChange}
+              onBlur={formik.handleBlur}
+            >
+              <option value=''></option>
+              <option value='utalk'>Utalk</option>
+              <option value='dialog'>Dialog360</option>
+              <option value='ycloud'>YCloud</option>
+              <option value='pabbly'>Pabbly</option>
+              <option value='baileys'>Baileys</option>
+            </select>
+            {formik.touched.whatsappDefault && formik.errors.whatsappDefault && (
+              <div className='text-danger small'>{formik.errors.whatsappDefault as string}</div>
+            )}
+          </div>
+
+          {formik.values.whatsappDefault && formik.values.whatsappDefault !== 'baileys' && (
+            <>
+              <div className='mb-3'>
+                <label htmlFor='whatsappToken' className='form-label'>Token do WhatsApp</label>
+                <input
+                  id='whatsappToken'
+                  name='whatsappToken'
+                  type='text'
+                  className='form-control'
+                  value={formik.values.whatsappToken}
+                  onChange={formik.handleChange}
+                  onBlur={formik.handleBlur}
+                />
+                {formik.touched.whatsappToken && formik.errors.whatsappToken && (
+                  <div className='text-danger small'>{formik.errors.whatsappToken as string}</div>
+                )}
+              </div>
+
+              <div className='mb-3'>
+                <label htmlFor='whatsappUrl' className='form-label'>URL do WhatsApp</label>
+                <input
+                  id='whatsappUrl'
+                  name='whatsappUrl'
+                  type='text'
+                  className='form-control'
+                  value={formik.values.whatsappUrl}
+                  onChange={formik.handleChange}
+                  onBlur={formik.handleBlur}
+                />
+                {formik.touched.whatsappUrl && formik.errors.whatsappUrl && (
+                  <div className='text-danger small'>{formik.errors.whatsappUrl as string}</div>
+                )}
+              </div>
+            </>
+          )}
+        </>
+      )
+    }
+
+    if (stepId === 'user') {
+      return (
+        <>
+          <div className='mb-3'>
+            <label htmlFor='userName' className='form-label'>Seu nome</label>
+            <input
+              id='userName'
+              name='userName'
+              type='text'
+              className='form-control'
+              value={formik.values.userName}
+              onChange={formik.handleChange}
+              onBlur={formik.handleBlur}
+            />
+            {formik.touched.userName && formik.errors.userName && (
+              <div className='text-danger small'>{formik.errors.userName as string}</div>
+            )}
+          </div>
+
+          <div className='mb-3'>
+            <label htmlFor='userEmail' className='form-label'>Seu e-mail</label>
+            <input
+              id='userEmail'
+              name='userEmail'
+              type='text'
+              className='form-control'
+              value={formik.values.userEmail}
+              onChange={formik.handleChange}
+              onBlur={formik.handleBlur}
+            />
+            {formik.touched.userEmail && formik.errors.userEmail && (
+              <div className='text-danger small'>{formik.errors.userEmail as string}</div>
+            )}
+          </div>
+
+          <div className='mb-3'>
+            <label htmlFor='password' className='form-label'>Senha</label>
+            <input
+              id='password'
+              name='password'
+              type='password'
+              className='form-control'
+              value={formik.values.password}
+              onChange={formik.handleChange}
+              onBlur={formik.handleBlur}
+            />
+            {formik.touched.password && formik.errors.password && (
+              <div className='text-danger small'>{formik.errors.password as string}</div>
+            )}
+          </div>
+
+          <div className='mb-3'>
+            <label htmlFor='confirmPassword' className='form-label'>Confirmar senha</label>
+            <input
+              id='confirmPassword'
+              name='confirmPassword'
+              type='password'
+              className='form-control'
+              value={formik.values.confirmPassword}
+              onChange={formik.handleChange}
+              onBlur={formik.handleBlur}
+            />
+            {formik.touched.confirmPassword && formik.errors.confirmPassword && (
+              <div className='text-danger small'>{formik.errors.confirmPassword as string}</div>
+            )}
+          </div>
+        </>
+      )
+    }
+
+    return null
+  }
+
+  const stepTitles: Record<StepId, string> = {
+    identity:     'Dados da Empresa',
+    integrations: 'Integrações',
+    chat:         'Plataforma de Chat',
+    whatsapp:     'Plataforma de WhatsApp',
+    user:         'Seus Dados',
+  }
+
+  return (
+    <div className='modal d-block' tabIndex={-1} style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}>
+      <div className='modal-dialog modal-dialog-centered modal-lg'>
+        <div className='modal-content'>
+          <Formik
+            initialValues={initialValues}
+            validationSchema={Yup.object()}
+            onSubmit={handleSubmit}
+          >
+            {(formik) => (
+              <>
+                <div className='modal-header'>
+                  <div>
+                    <h5 className='modal-title mb-0'>Criar conta</h5>
+                    <p className='text-muted mb-0 small'>
+                      Passo {currentStepIndex + 1} de {steps.length} — {stepTitles[stepId]}
+                    </p>
+                  </div>
+                  <button type='button' className='btn-close' onClick={onClose} />
+                </div>
+
+                <div className='modal-body'>
+                  {renderStepContent(formik)}
+                </div>
+
+                <div className='modal-footer flex-column align-items-stretch'>
+                  {(stepErrors || submitError) && (
+                    <div className='alert alert-danger mb-2'>
+                      {stepErrors?.map((e) => <div key={e}>{e}</div>)}
+                      {submitError && <div>{submitError}</div>}
+                    </div>
+                  )}
+
+                  <div className='d-flex justify-content-between'>
+                    {currentStepIndex === 0
+                      ? <button type='button' className='btn btn-secondary' onClick={onClose}>Cancelar</button>
+                      : <button type='button' className='btn btn-outline-secondary' onClick={handleBack}>← Voltar</button>
+                    }
+                    {isLast
+                      ? (
+                        <button
+                          type='button'
+                          className='btn btn-success'
+                          disabled={formik.isSubmitting}
+                          onClick={() => formik.submitForm()}
+                        >
+                          {formik.isSubmitting ? 'Criando...' : 'Criar conta'}
+                        </button>
+                      )
+                      : (
+                        <button
+                          type='button'
+                          className='btn btn-primary'
+                          onClick={() => handleNext(formik.values)}
+                        >
+                          Próximo →
+                        </button>
+                      )
+                    }
+                  </div>
+                </div>
+              </>
+            )}
+          </Formik>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default OnboardingModal

--- a/client/src/pages/SignIn/index.tsx
+++ b/client/src/pages/SignIn/index.tsx
@@ -4,13 +4,21 @@ import api from '../../services/api'
 import { login, fetchLoggedUser } from '../../services/auth'
 import styles from './index.module.scss'
 import { AppContext } from '../../contexts/App'
+import OnboardingModal from './OnboardingModal'
 
 function SignIn() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
+  const [isOnboardingOpen, setIsOnboardingOpen] = useState(false)
+  const [successMessage, setSuccessMessage] = useState('')
   let navigate = useNavigate()
   const { setCurrentUser } = useContext(AppContext)
+
+  function handleOnboardingSuccess() {
+    setIsOnboardingOpen(false)
+    setSuccessMessage('Conta criada com sucesso! Faça login para continuar.')
+  }
 
   async function handleSignIn(e: any) {
     e.preventDefault()
@@ -79,11 +87,25 @@ function SignIn() {
                   {error && <p>{error}</p>}
                 </div>
 
+                {successMessage && (
+                  <div className="alert alert-success mt-3">{successMessage}</div>
+                )}
+
                 <button
                   className='btn btn-primary mt-4 w-100'
                   onClick={handleSignIn}>
                   Entrar
                 </button>
+
+                <div className="text-center mt-3">
+                  <button
+                    type="button"
+                    className="btn btn-link text-white p-0"
+                    onClick={() => setIsOnboardingOpen(true)}
+                  >
+                    Criar conta
+                  </button>
+                </div>
 
               </div>
             </div>
@@ -91,6 +113,12 @@ function SignIn() {
 
         </div>
       </div>
+
+      <OnboardingModal
+        isOpen={isOnboardingOpen}
+        onClose={() => setIsOnboardingOpen(false)}
+        onSuccess={handleOnboardingSuccess}
+      />
     </>
   )
 }

--- a/client/src/services/onboarding.spec.ts
+++ b/client/src/services/onboarding.spec.ts
@@ -1,0 +1,37 @@
+import * as apiModule from './api'
+import { createAccount } from './onboarding'
+
+vi.mock('./api')
+
+describe('onboarding service', () => {
+  let mockPost: any
+
+  beforeEach(() => {
+    mockPost = vi.fn().mockResolvedValue({ status: 201, data: {} })
+    ;(apiModule.default as any).mockReturnValue({ post: mockPost })
+  })
+
+  describe('createAccount', () => {
+    const fields = {
+      licenseeName: 'Acme Corp',
+      kind: 'company',
+      document: '12345678000195',
+      licenseeEmail: 'acme@acme.com',
+      phone: '11999990000',
+      userName: 'John Doe',
+      userEmail: 'john@acme.com',
+      password: 'senha123',
+    }
+
+    it('sends POST to /onboarding with the provided fields', async () => {
+      await createAccount(fields)
+      expect(mockPost).toHaveBeenCalledWith('/onboarding', { body: fields })
+    })
+
+    it('does not include an x-access-token header', async () => {
+      await createAccount(fields)
+      const callArgs = mockPost.mock.calls[0][1]
+      expect(callArgs.headers).toBeUndefined()
+    })
+  })
+})

--- a/client/src/services/onboarding.ts
+++ b/client/src/services/onboarding.ts
@@ -1,0 +1,23 @@
+import api from './api'
+
+export interface OnboardingFields {
+  licenseeName: string
+  kind: string
+  document: string
+  licenseeEmail: string
+  phone: string
+  chatDefault?: string
+  chatUrl?: string
+  chatIdentifier?: string
+  chatKey?: string
+  whatsappDefault?: string
+  whatsappToken?: string
+  whatsappUrl?: string
+  userName: string
+  userEmail: string
+  password: string
+}
+
+export function createAccount(fields: OnboardingFields) {
+  return api().post('/onboarding', { body: fields })
+}


### PR DESCRIPTION
## Summary

- Adds "Criar conta" link (white btn-link) below login button in `SignIn/index.tsx`
- Mounts `OnboardingModal` inside `SignIn` JSX so the gradient background shows through the modal overlay
- Shows a persistent success banner after successful onboarding; login form remains ready

## Test plan
- [x] 245/245 client tests pass (no regressions)
- [ ] Manual: "Criar conta" link visible, opens modal over gradient background
- [ ] Manual: completing wizard shows success banner + login form ready

**Plan**: `onboarding-wizard` — phase-3/task-03 (final task)
**Depends on**: #2833 (modal component), #2832 (backend endpoint)
**Merge order**: #2832 → #2833 → this PR