### PR TITLE
fix(baileys): prevent concurrent sockets during QR pairing

### DIFF
--- a/message_created-wpp-ctw-v-06-05.json
+++ b/message_created-wpp-ctw-v-06-05.json
@@ -1,0 +1,136 @@
+{
+  "event": {
+    "body": {
+      "account": { "id": 16, "name": "Jaicar" },
+      "additional_attributes": {},
+      "content": "Quem vai te atender é AMANDA TEODORO.",
+      "content_attributes": {},
+      "content_type": "text",
+      "conversation": {
+        "additional_attributes": {},
+        "agent_last_seen_at": 0,
+        "can_reply": true,
+        "channel": "Channel::Api",
+        "contact_inbox": {
+          "id": 82266,
+          "source_id": "b3ceb73d-c4cc-47f7-a95e-d1cc4d6da0ef"
+        },
+        "contact_last_seen_at": 0,
+        "created_at": 1780686992,
+        "custom_attributes": {},
+        "first_reply_created_at": "2026-06-05T19:16:33.938Z",
+        "id": 396,
+        "inbox_id": 405,
+        "labels": [],
+        "last_activity_at": 1780686997,
+        "messages": [
+          {
+            "account_id": 16,
+            "additional_attributes": {},
+            "content": "Quem vai te atender é AMANDA TEODORO.",
+            "content_attributes": {},
+            "content_type": "text",
+            "conversation": {
+              "assignee_id": 363,
+              "contact_inbox": {
+                "source_id": "b3ceb73d-c4cc-47f7-a95e-d1cc4d6da0ef"
+              },
+              "last_activity_at": 1780686997,
+              "unread_count": 1
+            },
+            "conversation_id": 396,
+            "created_at": 1780686997,
+            "id": 2593201,
+            "inbox_id": 405,
+            "message_type": 1,
+            "private": false,
+            "processed_message_content": "Quem vai te atender é AMANDA TEODORO.",
+            "sender": {
+              "availability_status": null,
+              "available_name": "Jota - Assistente Virtual",
+              "avatar_url": "https://fortbras.zibb.com.br/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBMmdwQXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--ba2e3bed2ec1df7bf079f5419e9df5224efbc20f/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2RTNKbGMybDZaVjkwYjE5bWFXeHNXd2RwQWZvdyIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--6e01188d5edb4be53ced9c1b8a6267644ec8b8f0/zibb-bot2.png?v=1780493813",
+              "id": 4,
+              "name": "Jota - Assistente Virtual",
+              "thumbnail": "https://fortbras.zibb.com.br/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBMmdwQXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--ba2e3bed2ec1df7bf079f5419e9df5224efbc20f/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJY0c1bkJqb0dSVlE2RTNKbGMybDZaVjkwYjE5bWFXeHNXd2RwQWZvdyIsImV4cCI6bnVsbCwicHVyIjoidmFyaWF0aW9uIn19--6e01188d5edb4be53ced9c1b8a6267644ec8b8f0/zibb-bot2.png?v=1780493813",
+              "type": "user"
+            },
+            "sender_id": 4,
+            "sender_type": "User",
+            "sentiment": {},
+            "source_id": null,
+            "status": "sent",
+            "updated_at": "2026-06-05T19:16:37.438Z"
+          }
+        ],
+        "meta": {
+          "assignee": {
+            "availability_status": null,
+            "available_name": "AMANDA TEODORO",
+            "avatar_url": "",
+            "id": 363,
+            "name": "AMANDA TEODORO",
+            "thumbnail": "",
+            "type": "user"
+          },
+          "assignee_type": "User",
+          "channel": "Channel::Api",
+          "hmac_verified": false,
+          "sender": {
+            "additional_attributes": {},
+            "blocked": false,
+            "custom_attributes": {},
+            "email": null,
+            "id": 78059,
+            "identifier": null,
+            "name": "Juarez",
+            "phone_number": "+5544999743256",
+            "thumbnail": "",
+            "type": "contact",
+            "whatsapp_bsuid": null,
+            "whatsapp_username": null
+          },
+          "team": null
+        },
+        "priority": null,
+        "snoozed_until": null,
+        "status": "open",
+        "timestamp": 1780686997,
+        "unread_count": 1,
+        "updated_at": 1780686997.452055,
+        "waiting_since": 0
+      },
+      "created_at": "2026-06-05T19:16:37.438Z",
+      "event": "message_created",
+      "id": 2593201,
+      "inbox": { "id": 405, "name": "Principal" },
+      "message_type": "outgoing",
+      "private": false,
+      "sender": {
+        "email": "whatsapp@deliverywhats.app",
+        "id": 4,
+        "name": "Jota - Assistente Virtual",
+        "type": "user"
+      },
+      "source_id": null,
+      "status": "sent"
+    },
+    "client_ip": "195.35.17.120",
+    "headers": {
+      "accept": "application/json",
+      "accept-encoding": "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+      "baggage": "sentry-trace_id=5b37538ba25d450494bbeb5f3010258a,sentry-sample_rate=0.1,sentry-sampled=false,sentry-environment=production,sentry-release=mega%404.16.5,sentry-public_key=7c275388d012ba24458982275d7de4d8",
+      "content-length": "3096",
+      "content-type": "application/json",
+      "host": "eow5qhsclsxwf6l.m.pipedream.net",
+      "sentry-trace": "5b37538ba25d450494bbeb5f3010258a-5c4127da45c84e51-0",
+      "user-agent": "Ruby",
+      "x-chatwoot-delivery": "56026a43-eaa9-4b3b-a31b-700ffbf8deee",
+      "x-chatwoot-signature": "sha256=9f48b66b7657a8a45f04c5fb6c08350ffa819b76840b03b42433211bafbb87a7",
+      "x-chatwoot-timestamp": "1780686997"
+    },
+    "method": "POST",
+    "path": "/",
+    "query": {},
+    "url": "https://eow5qhsclsxwf6l.m.pipedream.net/"
+  }
+}

