### PR TITLE
plan(setores-webhook-providers): sector token routing for webhook providers

### DIFF
--- a/.plans/README.md
+++ b/.plans/README.md
@@ -22,7 +22,6 @@ Git-native Markdown plans for multi-step work.
 
 | # | Plan | Folder | Status | Description |
 |---|------|--------|--------|-------------|
-| 1 | [Setores — Webhook Providers](./setores-webhook-providers/overview.md) | `setores-webhook-providers/` | not-started | Extend sector routing to utalk/dialog/ycloud/pabbly via sector token in webhook URL; prerequisite: setores complete |
 | 2 | [MongoDB → PostgreSQL](./mongo-to-postgres/overview.md) | `mongo-to-postgres/` | not-started | Migrate all persistent data from MongoDB/Mongoose to PostgreSQL/Prisma using dual-write strategy; prerequisite: remove-pdv complete |
 | 3 | [Backend Type Narrowing](./type-backend/overview.md) | `type-backend/` | not-started | Replace `any` with interfaces across models, repositories, use cases, controllers, and plugins — 3 phases, 11 tasks |
 | 4 | [Client Type Narrowing](./type-client/overview.md) | `type-client/` | not-started | Replace `any` with interfaces across React services, contexts, pages, and components — 2 phases, 6 tasks |
@@ -48,6 +47,7 @@ Git-native Markdown plans for multi-step work.
 | 11 | [Local Chat Infrastructure](./local-chat-infra/overview.md) | `local-chat-infra/` | 2026-06-02 | User role system (agent/supervisor/admin/super), LocalChat plugin, super licensee flow, route authorization — prerequisite for setores |
 | 12 | [Onboarding Wizard](./onboarding-wizard/overview.md) | `onboarding-wizard/` | 2026-06-02 | Public sign-up flow from the login screen: wizard modal collects licensee identity + user credentials and creates both via a single unauthenticated endpoint |
 | 13 | [Setores](./setores/overview.md) | `setores/` | 2026-06-10 | Multiple WhatsApp numbers per licensee via sectors; sector-scoped message routing and agent access filtering |
+| 14 | [Setores — Webhook Providers](./setores-webhook-providers/overview.md) | `setores-webhook-providers/` | 2026-06-11 | sectorToken + webhookUrl virtual on Sector; auth middleware resolves ?sector= query param; MessengersController threads sectorId |
 
 ---
 

--- a/.plans/setores-webhook-providers/overview.md
+++ b/.plans/setores-webhook-providers/overview.md
@@ -1,8 +1,8 @@
 # Plan: Setores — Webhook Providers
 
-**Status**: not-started
+**Status**: complete
 **Created**: 2026-06-04
-**Last Updated**: 2026-06-04
+**Last Updated**: 2026-06-11
 **Estimated Demo Date**: TBD — depends on `setores` plan completion
 **Assigned Dev**: Alan Costa Facchini
 **Assigned QA**: unassigned

--- a/.plans/setores-webhook-providers/phase-1/task-01-setor-token/status.md
+++ b/.plans/setores-webhook-providers/phase-1/task-01-setor-token/status.md
@@ -1,9 +1,9 @@
 # Status: Setor token field + webhook URL virtual
 
-**Current Status**: not-started
-**Last Updated**: 2026-06-04
-**Agent**: —
-**Branch**: —
+**Current Status**: complete
+**Last Updated**: 2026-06-11
+**Agent**: claude-sonnet-4-6
+**Branch**: feature/setores-webhook-providers
 **PR**: —
 
 ## Status History
@@ -11,6 +11,14 @@
 | Timestamp | Status | Agent | Notes |
 |-----------|--------|-------|-------|
 | 2026-06-04 | not-started | — | Task created |
+| 2026-06-11 | in-progress | claude-sonnet-4-6 | Executing on single PR branch |
+| 2026-06-11 | complete | claude-sonnet-4-6 | sectorToken + webhookUrl virtual; SectorsController populates licensee; 28 tests pass |
+
+## Adaptations
+
+- Codebase uses English naming (Sector, SectorRepository) not Portuguese (Setor); adapted all identifiers
+- Unique index test dropped — DB-level constraint not testable with in-memory mongo setup
+- webhookUrl query param uses `sector=` (English) for consistency with codebase
 
 ## Blockers
 

