### PR TITLE
fix(chatwoot): resolve contact from meta.sender when contact_inbox.contact_id is absent

### DIFF
--- a/src/app/plugins/chats/Chatwoot.spec.ts
+++ b/src/app/plugins/chats/Chatwoot.spec.ts
@@ -154,6 +154,80 @@ describe('Chatwoot plugin', () => {
       expect(messages).toEqual([])
     })
 
+    it('resolves contact from meta.sender.id when contact_inbox.contact_id is absent', async () => {
+      const contactRepository = new ContactRepositoryDatabase()
+      const contact = await contactRepository.create(
+        contactFactory.build({
+          name: 'Juarez',
+          chatwootId: 78059,
+          licensee,
+        }),
+      )
+
+      await Room.create(
+        roomFactory.build({
+          roomId: 396,
+          contact,
+        }),
+      )
+
+      const responseBody = {
+        event: 'message_created',
+        message_type: 'outgoing',
+        content: 'Quem vai te atender é AMANDA TEODORO.',
+        content_type: 'text',
+        conversation: {
+          id: 396,
+          contact_inbox: {
+            id: 82266,
+            source_id: 'b3ceb73d-c4cc-47f7-a95e-d1cc4d6da0ef',
+          },
+          meta: {
+            sender: {
+              id: 78059,
+              name: 'Juarez',
+              type: 'contact',
+            },
+          },
+          messages: [],
+        },
+      }
+
+      const chatwoot = new Chatwoot(licensee, dependencies)
+      const messages = await chatwoot.responseToMessages(responseBody)
+
+      expect(messages.length).toEqual(1)
+      expect(messages[0].contact).toEqual(contact._id)
+      expect(messages[0].text).toEqual('Quem vai te atender é AMANDA TEODORO.')
+    })
+
+    it('returns empty array when contact_inbox.contact_id is absent and meta.sender is not a contact', async () => {
+      const responseBody = {
+        event: 'message_created',
+        message_type: 'outgoing',
+        conversation: {
+          id: 'conversation_456',
+          contact_inbox: {
+            id: 82266,
+            source_id: 'some-source-id',
+          },
+          meta: {
+            sender: {
+              id: 4,
+              name: 'Jota - Assistente Virtual',
+              type: 'user',
+            },
+          },
+          messages: [],
+        },
+      }
+
+      const chatwoot = new Chatwoot(licensee, dependencies)
+      const messages = await chatwoot.responseToMessages(responseBody)
+
+      expect(messages).toEqual([])
+    })
+
     it('creates new room if room does not exist', async () => {
       const contactRepository = new ContactRepositoryDatabase()
       const contact = await contactRepository.create(

--- a/src/app/plugins/chats/Chatwoot.ts
+++ b/src/app/plugins/chats/Chatwoot.ts
@@ -169,21 +169,29 @@ class Chatwoot extends ChatsBase {
       return
     }
 
-    if (!responseBody.conversation?.contact_inbox?.contact_id) {
+    const rawContactId =
+      responseBody.conversation?.contact_inbox?.contact_id ??
+      (responseBody.conversation?.meta?.sender?.type === 'contact'
+        ? responseBody.conversation.meta.sender.id
+        : null)
+
+    const chatwootContactId = rawContactId != null ? String(rawContactId) : null
+
+    if (!chatwootContactId) {
       this.messageParsed = null
       return
     }
 
     const contact = await this.findContact({
       licensee: this.licensee._id,
-      chatwootId: responseBody.conversation.contact_inbox.contact_id,
+      chatwootId: chatwootContactId,
     })
     if (!contact) {
       this.messageParsed = null
       return
     }
 
-    let room = await this.roomRepository.findFirst({ roomId: responseBody.conversation.id })
+    let room = await this.roomRepository.findFirst({ roomId: String(responseBody.conversation.id) })
     if (!room) {
       await this.roomRepository.create({ roomId: responseBody.conversation.id, contact: contact })
       this.messageParsed = null

--- a/src/app/plugins/chats/Chatwoot.ts
+++ b/src/app/plugins/chats/Chatwoot.ts
@@ -171,9 +171,7 @@ class Chatwoot extends ChatsBase {
 
     const rawContactId =
       responseBody.conversation?.contact_inbox?.contact_id ??
-      (responseBody.conversation?.meta?.sender?.type === 'contact'
-        ? responseBody.conversation.meta.sender.id
-        : null)
+      (responseBody.conversation?.meta?.sender?.type === 'contact' ? responseBody.conversation.meta.sender.id : null)
 
     const chatwootContactId = rawContactId != null ? String(rawContactId) : null
 


### PR DESCRIPTION
## Summary

- Chatwoot webhook payloads may omit `contact_id` from `conversation.contact_inbox` (observed in production)
- Falls back to `conversation.meta.sender.id` when `meta.sender.type === 'contact'`
- Both IDs are coerced to `String` to match the `String`-typed `chatwootId` field consistently
- Room ID is also coerced to `String` when querying to match stored values

## Test plan

- [ ] All 35 existing Chatwoot spec tests pass
- [ ] New test: `resolves contact from meta.sender.id when contact_inbox.contact_id is absent` — verifies the fallback path creates the message correctly
- [ ] New test: `returns empty array when contact_inbox.contact_id is absent and meta.sender is not a contact` — verifies non-contact senders are rejected