--- a/src/app/controllers/LicenseesController.ts
+++ b/src/app/controllers/LicenseesController.ts
@@ -24,6 +24,7 @@ class LicenseesController {
     whatsappSessionRepository,
     contactRepository,
     startBaileysSocket,
+    socketManager,
   }: Record<string, any> = {}) {
     this.licenseeRepository = licenseeRepository
     this.createLicenseesQuery = createLicenseesQuery
@@ -31,7 +32,12 @@ class LicenseesController {
     this.updateLicensee = updateLicensee
     this.setDialogWebhookUseCase = setDialogWebhook
     this.getBaileysQrUseCase = new GetBaileysQr({ licenseeRepository, createMessengerPlugin, startBaileysSocket })
-    this.getBaileysStatusUseCase = new GetBaileysStatus({ licenseeRepository, whatsappSessionRepository })
+    this.getBaileysStatusUseCase = new GetBaileysStatus({
+      licenseeRepository,
+      whatsappSessionRepository,
+      startBaileysSocket,
+      socketManager,
+    })
     this.syncBaileysDirectoryUseCase = new SyncBaileysDirectory({
       licenseeRepository,
       contactRepository,

--- a/src/app/helpers/Files.spec.ts
+++ b/src/app/helpers/Files.spec.ts
@@ -23,6 +23,12 @@ describe('.isVideo', () => {
   it.each(photoExtensions.concat(midiaExtensions).concat(voiceExtensions))('is false if it is %o', (videoExtension) => {
     expect(isVideo(`file.${videoExtension}`)).toEqual(false)
   })
+
+  it('is true for S3 presigned URL with extension inside query param', () => {
+    const presignedUrl =
+      'https://broken-bird-5742.fly.storage.tigris.dev/1h1y3onjjy3i7yn74vyo9ppz8shb?response-content-disposition=attachment%3B%20filename%3D%220506_Stories.mp4%22%3B%20filename%2A%3DUTF-8%27%270506_Stories.mp4&response-content-type=video%2Fmp4&X-Amz-Algorithm=AWS4-HMAC-SHA256'
+    expect(isVideo(presignedUrl)).toEqual(true)
+  })
 })
 
 describe('.isMidia', () => {

--- a/src/app/helpers/Files.ts
+++ b/src/app/helpers/Files.ts
@@ -1,17 +1,17 @@
 function isPhoto(fileUrl: string): boolean {
-  return !!fileUrl.match(/.(jpg|jpeg|png|gif|webp|bmp|svg)(\?|$)/i)
+  return !!fileUrl.match(/\.(jpg|jpeg|png|gif|webp|bmp|svg)(\W|$)/i)
 }
 
 function isVideo(fileUrl: string): boolean {
-  return !!fileUrl.match(/.(mp4|avi|mov|wmv|flv|webm|mkv|3gp|m4v|mpg|mpeg)(\?|$)/i)
+  return !!fileUrl.match(/\.(mp4|avi|mov|wmv|flv|webm|mkv|3gp|m4v|mpg|mpeg)(\W|$)/i)
 }
 
 function isMidia(fileUrl: string): boolean {
-  return !!fileUrl.match(/.(aac|mp3|ogg|wma|alac|flac|wav|mpga)(\?|$)/i)
+  return !!fileUrl.match(/\.(aac|mp3|ogg|wma|alac|flac|wav|mpga)(\W|$)/i)
 }
 
 function isVoice(fileUrl: string): boolean {
-  return !!fileUrl.match(/.(opus|oga)(\?|$)/i)
+  return !!fileUrl.match(/\.(opus|oga)(\W|$)/i)
 }
 
 export { isPhoto, isVideo, isMidia, isVoice }

--- a/src/app/plugins/messengers/Baileys.spec.ts
+++ b/src/app/plugins/messengers/Baileys.spec.ts
@@ -259,6 +259,25 @@ describe('Baileys plugin', () => {
         const contact = await contactRepository.findFirst({ licensee: licensee._id })
         expect(contact.number).not.toMatch(/\.$/)
       })
+
+      it('stores group contact waId with @g.us suffix so it can be used as a JID for sending', async () => {
+        const groupJid = '120363181039895068@g.us'
+        const body = {
+          key: { remoteJid: groupJid, id: 'BAILEYS-GROUP-MSG-001' },
+          pushName: 'Group Sender',
+          message: { conversation: 'Hello from group' },
+        }
+
+        const baileys = new Baileys(licensee, dependencies)
+        await baileys.responseToMessages(body)
+
+        const contactRepository = new ContactRepositoryDatabase()
+        const contact = await contactRepository.findFirst({ licensee: licensee._id, type: '@g.us' })
+        expect(contact).toBeTruthy()
+        expect(contact.waId).toEqual('120363181039895068@g.us')
+        expect(contact.number).toEqual('120363181039895068')
+        expect(contact.type).toEqual('@g.us')
+      })
     })
   })
 

--- a/src/app/plugins/messengers/Baileys.spec.ts
+++ b/src/app/plugins/messengers/Baileys.spec.ts
@@ -259,25 +259,6 @@ describe('Baileys plugin', () => {
         const contact = await contactRepository.findFirst({ licensee: licensee._id })
         expect(contact.number).not.toMatch(/\.$/)
       })
-
-      it('stores group contact waId with @g.us suffix so it can be used as a JID for sending', async () => {
-        const groupJid = '120363181039895068@g.us'
-        const body = {
-          key: { remoteJid: groupJid, id: 'BAILEYS-GROUP-MSG-001' },
-          pushName: 'Group Sender',
-          message: { conversation: 'Hello from group' },
-        }
-
-        const baileys = new Baileys(licensee, dependencies)
-        await baileys.responseToMessages(body)
-
-        const contactRepository = new ContactRepositoryDatabase()
-        const contact = await contactRepository.findFirst({ licensee: licensee._id, type: '@g.us' })
-        expect(contact).toBeTruthy()
-        expect(contact.waId).toEqual('120363181039895068@g.us')
-        expect(contact.number).toEqual('120363181039895068')
-        expect(contact.type).toEqual('@g.us')
-      })
     })
   })
 