--- a/.plans/setores-webhook-providers/phase-2/task-02-auth-middleware/status.md
+++ b/.plans/setores-webhook-providers/phase-2/task-02-auth-middleware/status.md
@@ -1,9 +1,9 @@
 # Status: Auth middleware — resolve sector from query param
 
-**Current Status**: not-started
-**Last Updated**: 2026-06-04
-**Agent**: —
-**Branch**: —
+**Current Status**: complete
+**Last Updated**: 2026-06-11
+**Agent**: claude-sonnet-4-6
+**Branch**: feature/setores-webhook-providers
 **PR**: —
 
 ## Status History
@@ -11,6 +11,13 @@
 | Timestamp | Status | Agent | Notes |
 |-----------|--------|-------|-------|
 | 2026-06-04 | not-started | — | Task created |
+| 2026-06-11 | in-progress | claude-sonnet-4-6 | Executing on single PR branch |
+| 2026-06-11 | complete | claude-sonnet-4-6 | api-routes.ts + api-routes.spec.ts; 7 tests pass |
+
+## Adaptations
+
+- buildAuthenticateLicensee exported for testability
+- Query param uses `sector=` (English) consistent with codebase naming
 
 ## Blockers
 

--- a/.plans/setores-webhook-providers/phase-2/task-03-ingest-pipeline/status.md
+++ b/.plans/setores-webhook-providers/phase-2/task-03-ingest-pipeline/status.md
@@ -1,9 +1,9 @@
 # Status: Ingest pipeline — thread setorId from controller to Message
 
-**Current Status**: not-started
-**Last Updated**: 2026-06-04
-**Agent**: —
-**Branch**: —
+**Current Status**: complete
+**Last Updated**: 2026-06-11
+**Agent**: claude-sonnet-4-6
+**Branch**: feature/setores-webhook-providers
 **PR**: —
 
 ## Status History
@@ -11,6 +11,12 @@
 | Timestamp | Status | Agent | Notes |
 |-----------|--------|-------|-------|
 | 2026-06-04 | not-started | — | Task created |
+| 2026-06-11 | in-progress | claude-sonnet-4-6 | Executing on single PR branch |
+| 2026-06-11 | complete | claude-sonnet-4-6 | MessengersController updated; IngestMessengerMessage + MessengerMessage already done by setores plan; 8 tests pass |
+
+## Adaptations
+
+- IngestMessengerMessage.ts and MessengerMessage.ts were already implemented by the setores plan — only MessengersController needed updating to forward sectorId
 
 ## Blockers
 

--- a/src/app/controllers/MessengersController.spec.ts
+++ b/src/app/controllers/MessengersController.spec.ts
@@ -31,8 +31,33 @@ describe('MessengersController delegation', () => {
 
     await controller.message(req, res)
 
-    expect(ingestMessengerMessage.execute).toHaveBeenCalledWith({ body: req.body, licenseeId: 'licensee-id' })
+    expect(ingestMessengerMessage.execute).toHaveBeenCalledWith({
+      body: req.body,
+      licenseeId: 'licensee-id',
+      sectorId: null,
+    })
     expect(res.status).toHaveBeenCalledWith(200)
     expect(res.send).toHaveBeenCalledWith({ body: 'Solicitação de mensagem para a plataforma de messenger agendado' })
+  })
+
+  it('forwards sectorId from req.sector when sector is present', async () => {
+    const { controller, ingestMessengerMessage } = buildController()
+    const req = {
+      body: { field: 'test' },
+      licensee: { _id: 'licensee-id' },
+      sector: { _id: 'sector-id' },
+    }
+    const res = buildResponse()
+
+    ingestMessengerMessage.execute.mockResolvedValue({})
+
+    await controller.message(req, res)
+
+    expect(ingestMessengerMessage.execute).toHaveBeenCalledWith({
+      body: req.body,
+      licenseeId: 'licensee-id',
+      sectorId: 'sector-id',
+    })
+    expect(res.status).toHaveBeenCalledWith(200)
   })
 })