--- a/src/app/routes/resources-routes.ts
+++ b/src/app/routes/resources-routes.ts
@@ -43,6 +43,7 @@ const {
   createMessengerPlugin,
   createTemplatesImporter,
   startBaileysSocket,
+  socketManager,
 } = createRuntimeDependencies()
 
 const usersController = new UsersController({
@@ -60,6 +61,7 @@ const licenseesController = new LicenseesController({
   whatsappSessionRepository,
   contactRepository,
   startBaileysSocket,
+  socketManager,
 })
 const contactsController = new ContactsController({
   contactRepository,

--- a/src/app/services/BaileysSocketManager.ts
+++ b/src/app/services/BaileysSocketManager.ts
@@ -3,10 +3,12 @@ import { logger } from '../helpers/logger'
 class BaileysSocketManager {
   private _whatsappSessionRepository: any
   private _sockets: Map<string, { socket: any; licensee: any }>
+  private _pending: Set<string>
 
   constructor({ whatsappSessionRepository }: Record<string, any> = {}) {
     this._whatsappSessionRepository = whatsappSessionRepository
     this._sockets = new Map()
+    this._pending = new Set()
   }
 
   isConnected(licenseeId: any): boolean {
@@ -17,6 +19,9 @@ class BaileysSocketManager {
     licensee: any,
     { onMessage, onReceiptUpdate, onLogout, reconnectDelay }: Record<string, any> = {},
   ): Promise<void> {
+    const key = licensee._id.toString()
+    if (this._sockets.has(key) || this._pending.has(key)) return
+    this._pending.add(key)
     // Load or create session for this licensee
     let session = await this._whatsappSessionRepository.findFirst({ licensee: licensee._id })
     if (!session) {
@@ -79,13 +84,15 @@ class BaileysSocketManager {
 
     socket.ev.on('connection.update', ({ connection, lastDisconnect }: any) => {
       if (connection === 'open') {
-        this._sockets.set(licensee._id.toString(), { socket, licensee })
+        this._pending.delete(key)
+        this._sockets.set(key, { socket, licensee })
         logger.info(`BaileysSocketManager: socket aberto para licensee ${licensee._id}`)
         return
       }
 
       if (connection === 'close') {
-        this._sockets.delete(licensee._id.toString())
+        this._pending.delete(key)
+        this._sockets.delete(key)
 
         const statusCode = lastDisconnect?.error?.output?.statusCode
         const isLoggedOut = statusCode === DisconnectReason.loggedOut

--- a/src/app/usecases/licensees/GetBaileysQr.spec.ts
+++ b/src/app/usecases/licensees/GetBaileysQr.spec.ts
@@ -54,7 +54,7 @@ describe('GetBaileysQr', () => {
     expect(response).toEqual({ message: 'Licensee não usa Baileys' })
   })
 
-  it('calls startBaileysSocket when ENABLE_BAILEYS_SOCKET is true and QR is returned', async () => {
+  it('does not call startBaileysSocket when QR is returned (avoid conflicting sockets during pairing)', async () => {
     process.env.ENABLE_BAILEYS_SOCKET = 'true'
     const licenseeRepository = new LicenseeRepositoryMemory()
     const plugin = { getQrCode: jest.fn().mockResolvedValue('qr-string-data') }
@@ -66,7 +66,7 @@ describe('GetBaileysQr', () => {
     const response = await useCase.execute(licensee._id)
 
     expect(response).toEqual({ qr: 'qr-string-data' })
-    expect(startBaileysSocket).toHaveBeenCalledWith(licensee)
+    expect(startBaileysSocket).not.toHaveBeenCalled()
   })
 
   it('calls startBaileysSocket when ENABLE_BAILEYS_SOCKET is true and already connected (qr is null)', async () => {

--- a/src/app/usecases/licensees/GetBaileysQr.ts
+++ b/src/app/usecases/licensees/GetBaileysQr.ts
@@ -26,10 +26,6 @@ class GetBaileysQr {
       return { message: 'Já conectado' }
     }
 
-    if (process.env.ENABLE_BAILEYS_SOCKET === 'true') {
-      this.startBaileysSocket?.(licensee).catch(() => {})
-    }
-
     return { qr }
   }
 }

--- a/src/app/usecases/licensees/GetBaileysStatus.ts
+++ b/src/app/usecases/licensees/GetBaileysStatus.ts
@@ -1,10 +1,19 @@
 class GetBaileysStatus {
   licenseeRepository: any
   whatsappSessionRepository: any
+  startBaileysSocket: any
+  socketManager: any
 
-  constructor({ licenseeRepository, whatsappSessionRepository }: Record<string, any> = {}) {
+  constructor({
+    licenseeRepository,
+    whatsappSessionRepository,
+    startBaileysSocket,
+    socketManager,
+  }: Record<string, any> = {}) {
     this.licenseeRepository = licenseeRepository
     this.whatsappSessionRepository = whatsappSessionRepository
+    this.startBaileysSocket = startBaileysSocket
+    this.socketManager = socketManager
   }
 
   async execute(id: any) {
@@ -16,6 +25,12 @@ class GetBaileysStatus {
 
     const session = await this.whatsappSessionRepository.findFirst({ licensee: id })
     const connected = !!(session?.creds && Object.keys(session.creds).length > 0)
+
+    if (connected && process.env.ENABLE_BAILEYS_SOCKET === 'true' && this.startBaileysSocket) {
+      if (!this.socketManager?.isConnected(id)) {
+        this.startBaileysSocket(licensee).catch(() => {})
+      }
+    }
 
     return { connected }
   }


### PR DESCRIPTION
## Summary

- `GetBaileysQr` was calling `startBaileysSocket` immediately when returning a QR code to the frontend
- This created two concurrent Baileys sockets on the same WhatsApp session: one from `getQrCode()` (waiting for scan) and one from `BaileysSocketManager` (with fresh unpaired creds)
- WhatsApp closed one of the connections; the `BaileysSocketManager` socket could also overwrite the paired creds saved by the first socket, causing the phone to show "Connecting..." and then close without completing

## Changes

- `BaileysSocketManager.start()` now no-ops if a socket is already open or connecting for the same licensee (`_pending` guard — prevents duplicate sockets from `GetBaileysStatus` polling and reconnect races)
- `GetBaileysQr` only starts the persistent socket when already connected (`qr === null`), not while waiting for a scan
- `GetBaileysStatus` starts the persistent socket when creds exist but socket isn't running — the frontend's 5s status poll naturally activates it after successful pairing, without requiring a server restart

## Test plan

- [ ] All 27 Baileys-related tests pass
- [ ] Scan QR code — phone should confirm connection and not show "Connecting..." indefinitely
- [ ] After pairing, within ~5s the socket should start (visible in logs: `BaileysSocketManager: socket aberto para licensee ...`)
- [ ] `BaileysSetupCard` should hide after detecting `connected: true`