--- a/src/app/controllers/MessengersController.ts
+++ b/src/app/controllers/MessengersController.ts
@@ -8,7 +8,11 @@ class MessengersController {
   }
 
   async message(req: any, res: any) {
-    await this.ingestMessengerMessage.execute({ body: req.body, licenseeId: req.licensee._id })
+    await this.ingestMessengerMessage.execute({
+      body: req.body,
+      licenseeId: req.licensee._id,
+      sectorId: req.sector?._id ?? null,
+    })
 
     res.status(200).send({ body: 'Solicitação de mensagem para a plataforma de messenger agendado' })
   }

--- a/src/app/controllers/SectorsController.spec.ts
+++ b/src/app/controllers/SectorsController.spec.ts
@@ -179,7 +179,10 @@ describe('SectorsController', () => {
     })
 
     it('populates licensee so webhookUrl virtual resolves', async () => {
-      const sectorData = { name: 'Vendas', webhookUrl: 'https://clave-digital.herokuapp.com/api/v1/messenger/message/?token=abc&sector=xyz' }
+      const sectorData = {
+        name: 'Vendas',
+        webhookUrl: 'https://clave-digital.herokuapp.com/api/v1/messenger/message/?token=abc&sector=xyz',
+      }
       const sectorRepository = {
         findFirst: jest.fn().mockResolvedValue(sectorData),
       }

--- a/src/app/controllers/SectorsController.spec.ts
+++ b/src/app/controllers/SectorsController.spec.ts
@@ -114,6 +114,19 @@ describe('SectorsController', () => {
       expect(res.status).toHaveBeenCalledWith(500)
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ errors: expect.any(Object) }))
     })
+
+    it('populates licensee so webhookUrl virtual resolves', async () => {
+      const sectorRepository = {
+        find: jest.fn().mockResolvedValue([]),
+      }
+      const controller = new SectorsController({ sectorRepository })
+      const req = { query: { licensee: 'lic-id' } }
+      const res = buildResponse()
+
+      await controller.index(req, res)
+
+      expect(sectorRepository.find).toHaveBeenCalledWith({ licensee: 'lic-id' }, ['licensee', 'users'])
+    })
   })
 
   describe('#destroy', () => {
@@ -163,6 +176,21 @@ describe('SectorsController', () => {
 
       expect(res.status).toHaveBeenCalledWith(200)
       expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ name: 'Vendas' }))
+    })
+
+    it('populates licensee so webhookUrl virtual resolves', async () => {
+      const sectorData = { name: 'Vendas', webhookUrl: 'https://clave-digital.herokuapp.com/api/v1/messenger/message/?token=abc&sector=xyz' }
+      const sectorRepository = {
+        findFirst: jest.fn().mockResolvedValue(sectorData),
+      }
+      const controller = new SectorsController({ sectorRepository })
+      const req = { params: { id: 'sector-id' } }
+      const res = buildResponse()
+
+      await controller.show(req, res)
+
+      expect(sectorRepository.findFirst).toHaveBeenCalledWith({ _id: 'sector-id' }, ['licensee', 'users'])
+      expect(res.status).toHaveBeenCalledWith(200)
     })
   })
 

--- a/src/app/controllers/SectorsController.ts
+++ b/src/app/controllers/SectorsController.ts
@@ -54,7 +54,7 @@ class SectorsController {
       const params: any = {}
       if (req.query.licensee) params.licensee = req.query.licensee
 
-      const sectors = await this.sectorRepository.find(params, ['users'])
+      const sectors = await this.sectorRepository.find(params, ['licensee', 'users'])
       return res.status(200).send(sectors)
     } catch (err: any) {
       return res.status(500).send({ errors: { message: `Erro interno do servidor: ${err.message}` } })
@@ -63,7 +63,7 @@ class SectorsController {
 
   async show(req: any, res: any) {
     try {
-      const sector = await this.sectorRepository.findFirst({ _id: req.params.id }, ['users'])
+      const sector = await this.sectorRepository.findFirst({ _id: req.params.id }, ['licensee', 'users'])
       return res.status(200).send(sector)
     } catch (err: any) {
       if (err.name === 'CastError' && err.kind === 'ObjectId') {

--- a/src/app/models/Sector.spec.ts
+++ b/src/app/models/Sector.spec.ts
@@ -39,7 +39,6 @@ describe('Sector', () => {
 
       expect(sector.sectorToken).toMatch(/^[0-9a-f-]{36}$/)
     })
-
   })
 
   describe('webhookUrl virtual', () => {
@@ -51,9 +50,7 @@ describe('Sector', () => {
       const sector = await Sector.create({ name: 'Vendas', licensee, users: [userId] })
       const populated = await Sector.findById(sector._id).populate('licensee')
 
-      expect(populated!.webhookUrl).toMatch(
-        new RegExp(`token=${licensee.apiToken}&sector=${sector.sectorToken}`),
-      )
+      expect(populated!.webhookUrl).toMatch(new RegExp(`token=${licensee.apiToken}&sector=${sector.sectorToken}`))
     })
 
     it('returns null when licensee is not populated', async () => {

--- a/src/app/models/Sector.spec.ts
+++ b/src/app/models/Sector.spec.ts
@@ -29,6 +29,43 @@ describe('Sector', () => {
 
       expect(sector.active).toEqual(true)
     })
+
+    it('auto-generates sectorToken as a UUID string', async () => {
+      const licenseeRepository = new LicenseeRepositoryDatabase()
+      const licensee = await licenseeRepository.create(licenseeFactory.build())
+      const userId = new mongoose.Types.ObjectId()
+
+      const sector = await Sector.create({ name: 'Vendas', licensee, users: [userId] })
+
+      expect(sector.sectorToken).toMatch(/^[0-9a-f-]{36}$/)
+    })
+
+  })
+
+  describe('webhookUrl virtual', () => {
+    it('returns webhookUrl when licensee is populated', async () => {
+      const licenseeRepository = new LicenseeRepositoryDatabase()
+      const licensee = await licenseeRepository.create(licenseeFactory.build())
+      const userId = new mongoose.Types.ObjectId()
+
+      const sector = await Sector.create({ name: 'Vendas', licensee, users: [userId] })
+      const populated = await Sector.findById(sector._id).populate('licensee')
+
+      expect(populated!.webhookUrl).toMatch(
+        new RegExp(`token=${licensee.apiToken}&sector=${sector.sectorToken}`),
+      )
+    })
+
+    it('returns null when licensee is not populated', async () => {
+      const licenseeRepository = new LicenseeRepositoryDatabase()
+      const licensee = await licenseeRepository.create(licenseeFactory.build())
+      const userId = new mongoose.Types.ObjectId()
+
+      const sector = await Sector.create({ name: 'Vendas', licensee, users: [userId] })
+      const unpopulated = await Sector.findById(sector._id)
+
+      expect(unpopulated!.webhookUrl).toBeNull()
+    })
   })
 
   describe('validations', () => {

--- a/src/app/models/Sector.ts
+++ b/src/app/models/Sector.ts
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose'
+import { v4 as uuidv4 } from 'uuid'
 
 const Schema = mongoose.Schema
 const ObjectId = Schema.ObjectId
@@ -23,6 +24,7 @@ const sectorSchema = new Schema(
       },
     },
     active: { type: Boolean, default: true },
+    sectorToken: { type: String, unique: true, default: uuidv4 },
   },
   { timestamps: true },
 )
@@ -31,6 +33,11 @@ sectorSchema.pre('save', function () {
   if (!this._id) {
     this._id = new mongoose.Types.ObjectId()
   }
+})
+
+sectorSchema.virtual('webhookUrl').get(function () {
+  if (!this.populated('licensee')) return null
+  return `https://clave-digital.herokuapp.com/api/v1/messenger/message/?token=${(this.licensee as any).apiToken}&sector=${this.sectorToken}`
 })
 
 sectorSchema.set('toJSON', {

--- a/src/app/routes/api-routes.spec.ts
+++ b/src/app/routes/api-routes.spec.ts
@@ -1,0 +1,132 @@
+import { buildAuthenticateLicensee } from './api-routes'
+
+function buildResponse() {
+  return {
+    json: jest.fn(),
+    status: jest.fn().mockReturnThis(),
+  }
+}
+
+describe('buildAuthenticateLicensee', () => {
+  describe('without sector param', () => {
+    it('sets req.licensee and calls next when token is valid', async () => {
+      const licensee = { _id: 'lic-id', apiToken: 'valid-token' }
+      const licenseeRepository = { findFirst: jest.fn().mockResolvedValue(licensee) }
+      const sectorRepository = { findFirst: jest.fn() }
+      const middleware = buildAuthenticateLicensee({ licenseeRepository, sectorRepository })
+
+      const req: any = { query: { token: 'valid-token' } }
+      const res = buildResponse()
+      const next = jest.fn()
+
+      await middleware(req, res, next)
+
+      expect(req.licensee).toEqual(licensee)
+      expect(req.sector).toBeUndefined()
+      expect(next).toHaveBeenCalled()
+      expect(res.status).not.toHaveBeenCalled()
+    })
+
+    it('returns 401 when token is missing', async () => {
+      const licenseeRepository = { findFirst: jest.fn() }
+      const sectorRepository = { findFirst: jest.fn() }
+      const middleware = buildAuthenticateLicensee({ licenseeRepository, sectorRepository })
+
+      const req: any = { query: {} }
+      const res = buildResponse()
+      const next = jest.fn()
+
+      await middleware(req, res, next)
+
+      expect(res.status).toHaveBeenCalledWith(401)
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    it('returns 401 when token is invalid', async () => {
+      const licenseeRepository = { findFirst: jest.fn().mockResolvedValue(null) }
+      const sectorRepository = { findFirst: jest.fn() }
+      const middleware = buildAuthenticateLicensee({ licenseeRepository, sectorRepository })
+
+      const req: any = { query: { token: 'bad-token' } }
+      const res = buildResponse()
+      const next = jest.fn()
+
+      await middleware(req, res, next)
+
+      expect(res.status).toHaveBeenCalledWith(401)
+      expect(next).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('with sector param', () => {
+    it('sets req.sector and calls next when sector token is valid and active', async () => {
+      const licensee = { _id: 'lic-id', apiToken: 'valid-token' }
+      const sector = { _id: 'sec-id', sectorToken: 'valid-sector', active: true, licensee: 'lic-id' }
+      const licenseeRepository = { findFirst: jest.fn().mockResolvedValue(licensee) }
+      const sectorRepository = { findFirst: jest.fn().mockResolvedValue(sector) }
+      const middleware = buildAuthenticateLicensee({ licenseeRepository, sectorRepository })
+
+      const req: any = { query: { token: 'valid-token', sector: 'valid-sector' } }
+      const res = buildResponse()
+      const next = jest.fn()
+
+      await middleware(req, res, next)
+
+      expect(sectorRepository.findFirst).toHaveBeenCalledWith({
+        sectorToken: 'valid-sector',
+        licensee: 'lic-id',
+      })
+      expect(req.sector).toEqual(sector)
+      expect(next).toHaveBeenCalled()
+    })
+
+    it('returns 401 when sector token belongs to a different licensee', async () => {
+      const licensee = { _id: 'lic-id', apiToken: 'valid-token' }
+      const licenseeRepository = { findFirst: jest.fn().mockResolvedValue(licensee) }
+      const sectorRepository = { findFirst: jest.fn().mockResolvedValue(null) }
+      const middleware = buildAuthenticateLicensee({ licenseeRepository, sectorRepository })
+
+      const req: any = { query: { token: 'valid-token', sector: 'other-sector' } }
+      const res = buildResponse()
+      const next = jest.fn()
+
+      await middleware(req, res, next)
+
+      expect(res.status).toHaveBeenCalledWith(401)
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    it('returns 401 when sector is inactive', async () => {
+      const licensee = { _id: 'lic-id', apiToken: 'valid-token' }
+      const sector = { _id: 'sec-id', sectorToken: 'valid-sector', active: false, licensee: 'lic-id' }
+      const licenseeRepository = { findFirst: jest.fn().mockResolvedValue(licensee) }
+      const sectorRepository = { findFirst: jest.fn().mockResolvedValue(sector) }
+      const middleware = buildAuthenticateLicensee({ licenseeRepository, sectorRepository })
+
+      const req: any = { query: { token: 'valid-token', sector: 'valid-sector' } }
+      const res = buildResponse()
+      const next = jest.fn()
+
+      await middleware(req, res, next)
+
+      expect(res.status).toHaveBeenCalledWith(401)
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    it('returns 401 when sector token is unknown', async () => {
+      const licensee = { _id: 'lic-id', apiToken: 'valid-token' }
+      const licenseeRepository = { findFirst: jest.fn().mockResolvedValue(licensee) }
+      const sectorRepository = { findFirst: jest.fn().mockResolvedValue(null) }
+      const middleware = buildAuthenticateLicensee({ licenseeRepository, sectorRepository })
+
+      const req: any = { query: { token: 'valid-token', sector: 'unknown' } }
+      const res = buildResponse()
+      const next = jest.fn()
+
+      await middleware(req, res, next)
+
+      expect(res.status).toHaveBeenCalledWith(401)
+      expect(next).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/app/routes/api-routes.ts
+++ b/src/app/routes/api-routes.ts
@@ -1,16 +1,30 @@
 import express from 'express'
 import v1Routes from './v1/v1-routes'
 import { LicenseeRepositoryDatabase } from '../repositories/licensee'
+import { SectorRepositoryDatabase } from '../repositories/sector'
 
 const router = express.Router()
 const licenseeRepository = new LicenseeRepositoryDatabase()
+const sectorRepository = new SectorRepositoryDatabase()
 
-function buildAuthenticateLicensee({ licenseeRepository }: any) {
+export function buildAuthenticateLicensee({ licenseeRepository, sectorRepository }: any) {
   return async function authenticateLicensee(req: any, res: any, next: any) {
     if (req.query.token) {
       const licensee = await licenseeRepository.findFirst({ apiToken: req.query.token })
       if (licensee) {
         req.licensee = licensee
+
+        if (req.query.sector) {
+          const sector = await sectorRepository.findFirst({
+            sectorToken: req.query.sector,
+            licensee: licensee._id,
+          })
+          if (!sector || !sector.active) {
+            return res.status(401).json({ message: 'Token de setor inválido ou inativo.' })
+          }
+          req.sector = sector
+        }
+
         return next()
       }
     }
@@ -19,7 +33,7 @@ function buildAuthenticateLicensee({ licenseeRepository }: any) {
   }
 }
 
-router.use(buildAuthenticateLicensee({ licenseeRepository }))
+router.use(buildAuthenticateLicensee({ licenseeRepository, sectorRepository }))
 
 router.use('/v1', v1Routes)
 


### PR DESCRIPTION
## Summary

- Adds `sectorToken` field (UUID, unique) to `Sector` model and `webhookUrl` virtual that computes the sector-scoped webhook URL from `licensee.apiToken + sectorToken`
- Extends `authenticateLicensee` middleware in `api-routes.ts` to resolve an optional `?sector=` query param, look up the matching active `Sector`, and attach it to `req.sector` (returns 401 on invalid/inactive token)
- `MessengersController.message` now forwards `sectorId: req.sector?._id ?? null` to `IngestMessengerMessage` — `IngestMessengerMessage` and `MessengerMessage` sector propagation was already in place from the `setores` plan

## Test plan

- [x] `Sector` auto-generates `sectorToken` as UUID string on save
- [x] `Sector.webhookUrl` virtual resolves with correct format when `licensee` is populated; returns `null` when unpopulated
- [x] `SectorsController.show/index` now call `findFirst/find` with `['licensee', 'users']` populate
- [x] Auth middleware: valid token + no sector → `req.licensee` set, `next()` called
- [x] Auth middleware: valid token + valid active sector → `req.sector` set, `next()` called
- [x] Auth middleware: valid token + invalid/inactive/cross-licensee sector → 401
- [x] `MessengersController.message`: forwards `sectorId: null` when `req.sector` absent
- [x] `MessengersController.message`: forwards `sectorId` from `req.sector._id` when present
- [x] All 43 targeted tests pass; full suite 2627/2628 (1 pre-existing flaky test in `resources-routes.spec.ts` unrelated to this PR — passes in isolation)
- [x] `npx eslint` on all changed files: clean

## Adaptations from plan

- Codebase uses English naming (`Sector`, `sectorToken`, `?sector=`) not Portuguese (`Setor`, `setorToken`, `?setor=`) — all identifiers adapted
- `IngestMessengerMessage.ts` and `MessengerMessage.ts` were already implemented by the `setores` plan; only `MessengersController` needed updating