### PR TITLE
plan(local-chat-ui): Agent-facing local chat UI

### DIFF
--- a/.plans/README.md
+++ b/.plans/README.md
@@ -23,6 +23,7 @@ Git-native Markdown plans for multi-step work.
 | # | Plan | Folder | Status | Description |
 |---|------|--------|--------|-------------|
 | 2 | [MongoDB → PostgreSQL](./mongo-to-postgres/overview.md) | `mongo-to-postgres/` | not-started | Migrate all persistent data from MongoDB/Mongoose to PostgreSQL/Prisma using dual-write strategy; prerequisite: remove-pdv complete |
+| 5 | [Local Chat UI](./local-chat-ui/overview.md) | `local-chat-ui/` | not-started | Agent-facing full-screen chat page at /chat: room list + conversation panel adapted from whatsapp-web-clone, conditional navbar link, Socket.IO real-time updates |
 | 3 | [Backend Type Narrowing](./type-backend/overview.md) | `type-backend/` | not-started | Replace `any` with interfaces across models, repositories, use cases, controllers, and plugins — 3 phases, 11 tasks |
 | 4 | [Client Type Narrowing](./type-client/overview.md) | `type-client/` | not-started | Replace `any` with interfaces across React services, contexts, pages, and components — 2 phases, 6 tasks |
 

--- a/.plans/local-chat-ui/overview.md
+++ b/.plans/local-chat-ui/overview.md
@@ -1,0 +1,109 @@
+# Plan: Local Chat UI
+
+**Status**: not-started
+**Created**: 2026-06-15
+**Last Updated**: 2026-06-15
+**Assigned Dev**: Alan Costa Facchini
+**PR Strategy**: per-wave
+
+## Objective
+
+Build the agent-facing frontend for the local chat: a full-screen WhatsApp-style page at `/chat`, conditionally linked from the navbar, backed by two new REST endpoints and wired to real-time Socket.IO events already emitted by the `LocalChat` backend plugin.
+
+## Scope
+
+### In Scope
+- `GET /resources/rooms` — list open rooms for the requesting user's effective licensee
+- `GET /resources/rooms/:roomId/messages` — paginated message history for a room
+- `/chat` page — full-screen layout (own viewport, no Bootstrap container), sidebar + conversation panel, adapted from whatsapp-web-clone components
+- Navbar link — shown only when `effectiveLicensee.chatDefault === 'local'`
+- `PrivateRoute` — add `noLayout` prop to skip BaseLayout wrapping (needed for full-screen route)
+- Socket.IO client integration — join `licensee:{id}` room, receive `new-room-message` events in real time
+- Server-side socket join handler — accept `join-licensee` event from clients
+
+### Out of Scope
+- Agent assignment / room claiming UI — rooms are displayed as they arrive; assignment deferred
+- File/image attachment sending — text messages only in this plan
+- Typing indicators — deferred
+- Read receipts / message status — deferred
+- Push notifications — deferred
+- Room search / filtering — deferred
+
+## Kill Criteria
+
+- If the Socket.IO join mechanism conflicts with security requirements (unauthenticated clients joining arbitrary licensee rooms), stop and design an authenticated join flow before proceeding with task-03
+- If adapting whatsapp-web-clone CSS causes major visual regressions on existing pages, scope styles to a dedicated CSS module
+
+## Prerequisites
+
+- `local-chat-infra` plan: complete ✓ — LocalChat plugin, Room model, agent reply endpoint, socketEmitter singleton all exist
+
+## Phases
+
+| Phase | Name | Tasks | Dependencies | Description |
+|-------|------|-------|--------------|-------------|
+| 1 | Backend API | task-01 | None | New RoomsController with index + messages endpoints |
+| 2 | Chat Page | task-02 | Phase 1 | Full-screen chat UI, navbar link, routing |
+| 3 | Real-Time | task-03 | Phase 2 | Socket.IO join handler (server) + useChatSocket hook (client) |
+
+## Task Summary
+
+| Task Path | Title | Phase | Status | Depends On |
+|-----------|-------|-------|--------|------------|
+| phase-1/task-01-rooms-api | Rooms API endpoints | 1 | not-started | — |
+| phase-2/task-02-chat-page | Chat page UI + routing + navbar | 2 | not-started | phase-1/task-01-rooms-api |
+| phase-3/task-03-socket-realtime | Socket.IO real-time integration | 3 | not-started | phase-2/task-02-chat-page |
+
+## Branch Convention
+
+Pattern: `plan/local-chat-ui/{task-path}`
+
+Example branches:
+- `plan/local-chat-ui/phase-1/task-01-rooms-api`
+- `plan/local-chat-ui/phase-2/task-02-chat-page`
+- `plan/local-chat-ui/phase-3/task-03-socket-realtime`
+
+Base branch: `main`
+
+## Key Files
+
+| File/Directory | Relevance |
+|----------------|-----------|
+| `src/app/controllers/RoomsController.ts` | NEW — index + messages actions |
+| `src/app/routes/resources-routes.ts` | Add GET /rooms and GET /rooms/:roomId/messages |
+| `src/app/repositories/room.ts` | Add `findForLicensee()` helper |
+| `src/app/models/Room.ts` | Reference — existing schema |
+| `src/config/http.ts` | Add `join-licensee` socket event handler |
+| `client/src/pages/Chat/` | NEW — full-screen chat page + components |
+| `client/src/services/rooms.ts` | NEW — getRooms, getRoomMessages, sendMessage |
+| `client/src/hooks/useChatSocket.ts` | NEW — socket.io-client hook |
+| `client/src/pages/routes.tsx` | Add /chat route with noLayout PrivateRoute |
+| `client/src/pages/Navbar/index.tsx` | Add conditional Chat link |
+| `client/src/pages/PrivateRoute/index.tsx` | Add noLayout prop |
+
+## Risks
+
+- **Unauthenticated socket joins** — `join-licensee` could allow arbitrary clients to join any licensee room. Mitigation: validate licenseeId against the authenticated user server-side in the join handler (task-03); for now, ensure the socket server rejects joins from unauthenticated clients by requiring a valid JWT handshake in the connection.
+- **PrivateRoute change** — adding `noLayout` prop touches a shared component. Mitigation: additive-only change (default `false`), no existing callers need updating.
+- **CSS scope bleed** — whatsapp-web-clone CSS uses global class names. Mitigation: scope all styles inside a `chat-layout` root selector or use CSS modules.
+
+## Success Criteria
+
+- [ ] `GET /resources/rooms` returns open rooms for the authenticated user's licensee; super can filter by `?licensee=`
+- [ ] `GET /resources/rooms/:roomId/messages` returns paginated messages; unauthorized rooms return 403
+- [ ] Navigating to `/#/chat` shows the full-screen chat layout when the active licensee has `chatDefault: 'local'`
+- [ ] Navbar shows a "Chat" link only when `effectiveLicensee?.chatDefault === 'local'`
+- [ ] Clicking a room in the sidebar loads its message history
+- [ ] Agent can send a text reply via the input bar; message appears in the conversation
+- [ ] New inbound messages appear in real time without page refresh
+- [ ] All backend tests pass: `npx jest`
+- [ ] Frontend tests pass: `npx vitest run` inside `client/`
+- [ ] `npx eslint .` produces no new errors
+- [ ] No regressions in existing pages
+
+## References
+
+- **JIRA Epic**: N/A
+- **Related Plans**: [Local Chat Infrastructure](../local-chat-infra/overview.md) — prerequisite (complete)
+- **whatsapp-web-clone source**: `/Users/alan/Developer/pessoal/whatsapp-web-clone/src`
+- **Rock Alignment**: N/A

--- a/.plans/local-chat-ui/overview.md
+++ b/.plans/local-chat-ui/overview.md
@@ -2,57 +2,60 @@
 
 **Status**: not-started
 **Created**: 2026-06-15
-**Last Updated**: 2026-06-15
+**Last Updated**: 2026-06-16
 **Assigned Dev**: Alan Costa Facchini
 **PR Strategy**: per-wave
 
 ## Objective
 
-Build the agent-facing frontend for the local chat: a full-screen WhatsApp-style page at `/chat`, conditionally linked from the navbar, backed by two new REST endpoints and wired to real-time Socket.IO events already emitted by the `LocalChat` backend plugin.
+Build the agent-facing frontend for the local chat: a full-screen WhatsApp-style page at `/chat`, conditionally linked from the navbar, backed by new REST endpoints (with sector-aware filtering and agent-initiated room creation), a LocalChat sector-assignment fix, and wired to real-time Socket.IO events already emitted by the backend plugin.
 
 ## Scope
 
 ### In Scope
-- `GET /resources/rooms` — list open rooms for the requesting user's effective licensee
+- **LocalChat sector fix** — when `LocalChat.sendMessage` creates a new room, it must carry `message.sector` into the room so that sector-scoped filtering works
+- `GET /resources/rooms` — list open rooms for the requesting user's effective licensee, filtered by the agent's sectors when applicable
+- `POST /resources/rooms` — create a room (contact + sector) for agent-initiated conversations; returns existing open room if one already exists for that contact
 - `GET /resources/rooms/:roomId/messages` — paginated message history for a room
 - `/chat` page — full-screen layout (own viewport, no Bootstrap container), sidebar + conversation panel, adapted from whatsapp-web-clone components
+- **Nova conversa** — "+" button in the sidebar opens contact search (reuses `SelectContactsWithFilter`), creates a room via `POST /resources/rooms`, auto-selects it
 - Navbar link — shown only when `effectiveLicensee.chatDefault === 'local'`
 - `PrivateRoute` — add `noLayout` prop to skip BaseLayout wrapping (needed for full-screen route)
 - Socket.IO client integration — join `licensee:{id}` room, receive `new-room-message` events in real time
-- Server-side socket join handler — accept `join-licensee` event from clients
+- Server-side socket join handler — accept `join-licensee` event from clients (with JWT validation)
 
 ### Out of Scope
 - Agent assignment / room claiming UI — rooms are displayed as they arrive; assignment deferred
 - File/image attachment sending — text messages only in this plan
-- Typing indicators — deferred
-- Read receipts / message status — deferred
-- Push notifications — deferred
+- Typing indicators, read receipts, push notifications — deferred
 - Room search / filtering — deferred
 
 ## Kill Criteria
 
-- If the Socket.IO join mechanism conflicts with security requirements (unauthenticated clients joining arbitrary licensee rooms), stop and design an authenticated join flow before proceeding with task-03
-- If adapting whatsapp-web-clone CSS causes major visual regressions on existing pages, scope styles to a dedicated CSS module
+- If the sector-filtering logic causes N+1 queries at scale, stop and redesign using a join/aggregation pipeline
+- If the Socket.IO join mechanism conflicts with security requirements (unauthenticated clients joining arbitrary licensee rooms), stop and design an authenticated join flow before proceeding with task-04
 
 ## Prerequisites
 
-- `local-chat-infra` plan: complete ✓ — LocalChat plugin, Room model, agent reply endpoint, socketEmitter singleton all exist
+- `local-chat-infra` plan: complete ✓ — LocalChat plugin, Room model (with `sector` field), agent reply endpoint, socketEmitter singleton all exist
+- `setores-webhook-providers` plan: complete ✓ — messages arriving via sector webhooks already carry `message.sector`
 
 ## Phases
 
 | Phase | Name | Tasks | Dependencies | Description |
 |-------|------|-------|--------------|-------------|
-| 1 | Backend API | task-01 | None | New RoomsController with index + messages endpoints |
-| 2 | Chat Page | task-02 | Phase 1 | Full-screen chat UI, navbar link, routing |
-| 3 | Real-Time | task-03 | Phase 2 | Socket.IO join handler (server) + useChatSocket hook (client) |
+| 1 | Backend API | task-01, task-02 | None | Rooms API (sector-aware) + LocalChat sector assignment fix — parallel, no shared files |
+| 2 | Chat Page | task-03 | Phase 1 | Full-screen chat UI, Nova conversa flow, navbar link, routing |
+| 3 | Real-Time | task-04 | Phase 2 | Socket.IO join handler (server) + useChatSocket hook (client) |
 
 ## Task Summary
 
 | Task Path | Title | Phase | Status | Depends On |
 |-----------|-------|-------|--------|------------|
-| phase-1/task-01-rooms-api | Rooms API endpoints | 1 | not-started | — |
-| phase-2/task-02-chat-page | Chat page UI + routing + navbar | 2 | not-started | phase-1/task-01-rooms-api |
-| phase-3/task-03-socket-realtime | Socket.IO real-time integration | 3 | not-started | phase-2/task-02-chat-page |
+| phase-1/task-01-rooms-api | Rooms API endpoints (sector-aware) | 1 | not-started | — |
+| phase-1/task-02-localchat-sector | LocalChat: assign sector to new rooms | 1 | not-started | — |
+| phase-2/task-03-chat-page | Chat page UI + Nova conversa + routing + navbar | 2 | not-started | phase-1/task-01-rooms-api, phase-1/task-02-localchat-sector |
+| phase-3/task-04-socket-realtime | Socket.IO real-time integration | 3 | not-started | phase-2/task-03-chat-page |
 
 ## Branch Convention
 
@@ -60,8 +63,9 @@ Pattern: `plan/local-chat-ui/{task-path}`
 
 Example branches:
 - `plan/local-chat-ui/phase-1/task-01-rooms-api`
-- `plan/local-chat-ui/phase-2/task-02-chat-page`
-- `plan/local-chat-ui/phase-3/task-03-socket-realtime`
+- `plan/local-chat-ui/phase-1/task-02-localchat-sector`
+- `plan/local-chat-ui/phase-2/task-03-chat-page`
+- `plan/local-chat-ui/phase-3/task-04-socket-realtime`
 
 Base branch: `main`
 
@@ -69,13 +73,15 @@ Base branch: `main`
 
 | File/Directory | Relevance |
 |----------------|-----------|
-| `src/app/controllers/RoomsController.ts` | NEW — index + messages actions |
-| `src/app/routes/resources-routes.ts` | Add GET /rooms and GET /rooms/:roomId/messages |
-| `src/app/repositories/room.ts` | Add `findForLicensee()` helper |
-| `src/app/models/Room.ts` | Reference — existing schema |
-| `src/config/http.ts` | Add `join-licensee` socket event handler |
+| `src/app/controllers/RoomsController.ts` | NEW — index, create, messages actions |
+| `src/app/routes/resources-routes.ts` | Add GET /rooms, POST /rooms, GET /rooms/:id/messages |
+| `src/app/repositories/room.ts` | Add `findForLicensee()` with sector scoping |
+| `src/app/models/Room.ts` | Reference — existing schema (has `sector` field) |
+| `src/app/plugins/chats/LocalChat.ts` | Fix `sendMessage` to pass `message.sector` when creating room |
+| `src/config/http.ts` | Add `join-licensee` socket event handler with JWT validation |
 | `client/src/pages/Chat/` | NEW — full-screen chat page + components |
-| `client/src/services/rooms.ts` | NEW — getRooms, getRoomMessages, sendMessage |
+| `client/src/pages/Chat/components/NewConversationModal.tsx` | NEW — contact search + room creation |
+| `client/src/services/rooms.ts` | NEW — getRooms, createRoom, getRoomMessages, sendMessage |
 | `client/src/hooks/useChatSocket.ts` | NEW — socket.io-client hook |
 | `client/src/pages/routes.tsx` | Add /chat route with noLayout PrivateRoute |
 | `client/src/pages/Navbar/index.tsx` | Add conditional Chat link |
@@ -83,19 +89,24 @@ Base branch: `main`
 
 ## Risks
 
-- **Unauthenticated socket joins** — `join-licensee` could allow arbitrary clients to join any licensee room. Mitigation: validate licenseeId against the authenticated user server-side in the join handler (task-03); for now, ensure the socket server rejects joins from unauthenticated clients by requiring a valid JWT handshake in the connection.
-- **PrivateRoute change** — adding `noLayout` prop touches a shared component. Mitigation: additive-only change (default `false`), no existing callers need updating.
-- **CSS scope bleed** — whatsapp-web-clone CSS uses global class names. Mitigation: scope all styles inside a `chat-layout` root selector or use CSS modules.
+- **Sector N+1** — the `findForLicensee` method fetches contacts by licensee, then rooms by contactId list. Adding sector lookup (fetch sectors by userId, then filter rooms by sectorId) may cascade. Mitigation: use `$in` queries with index-backed fields; sectors per agent are bounded (single-digit).
+- **Unauthenticated socket joins** — validate JWT in socket handshake middleware and ObjectId format in `join-licensee` handler (task-04).
+- **Duplicate rooms** — `POST /resources/rooms` must return the existing open room if one already exists for the contact, not create a second one.
+- **PrivateRoute change** — additive only (`noLayout` defaults to `false`); no existing callers break.
 
 ## Success Criteria
 
-- [ ] `GET /resources/rooms` returns open rooms for the authenticated user's licensee; super can filter by `?licensee=`
+- [ ] New inbound message via LocalChat creates a room with the correct `sector` field populated
+- [ ] `GET /resources/rooms` returns only rooms belonging to the agent's sectors; agent with no sectors sees all rooms for the licensee
+- [ ] `POST /resources/rooms` creates a room (or returns existing open one) for the given contact
 - [ ] `GET /resources/rooms/:roomId/messages` returns paginated messages; unauthorized rooms return 403
 - [ ] Navigating to `/#/chat` shows the full-screen chat layout when the active licensee has `chatDefault: 'local'`
 - [ ] Navbar shows a "Chat" link only when `effectiveLicensee?.chatDefault === 'local'`
+- [ ] "Nova conversa" opens contact search, creates a room, auto-selects it in the sidebar
 - [ ] Clicking a room in the sidebar loads its message history
-- [ ] Agent can send a text reply via the input bar; message appears in the conversation
+- [ ] Agent can send a text reply; message appears in the conversation
 - [ ] New inbound messages appear in real time without page refresh
+- [ ] Rooms with unread messages show an unread count badge
 - [ ] All backend tests pass: `npx jest`
 - [ ] Frontend tests pass: `npx vitest run` inside `client/`
 - [ ] `npx eslint .` produces no new errors
@@ -104,6 +115,6 @@ Base branch: `main`
 ## References
 
 - **JIRA Epic**: N/A
-- **Related Plans**: [Local Chat Infrastructure](../local-chat-infra/overview.md) — prerequisite (complete)
+- **Related Plans**: [Local Chat Infrastructure](../local-chat-infra/overview.md) — prerequisite (complete); [Setores](../setores/overview.md) — sector model used here
 - **whatsapp-web-clone source**: `/Users/alan/Developer/pessoal/whatsapp-web-clone/src`
 - **Rock Alignment**: N/A

--- a/.plans/local-chat-ui/phase-1/task-01-rooms-api/status.md
+++ b/.plans/local-chat-ui/phase-1/task-01-rooms-api/status.md
@@ -1,0 +1,25 @@
+# Status: Rooms API endpoints
+
+**Current Status**: not-started
+**Last Updated**: 2026-06-15
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-06-15 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/local-chat-ui/phase-1/task-01-rooms-api/task.md
+++ b/.plans/local-chat-ui/phase-1/task-01-rooms-api/task.md
@@ -1,0 +1,227 @@
+# Task: Rooms API endpoints
+
+**Plan**: Local Chat UI
+**Phase**: 1
+**Task ID (phase-local)**: task-01
+**Task Path**: phase-1/task-01-rooms-api
+**Depends On**: None
+**JIRA**: N/A
+
+## Objective
+
+Create two REST endpoints that the frontend chat page will consume: `GET /resources/rooms` (list open rooms for the current user's licensee) and `GET /resources/rooms/:roomId/messages` (paginated message history for a room).
+
+## Context
+
+The `local-chat-infra` plan already built the Room model, the LocalChat plugin, and the agent-reply endpoint (`POST /v1/chat/rooms/:roomId/messages`). The dashboard controller has a similar `openRooms` endpoint but it is super/admin-only and unsuitable for agents — a dedicated resource controller is needed.
+
+Key existing files:
+- `src/app/models/Room.ts` — Room schema: `contact (ref Contact)`, `agent (ref User)`, `status (pending|open|closed)`, `closed (bool)`, `closedAt`
+- `src/app/repositories/room.ts` — `RoomRepositoryDatabase` with `findOpenForContact` and `findForAgent`
+- `src/app/controllers/DashboardController.ts` — `openRooms()` for reference (super/admin only)
+- `src/app/routes/resources-routes.ts` — composition root; add routes here
+- `src/types/index.ts` — shared interfaces; `IRoom`, `IContact` live here
+
+Auth pattern (from `resources-routes.ts`):
+```ts
+function authenticate(req, res, next) { /* validates x-access-token JWT */ }
+function authorize(...roles) { /* checks user.role */ }
+router.use(authenticate)
+```
+
+The `req.userId` is set by `authenticate`. Use `userRepository.findFirst({ _id: req.userId })` to resolve the user; the user's `licensee` field is an ObjectId (not populated on this call).
+
+Super users have no `licensee` on their User document; they can pass `?licensee=` as a query param to filter by licensee.
+
+## Before You Start
+
+- [ ] `git switch main && git pull --rebase origin main`
+- [ ] Verify `phase-1/task-01-rooms-api/status.md` shows `not-started`
+- [ ] Read `src/app/controllers/DashboardController.ts` — `openRooms` method — for the aggregation pattern to fetch lastMessage per room
+- [ ] Read `src/app/repositories/room.ts` for existing query helpers
+- [ ] Read `src/app/routes/resources-routes.ts` to understand the composition root
+- [ ] Mark this task `in-progress` in `status.md`
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/app/controllers/RoomsController.ts` | create | New controller |
+| `src/app/controllers/RoomsController.spec.ts` | create | Controller specs |
+| `src/app/repositories/room.ts` | modify | Add `findForLicensee()` helper |
+| `src/app/routes/resources-routes.ts` | modify | Wire routes + controller |
+
+### Do NOT Modify
+
+- `src/app/controllers/DashboardController.ts` — read-only reference
+- `src/app/models/Room.ts` — schema is stable; read-only
+- `src/types/index.ts` — no new types needed for this task
+
+## Implementation Steps
+
+### Step 1: Add `findForLicensee` to `RoomRepositoryDatabase`
+
+In `src/app/repositories/room.ts`, add a method to `RoomRepositoryDatabase`:
+
+```ts
+async findForLicensee(licenseeId: any, { status, page = 1, limit = 20 }: { status?: string; page?: number; limit?: number } = {}) {
+  const contacts = await this.model().db.model('Contact').find({ licensee: licenseeId }).select('_id').lean()
+  const contactIds = contacts.map((c: any) => c._id)
+  const filter: any = { contact: { $in: contactIds } }
+  if (status) {
+    filter.status = status
+  } else {
+    filter.closed = false
+  }
+  return this.model()
+    .find(filter)
+    .sort({ updatedAt: -1 })
+    .skip((page - 1) * limit)
+    .limit(limit + 1)
+    .populate('contact', 'name number')
+    .lean()
+}
+```
+
+This pattern mirrors the contact lookup in `DashboardController.openRooms`.
+
+### Step 2: Create `RoomsController`
+
+Create `src/app/controllers/RoomsController.ts`:
+
+```ts
+class RoomsController {
+  userRepository: any
+  roomRepository: any
+  messageRepository: any
+
+  constructor({ userRepository, roomRepository, messageRepository }: Record<string, any> = {}) {
+    this.userRepository = userRepository
+    this.roomRepository = roomRepository
+    this.messageRepository = messageRepository
+    this.index = this.index.bind(this)
+    this.messages = this.messages.bind(this)
+  }
+
+  async index(req: any, res: any) {
+    try {
+      const user = await this.userRepository.findFirst({ _id: req.userId }, ['licensee'])
+      if (!user) return res.status(404).json({ message: 'Usuário não encontrado.' })
+
+      const licenseeId = user.role === 'super'
+        ? (req.query.licensee ?? null)
+        : user.licensee?._id ?? user.licensee
+
+      if (!licenseeId) return res.status(400).json({ message: 'Licenciado não identificado.' })
+
+      const page = Math.max(1, parseInt(req.query.page as string) || 1)
+      const limit = 20
+
+      const roomResults = await this.roomRepository.findForLicensee(licenseeId, { page, limit })
+      const hasMore = roomResults.length > limit
+      const rooms = hasMore ? roomResults.slice(0, limit) : roomResults
+
+      // Attach last message to each room
+      const roomIds = rooms.map((r: any) => r._id)
+      const lastMessages = await this.messageRepository.model().aggregate([
+        { $match: { room: { $in: roomIds } } },
+        { $sort: { createdAt: -1 } },
+        { $group: { _id: '$room', text: { $first: '$text' }, kind: { $first: '$kind' }, createdAt: { $first: '$createdAt' } } },
+      ])
+      const lastMsgMap: Record<string, any> = {}
+      for (const m of lastMessages) lastMsgMap[m._id.toString()] = m
+      const roomsWithLast = rooms.map((r: any) => ({ ...r, lastMessage: lastMsgMap[r._id.toString()] || null }))
+
+      return res.status(200).json({ rooms: roomsWithLast, hasMore })
+    } catch (err: any) {
+      return res.status(500).json({ message: `Erro interno do servidor: ${err.message}` })
+    }
+  }
+
+  async messages(req: any, res: any) {
+    try {
+      const user = await this.userRepository.findFirst({ _id: req.userId }, ['licensee'])
+      if (!user) return res.status(404).json({ message: 'Usuário não encontrado.' })
+
+      const room = await this.roomRepository.findFirst({ _id: req.params.roomId }, ['contact'])
+      if (!room) return res.status(404).json({ message: 'Conversa não encontrada.' })
+
+      // Authorization: room's contact must belong to the user's licensee
+      const userLicenseeId = user.role === 'super' ? null : (user.licensee?._id ?? user.licensee)?.toString()
+      const roomLicenseeId = room.contact?.licensee?.toString()
+      if (userLicenseeId && roomLicenseeId && userLicenseeId !== roomLicenseeId) {
+        return res.status(403).json({ message: 'Acesso negado.' })
+      }
+
+      const page = Math.max(1, parseInt(req.query.page as string) || 1)
+      const limit = 30
+
+      const total = await this.messageRepository.model().countDocuments({ room: room._id })
+      const messages = await this.messageRepository.model()
+        .find({ room: room._id })
+        .sort({ createdAt: 1 })
+        .skip((page - 1) * limit)
+        .limit(limit)
+        .lean()
+
+      return res.status(200).json({ messages, total, page, hasMore: page * limit < total })
+    } catch (err: any) {
+      return res.status(500).json({ message: `Erro interno do servidor: ${err.message}` })
+    }
+  }
+}
+
+export { RoomsController }
+```
+
+### Step 3: Wire routes in `resources-routes.ts`
+
+In `src/app/routes/resources-routes.ts`:
+
+1. Import `RoomsController`:
+```ts
+import { RoomsController } from '../controllers/RoomsController'
+```
+
+2. In the composition root (after `createRuntimeDependencies()`):
+```ts
+const roomsController = new RoomsController({ userRepository, roomRepository, messageRepository })
+```
+
+3. Add routes (after existing router registrations, before `export default router`):
+```ts
+router.get('/rooms', roomsController.index)
+router.get('/rooms/:roomId/messages', roomsController.messages)
+```
+
+### Step 4: Write `RoomsController.spec.ts`
+
+Follow the pattern of existing controller specs (e.g., `DashboardController.spec.ts` or `MessagesController.spec.ts`). Use the Memory repository variants.
+
+Tests to write:
+- `index` — returns rooms for user's licensee; super can filter by `?licensee=`; 400 when super provides no licensee; 404 for unknown user
+- `index` — pagination: `hasMore: true` when > 20 rooms exist
+- `messages` — returns messages sorted by `createdAt` asc for valid room; 403 when user's licensee doesn't match room's contact licensee; 404 for unknown room
+
+## Testing
+
+- [ ] `RoomsController.spec.ts` covers: index (happy path, super filter, no-licensee 400, pagination), messages (happy path, 403 cross-licensee, 404 unknown room)
+- [ ] Existing backend tests still pass: `npx jest`
+- [ ] `npx eslint .` produces no new errors
+
+## Documentation / KB Updates
+
+- [ ] No KB/doc updates required — this follows the established controller pattern. If the pattern diverges significantly, run `document-solution` after completion.
+
+## Completion Criteria
+
+- [ ] `GET /resources/rooms` returns open rooms with populated contact + lastMessage
+- [ ] `GET /resources/rooms/:roomId/messages` returns paginated message list; 403 on cross-licensee access
+- [ ] All new and existing backend tests pass
+- [ ] Lint clean
+- [ ] Status updated to `complete` in `status.md`
+- [ ] Changes committed to `plan/local-chat-ui/phase-1/task-01-rooms-api`
+
+## Conflict Avoidance Notes
+
+No sibling tasks in Phase 1.

--- a/.plans/local-chat-ui/phase-1/task-01-rooms-api/task.md
+++ b/.plans/local-chat-ui/phase-1/task-01-rooms-api/task.md
@@ -1,4 +1,4 @@
-# Task: Rooms API endpoints
+# Task: Rooms API endpoints (sector-aware)
 
 **Plan**: Local Chat UI
 **Phase**: 1
@@ -9,70 +9,81 @@
 
 ## Objective
 
-Create two REST endpoints that the frontend chat page will consume: `GET /resources/rooms` (list open rooms for the current user's licensee) and `GET /resources/rooms/:roomId/messages` (paginated message history for a room).
+Create three REST endpoints: `GET /resources/rooms` (sector-aware room listing), `POST /resources/rooms` (agent-initiated room creation), and `GET /resources/rooms/:roomId/messages` (paginated message history).
 
 ## Context
 
-The `local-chat-infra` plan already built the Room model, the LocalChat plugin, and the agent-reply endpoint (`POST /v1/chat/rooms/:roomId/messages`). The dashboard controller has a similar `openRooms` endpoint but it is super/admin-only and unsuitable for agents — a dedicated resource controller is needed.
+The `local-chat-infra` plan built the Room model, the LocalChat plugin, and the agent-reply endpoint (`POST /v1/chat/rooms/:roomId/messages`). The `setores-webhook-providers` plan added sector-scoped webhook routing — messages arriving via a sector's webhook already carry `message.sector`. The dashboard controller has a similar `openRooms` endpoint but it is super/admin-only; a dedicated resource controller is needed.
 
-Key existing files:
-- `src/app/models/Room.ts` — Room schema: `contact (ref Contact)`, `agent (ref User)`, `status (pending|open|closed)`, `closed (bool)`, `closedAt`
+**Key existing files:**
+- `src/app/models/Room.ts` — schema: `contact (ref Contact)`, `sector (ref Sector, nullable)`, `agent (ref User)`, `status (pending|open|closed)`, `closed (bool)`
+- `src/app/models/Sector.ts` — schema: `licensee`, `users: [ObjectId ref User]`, `active`
 - `src/app/repositories/room.ts` — `RoomRepositoryDatabase` with `findOpenForContact` and `findForAgent`
 - `src/app/controllers/DashboardController.ts` — `openRooms()` for reference (super/admin only)
-- `src/app/routes/resources-routes.ts` — composition root; add routes here
-- `src/types/index.ts` — shared interfaces; `IRoom`, `IContact` live here
+- `src/app/routes/resources-routes.ts` — composition root
 
-Auth pattern (from `resources-routes.ts`):
+**Auth pattern:**
 ```ts
-function authenticate(req, res, next) { /* validates x-access-token JWT */ }
-function authorize(...roles) { /* checks user.role */ }
+// authenticate sets req.userId from JWT; authorize checks user.role
 router.use(authenticate)
 ```
 
-The `req.userId` is set by `authenticate`. Use `userRepository.findFirst({ _id: req.userId })` to resolve the user; the user's `licensee` field is an ObjectId (not populated on this call).
+**Sector-scoped filtering logic:**
+- Fetch sectors where `users` array contains `req.userId` → `agentSectorIds`
+- If `agentSectorIds.length > 0`: filter rooms where `room.sector` is in `agentSectorIds`
+- If `agentSectorIds.length === 0` (agent not in any sector, or admin/super): return all rooms for the licensee regardless of sector
+- Super can pass `?licensee=` to filter by licensee
 
-Super users have no `licensee` on their User document; they can pass `?licensee=` as a query param to filter by licensee.
+**Agent-initiated room creation (`POST /resources/rooms`):**
+- If an open room already exists for the contact, return it (no duplicate)
+- If only closed rooms exist, create a new one
+- Validate that the contact belongs to the user's licensee (prevent cross-licensee room creation)
 
 ## Before You Start
 
 - [ ] `git switch main && git pull --rebase origin main`
-- [ ] Verify `phase-1/task-01-rooms-api/status.md` shows `not-started`
-- [ ] Read `src/app/controllers/DashboardController.ts` — `openRooms` method — for the aggregation pattern to fetch lastMessage per room
-- [ ] Read `src/app/repositories/room.ts` for existing query helpers
-- [ ] Read `src/app/routes/resources-routes.ts` to understand the composition root
+- [ ] Verify `status.md` shows `not-started`
+- [ ] Read `src/app/controllers/DashboardController.ts` — `openRooms` and `closeRoom` for aggregation patterns
+- [ ] Read `src/app/repositories/room.ts` — existing helpers
+- [ ] Read `src/app/models/Sector.ts` — `users` array field
+- [ ] Read `src/app/routes/resources-routes.ts` — composition root pattern
 - [ ] Mark this task `in-progress` in `status.md`
 
 ## File Ownership
 
 | File | Action | Notes |
 |------|--------|-------|
-| `src/app/controllers/RoomsController.ts` | create | New controller |
+| `src/app/controllers/RoomsController.ts` | create | index, create, messages actions |
 | `src/app/controllers/RoomsController.spec.ts` | create | Controller specs |
 | `src/app/repositories/room.ts` | modify | Add `findForLicensee()` helper |
-| `src/app/routes/resources-routes.ts` | modify | Wire routes + controller |
+| `src/app/routes/resources-routes.ts` | modify | Wire 3 new routes |
 
 ### Do NOT Modify
 
 - `src/app/controllers/DashboardController.ts` — read-only reference
 - `src/app/models/Room.ts` — schema is stable; read-only
-- `src/types/index.ts` — no new types needed for this task
+- `src/app/plugins/chats/LocalChat.ts` — owned by phase-1/task-02-localchat-sector
 
 ## Implementation Steps
 
 ### Step 1: Add `findForLicensee` to `RoomRepositoryDatabase`
 
-In `src/app/repositories/room.ts`, add a method to `RoomRepositoryDatabase`:
+In `src/app/repositories/room.ts`, add to `RoomRepositoryDatabase`:
 
 ```ts
-async findForLicensee(licenseeId: any, { status, page = 1, limit = 20 }: { status?: string; page?: number; limit?: number } = {}) {
+async findForLicensee(
+  licenseeId: any,
+  { sectorIds = [], page = 1, limit = 20 }: { sectorIds?: any[]; page?: number; limit?: number } = {}
+) {
   const contacts = await this.model().db.model('Contact').find({ licensee: licenseeId }).select('_id').lean()
   const contactIds = contacts.map((c: any) => c._id)
-  const filter: any = { contact: { $in: contactIds } }
-  if (status) {
-    filter.status = status
-  } else {
-    filter.closed = false
+
+  const filter: any = { contact: { $in: contactIds }, closed: false }
+
+  if (sectorIds.length > 0) {
+    filter.sector = { $in: sectorIds }
   }
+
   return this.model()
     .find(filter)
     .sort({ updatedAt: -1 })
@@ -83,140 +94,164 @@ async findForLicensee(licenseeId: any, { status, page = 1, limit = 20 }: { statu
 }
 ```
 
-This pattern mirrors the contact lookup in `DashboardController.openRooms`.
+When `sectorIds` is empty the sector filter is omitted — all open rooms for the licensee are returned (admin/super or agents not assigned to any sector).
 
 ### Step 2: Create `RoomsController`
 
-Create `src/app/controllers/RoomsController.ts`:
+Create `src/app/controllers/RoomsController.ts` with three actions:
 
+**`index`** — `GET /resources/rooms`:
 ```ts
-class RoomsController {
-  userRepository: any
-  roomRepository: any
-  messageRepository: any
+async index(req, res) {
+  const user = await this.userRepository.findFirst({ _id: req.userId }, ['licensee'])
+  if (!user) return res.status(404).json({ message: 'Usuário não encontrado.' })
 
-  constructor({ userRepository, roomRepository, messageRepository }: Record<string, any> = {}) {
-    this.userRepository = userRepository
-    this.roomRepository = roomRepository
-    this.messageRepository = messageRepository
-    this.index = this.index.bind(this)
-    this.messages = this.messages.bind(this)
-  }
+  const licenseeId = user.role === 'super'
+    ? (req.query.licensee ?? null)
+    : (user.licensee?._id ?? user.licensee)
 
-  async index(req: any, res: any) {
-    try {
-      const user = await this.userRepository.findFirst({ _id: req.userId }, ['licensee'])
-      if (!user) return res.status(404).json({ message: 'Usuário não encontrado.' })
+  if (!licenseeId) return res.status(400).json({ message: 'Licenciado não identificado.' })
 
-      const licenseeId = user.role === 'super'
-        ? (req.query.licensee ?? null)
-        : user.licensee?._id ?? user.licensee
+  // Resolve agent's sectors
+  const agentSectors = await this.sectorRepository
+    .model()
+    .find({ users: req.userId, licensee: licenseeId, active: true })
+    .select('_id')
+    .lean()
+  const sectorIds = agentSectors.map((s: any) => s._id)
 
-      if (!licenseeId) return res.status(400).json({ message: 'Licenciado não identificado.' })
+  const page = Math.max(1, parseInt(req.query.page as string) || 1)
+  const limit = 20
 
-      const page = Math.max(1, parseInt(req.query.page as string) || 1)
-      const limit = 20
+  const roomResults = await this.roomRepository.findForLicensee(licenseeId, { sectorIds, page, limit })
+  const hasMore = roomResults.length > limit
+  const rooms = hasMore ? roomResults.slice(0, limit) : roomResults
 
-      const roomResults = await this.roomRepository.findForLicensee(licenseeId, { page, limit })
-      const hasMore = roomResults.length > limit
-      const rooms = hasMore ? roomResults.slice(0, limit) : roomResults
+  // Attach last message
+  const roomIds = rooms.map((r: any) => r._id)
+  const lastMessages = await this.messageRepository.model().aggregate([
+    { $match: { room: { $in: roomIds } } },
+    { $sort: { createdAt: -1 } },
+    { $group: { _id: '$room', text: { $first: '$text' }, kind: { $first: '$kind' }, createdAt: { $first: '$createdAt' } } },
+  ])
+  const lastMsgMap: Record<string, any> = {}
+  for (const m of lastMessages) lastMsgMap[m._id.toString()] = m
+  const roomsWithLast = rooms.map((r: any) => ({ ...r, lastMessage: lastMsgMap[r._id.toString()] || null }))
 
-      // Attach last message to each room
-      const roomIds = rooms.map((r: any) => r._id)
-      const lastMessages = await this.messageRepository.model().aggregate([
-        { $match: { room: { $in: roomIds } } },
-        { $sort: { createdAt: -1 } },
-        { $group: { _id: '$room', text: { $first: '$text' }, kind: { $first: '$kind' }, createdAt: { $first: '$createdAt' } } },
-      ])
-      const lastMsgMap: Record<string, any> = {}
-      for (const m of lastMessages) lastMsgMap[m._id.toString()] = m
-      const roomsWithLast = rooms.map((r: any) => ({ ...r, lastMessage: lastMsgMap[r._id.toString()] || null }))
-
-      return res.status(200).json({ rooms: roomsWithLast, hasMore })
-    } catch (err: any) {
-      return res.status(500).json({ message: `Erro interno do servidor: ${err.message}` })
-    }
-  }
-
-  async messages(req: any, res: any) {
-    try {
-      const user = await this.userRepository.findFirst({ _id: req.userId }, ['licensee'])
-      if (!user) return res.status(404).json({ message: 'Usuário não encontrado.' })
-
-      const room = await this.roomRepository.findFirst({ _id: req.params.roomId }, ['contact'])
-      if (!room) return res.status(404).json({ message: 'Conversa não encontrada.' })
-
-      // Authorization: room's contact must belong to the user's licensee
-      const userLicenseeId = user.role === 'super' ? null : (user.licensee?._id ?? user.licensee)?.toString()
-      const roomLicenseeId = room.contact?.licensee?.toString()
-      if (userLicenseeId && roomLicenseeId && userLicenseeId !== roomLicenseeId) {
-        return res.status(403).json({ message: 'Acesso negado.' })
-      }
-
-      const page = Math.max(1, parseInt(req.query.page as string) || 1)
-      const limit = 30
-
-      const total = await this.messageRepository.model().countDocuments({ room: room._id })
-      const messages = await this.messageRepository.model()
-        .find({ room: room._id })
-        .sort({ createdAt: 1 })
-        .skip((page - 1) * limit)
-        .limit(limit)
-        .lean()
-
-      return res.status(200).json({ messages, total, page, hasMore: page * limit < total })
-    } catch (err: any) {
-      return res.status(500).json({ message: `Erro interno do servidor: ${err.message}` })
-    }
-  }
+  return res.status(200).json({ rooms: roomsWithLast, hasMore })
 }
-
-export { RoomsController }
 ```
+
+**`create`** — `POST /resources/rooms`:
+```ts
+async create(req, res) {
+  const user = await this.userRepository.findFirst({ _id: req.userId }, ['licensee'])
+  if (!user) return res.status(404).json({ message: 'Usuário não encontrado.' })
+
+  const licenseeId = (user.licensee?._id ?? user.licensee)?.toString()
+
+  const contact = await this.contactRepository.findFirst({ _id: req.body.contactId })
+  if (!contact) return res.status(404).json({ message: 'Contato não encontrado.' })
+  if (contact.licensee?.toString() !== licenseeId && user.role !== 'super') {
+    return res.status(403).json({ message: 'Acesso negado.' })
+  }
+
+  // Return existing open room if one exists
+  const existing = await this.roomRepository.findOpenForContact(contact._id)
+  if (existing) return res.status(200).json({ room: existing })
+
+  const room = await this.roomRepository.create({
+    contact: contact._id,
+    status: 'pending',
+  })
+  return res.status(201).json({ room })
+}
+```
+
+**`messages`** — `GET /resources/rooms/:roomId/messages`:
+```ts
+async messages(req, res) {
+  const user = await this.userRepository.findFirst({ _id: req.userId }, ['licensee'])
+  if (!user) return res.status(404).json({ message: 'Usuário não encontrado.' })
+
+  const room = await this.roomRepository.findFirst({ _id: req.params.roomId }, ['contact'])
+  if (!room) return res.status(404).json({ message: 'Conversa não encontrada.' })
+
+  const userLicenseeId = user.role === 'super' ? null : (user.licensee?._id ?? user.licensee)?.toString()
+  const roomLicenseeId = room.contact?.licensee?.toString()
+  if (userLicenseeId && roomLicenseeId && userLicenseeId !== roomLicenseeId) {
+    return res.status(403).json({ message: 'Acesso negado.' })
+  }
+
+  const page = Math.max(1, parseInt(req.query.page as string) || 1)
+  const limit = 30
+  const total = await this.messageRepository.model().countDocuments({ room: room._id })
+  const messages = await this.messageRepository.model()
+    .find({ room: room._id })
+    .sort({ createdAt: 1 })
+    .skip((page - 1) * limit)
+    .limit(limit)
+    .lean()
+
+  return res.status(200).json({ messages, total, page, hasMore: page * limit < total })
+}
+```
+
+Constructor must inject `sectorRepository` and `contactRepository` in addition to user/room/message repos.
 
 ### Step 3: Wire routes in `resources-routes.ts`
 
-In `src/app/routes/resources-routes.ts`:
-
-1. Import `RoomsController`:
-```ts
-import { RoomsController } from '../controllers/RoomsController'
-```
-
-2. In the composition root (after `createRuntimeDependencies()`):
-```ts
-const roomsController = new RoomsController({ userRepository, roomRepository, messageRepository })
-```
-
-3. Add routes (after existing router registrations, before `export default router`):
+1. Import `RoomsController`.
+2. In the composition root: `const roomsController = new RoomsController({ userRepository, roomRepository, messageRepository, sectorRepository, contactRepository })`
+3. Add routes:
 ```ts
 router.get('/rooms', roomsController.index)
+router.post('/rooms', roomsController.create)
 router.get('/rooms/:roomId/messages', roomsController.messages)
 ```
 
 ### Step 4: Write `RoomsController.spec.ts`
 
-Follow the pattern of existing controller specs (e.g., `DashboardController.spec.ts` or `MessagesController.spec.ts`). Use the Memory repository variants.
+Follow the pattern of existing controller specs (e.g., `DashboardController.spec.ts`). Use Memory repository variants.
 
-Tests to write:
-- `index` — returns rooms for user's licensee; super can filter by `?licensee=`; 400 when super provides no licensee; 404 for unknown user
-- `index` — pagination: `hasMore: true` when > 20 rooms exist
-- `messages` — returns messages sorted by `createdAt` asc for valid room; 403 when user's licensee doesn't match room's contact licensee; 404 for unknown room
+**`index` tests:**
+- Returns rooms for user's licensee (happy path)
+- Returns only rooms in agent's sectors when agent belongs to sectors
+- Returns all rooms when agent has no sectors (not sector-restricted)
+- Super can filter by `?licensee=`
+- Returns 400 when super provides no `?licensee=`
+- Returns 404 for unknown user
+- `hasMore: true` when > 20 rooms exist
+
+**`create` tests:**
+- Creates and returns a new room for a valid contact
+- Returns the existing open room (HTTP 200) when one already exists for the contact
+- Returns 404 when contact not found
+- Returns 403 when contact belongs to a different licensee
+- Returns 404 when user not found
+
+**`messages` tests:**
+- Returns paginated messages sorted by `createdAt asc` for a valid room
+- Returns 403 when user's licensee doesn't match room's contact licensee
+- Returns 404 when room not found
+- `hasMore` reflects pagination correctly
 
 ## Testing
 
-- [ ] `RoomsController.spec.ts` covers: index (happy path, super filter, no-licensee 400, pagination), messages (happy path, 403 cross-licensee, 404 unknown room)
+- [ ] `RoomsController.spec.ts` covers all cases listed above (12+ test cases)
+- [ ] `findForLicensee` sector filtering is exercised via controller spec (agent with sectors vs. without)
 - [ ] Existing backend tests still pass: `npx jest`
 - [ ] `npx eslint .` produces no new errors
 
 ## Documentation / KB Updates
 
-- [ ] No KB/doc updates required — this follows the established controller pattern. If the pattern diverges significantly, run `document-solution` after completion.
+- [ ] No KB/doc updates required for this task — follows established controller pattern.
 
 ## Completion Criteria
 
-- [ ] `GET /resources/rooms` returns open rooms with populated contact + lastMessage
-- [ ] `GET /resources/rooms/:roomId/messages` returns paginated message list; 403 on cross-licensee access
+- [ ] `GET /resources/rooms` returns sector-filtered rooms with last message
+- [ ] `POST /resources/rooms` creates a room or returns existing open room; 403 on cross-licensee contact
+- [ ] `GET /resources/rooms/:roomId/messages` returns paginated messages; 403 on cross-licensee room
 - [ ] All new and existing backend tests pass
 - [ ] Lint clean
 - [ ] Status updated to `complete` in `status.md`
@@ -224,4 +259,4 @@ Tests to write:
 
 ## Conflict Avoidance Notes
 
-No sibling tasks in Phase 1.
+Parallel task in Phase 1: `phase-1/task-02-localchat-sector` owns `src/app/plugins/chats/LocalChat.ts` — do not touch that file.

--- a/.plans/local-chat-ui/phase-1/task-02-localchat-sector/status.md
+++ b/.plans/local-chat-ui/phase-1/task-02-localchat-sector/status.md
@@ -1,0 +1,25 @@
+# Status: LocalChat — assign sector to new rooms
+
+**Current Status**: not-started
+**Last Updated**: 2026-06-16
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-06-16 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/local-chat-ui/phase-1/task-02-localchat-sector/task.md
+++ b/.plans/local-chat-ui/phase-1/task-02-localchat-sector/task.md
@@ -1,0 +1,114 @@
+# Task: LocalChat — assign sector to new rooms
+
+**Plan**: Local Chat UI
+**Phase**: 1
+**Task ID (phase-local)**: task-02
+**Task Path**: phase-1/task-02-localchat-sector
+**Depends On**: None
+**JIRA**: N/A
+
+## Objective
+
+Fix `LocalChat.sendMessage` to pass `message.sector` when creating a new room, so that sector-aware room filtering (task-01) has correct data to work with.
+
+## Context
+
+`LocalChat.sendMessage` creates a room when no open room exists for the contact:
+
+```ts
+room = await this._roomRepository.create({
+  contact: message.contact._id,
+  status: 'pending',
+  // sector missing — always null today
+})
+```
+
+The `Room` model already has a `sector (ref Sector, nullable)` field (added in `local-chat-infra`).
+
+The message being processed already carries a `sector` field when it arrived via a sector-specific webhook (implemented in `setores-webhook-providers`). The `findFirst` call that loads the message only populates `contact` — `sector` is an ObjectId on the message document and doesn't need population for this use.
+
+The fix is one line: pass `sector: message.sector ?? null` in the `create` call.
+
+The `findOpenForContact` used to check for existing rooms does NOT filter by sector — this is intentional. A contact can only have one open room at a time regardless of sector; if they switch sectors between sessions, the new room will carry the new sector.
+
+**Key files:**
+- `src/app/plugins/chats/LocalChat.ts` — the fix lives here
+- `src/app/plugins/chats/LocalChat.spec.ts` — add a test case
+
+## Before You Start
+
+- [ ] `git switch main && git pull --rebase origin main`
+- [ ] Verify `status.md` shows `not-started`
+- [ ] Read `src/app/plugins/chats/LocalChat.ts` in full
+- [ ] Read `src/app/plugins/chats/LocalChat.spec.ts` to understand existing test patterns
+- [ ] Read `src/app/models/Room.ts` to confirm `sector` field exists
+- [ ] Mark this task `in-progress` in `status.md`
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/app/plugins/chats/LocalChat.ts` | modify | Pass sector when creating room |
+| `src/app/plugins/chats/LocalChat.spec.ts` | modify | Add sector-propagation test case |
+
+### Do NOT Modify
+
+- `src/app/repositories/room.ts` — owned by phase-1/task-01-rooms-api
+- `src/app/routes/resources-routes.ts` — owned by phase-1/task-01-rooms-api
+- `src/app/models/Room.ts` — schema is stable; read-only
+
+## Implementation Steps
+
+### Step 1: Fix `LocalChat.sendMessage`
+
+In `src/app/plugins/chats/LocalChat.ts`, update the room creation block:
+
+```ts
+if (!room) {
+  room = await this._roomRepository.create({
+    contact: message.contact._id,
+    status: 'pending',
+    sector: message.sector ?? null,
+  })
+}
+```
+
+No other changes needed. The `message` object already has `sector` as an ObjectId or null (it is a raw field on the document, not a populated relation — no extra populate call required).
+
+### Step 2: Update `LocalChat.spec.ts`
+
+Add two test cases to the `sendMessage` describe block:
+
+**"creates a room with the message's sector when no open room exists"**
+- Setup: message with a `sector` ObjectId, no existing open room
+- Assert: `roomRepository.create` is called with `sector` equal to the message's sector
+
+**"creates a room with sector null when message has no sector"**
+- Setup: message without `sector`, no existing open room
+- Assert: `roomRepository.create` is called with `sector: null`
+
+The existing test patterns in `LocalChat.spec.ts` use the Memory repository variants — follow the same approach.
+
+## Testing
+
+- [ ] New `sendMessage` specs pass (sector propagated / sector null)
+- [ ] All existing `LocalChat.spec.ts` tests still pass
+- [ ] `npx jest` — all backend tests pass
+- [ ] `npx eslint .` — no new errors
+
+## Documentation / KB Updates
+
+- [ ] No KB/doc updates required — the change is a one-line bugfix with a targeted spec.
+
+## Completion Criteria
+
+- [ ] `LocalChat.sendMessage` passes `sector` (or `null`) when creating a new room
+- [ ] Two new test cases cover the sector propagation behaviour
+- [ ] All backend tests pass
+- [ ] Lint clean
+- [ ] Status updated to `complete` in `status.md`
+- [ ] Changes committed to `plan/local-chat-ui/phase-1/task-02-localchat-sector`
+
+## Conflict Avoidance Notes
+
+Parallel task in Phase 1: `phase-1/task-01-rooms-api` owns `src/app/repositories/room.ts` and `src/app/routes/resources-routes.ts` — do not touch those files.

--- a/.plans/local-chat-ui/phase-2/task-02-chat-page/status.md
+++ b/.plans/local-chat-ui/phase-2/task-02-chat-page/status.md
@@ -1,0 +1,25 @@
+# Status: Chat page UI + routing + navbar
+
+**Current Status**: not-started
+**Last Updated**: 2026-06-15
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-06-15 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/local-chat-ui/phase-2/task-02-chat-page/task.md
+++ b/.plans/local-chat-ui/phase-2/task-02-chat-page/task.md
@@ -1,49 +1,54 @@
-# Task: Chat page UI + routing + navbar
+# Task: Chat page UI + Nova conversa + routing + navbar
 
 **Plan**: Local Chat UI
 **Phase**: 2
-**Task ID (phase-local)**: task-02
-**Task Path**: phase-2/task-02-chat-page
-**Depends On**: phase-1/task-01-rooms-api
+**Task ID (phase-local)**: task-03
+**Task Path**: phase-2/task-03-chat-page
+**Depends On**: phase-1/task-01-rooms-api, phase-1/task-02-localchat-sector
 **JIRA**: N/A
 
 ## Objective
 
-Build the full-screen `/chat` page with a room list sidebar and conversation panel (adapted from whatsapp-web-clone), wire it into the React router, and add a conditional "Chat" link to the navbar.
+Build the full-screen `/chat` page (room list + conversation panel), the "Nova conversa" flow for agent-initiated conversations (contact search → create room → auto-select), wire it into the React router, and add a conditional "Chat" link to the navbar.
 
 ## Context
 
 **Whatsapp-web-clone reference** (`/Users/alan/Developer/pessoal/whatsapp-web-clone/src`):
-- `pages/Chat/index.jsx` — top-level chat layout (sidebar + main panel)
+- `pages/Chat/index.jsx` — top-level layout (sidebar + main panel)
 - `pages/Chat/components/ChatInput.jsx` — message input bar
-- `pages/Chat/components/Convo.jsx` — message list (scrollable)
+- `pages/Chat/components/Convo.jsx` — scrollable message list
 - `pages/Chat/components/Header.jsx` — conversation header
 - `components/Sidebar/index.jsx` — contact list sidebar
-- `components/Sidebar/Contact.jsx` — single contact/room item
+- `components/Sidebar/Contact.jsx` — single list item
 - CSS in `pages/Chat/styles/main.css` and `components/Sidebar/styles/main.css`
 
 **Existing ecomanda patterns:**
-- Pages live at `client/src/pages/{PageName}/index.tsx`; sub-components at `client/src/pages/{PageName}/components/`
-- Services live at `client/src/services/{noun}.ts` and use `api()` from `../services/api`
+- Pages: `client/src/pages/{PageName}/index.tsx`; sub-components in `components/`
+- Services: `client/src/services/{noun}.ts` using `api()` from `../services/api`
 - `AppContext` provides `currentUser` + `activeLicensee`; effective licensee = `activeLicensee ?? currentUser?.licensee`
-- `PrivateRoute` (`client/src/pages/PrivateRoute/index.tsx`) currently always wraps children in `BaseLayout`. Add a `noLayout` prop (default `false`) that skips `BaseLayout` wrapping for the full-screen chat route.
-- `client/src/pages/Navbar/index.tsx` already imports `AppContext`; extend to read `activeLicensee` and show the Chat link when `effectiveLicensee?.chatDefault === 'local'`
+- Existing reusable component: `client/src/components/SelectContactsWithFilter/index.tsx` — use for the Nova conversa contact search
+- `PrivateRoute` wraps children in `BaseLayout`; add `noLayout` prop to skip that for the full-screen route
 
-**API endpoints available after task-01:**
-- `GET /resources/rooms?page=1` — `{ rooms: [...], hasMore: bool }`
-- `GET /resources/rooms/:roomId/messages?page=1` — `{ messages: [...], total, page, hasMore }`
-- `POST /v1/chat/rooms/:roomId/messages` body `{ text }` — send agent reply
+**API endpoints from task-01:**
+- `GET /resources/rooms?page=1` → `{ rooms: [...], hasMore }`
+- `POST /resources/rooms` body `{ contactId }` → `{ room }` (or existing open room)
+- `GET /resources/rooms/:roomId/messages?page=1` → `{ messages, total, page, hasMore }`
+- `POST /v1/chat/rooms/:roomId/messages` body `{ text }` → send agent reply (already exists)
 
-**Auth headers:** all requests use `x-access-token` header (see `client/src/services/api.ts` for the axios instance).
+**Navbar condition:** `effectiveLicensee?.chatDefault === 'local'`
+
+The Navbar already has `useContext(AppContext)` pulling `resetLicenseeModal` — extend to also pull `activeLicensee`.
 
 ## Before You Start
 
 - [ ] `git switch main && git pull --rebase origin main`
 - [ ] Verify `phase-1/task-01-rooms-api/status.md` shows `complete`
-- [ ] Read `client/src/pages/PrivateRoute/index.tsx` — current implementation
-- [ ] Read `client/src/pages/Navbar/index.tsx` — current navbar structure
-- [ ] Read `client/src/pages/routes.tsx` — current route list
-- [ ] Skim `/Users/alan/Developer/pessoal/whatsapp-web-clone/src/pages/Chat/` — identify which components to adapt
+- [ ] Verify `phase-1/task-02-localchat-sector/status.md` shows `complete`
+- [ ] Read `client/src/pages/PrivateRoute/index.tsx`
+- [ ] Read `client/src/pages/Navbar/index.tsx`
+- [ ] Read `client/src/pages/routes.tsx`
+- [ ] Read `client/src/components/SelectContactsWithFilter/index.tsx` — understand its `onChange` prop
+- [ ] Skim `/Users/alan/Developer/pessoal/whatsapp-web-clone/src/pages/Chat/` — identify components to adapt
 - [ ] Mark this task `in-progress` in `status.md`
 
 ## File Ownership
@@ -53,10 +58,7 @@ Build the full-screen `/chat` page with a room list sidebar and conversation pan
 | `client/src/pages/PrivateRoute/index.tsx` | modify | Add `noLayout` prop |
 | `client/src/pages/routes.tsx` | modify | Add `/chat` route |
 | `client/src/pages/Navbar/index.tsx` | modify | Add conditional Chat link |
-| `client/src/pages/PrivateRoute/index.tsx` | modify | Add `noLayout` prop |
-| `client/src/pages/routes.tsx` | modify | Add `/chat` route |
-| `client/src/pages/Navbar/index.tsx` | modify | Add conditional Chat link |
-| `client/src/pages/Chat/index.tsx` | create | Full-screen page entry |
+| `client/src/pages/Chat/index.tsx` | create | Full-screen page entry, state management |
 | `client/src/pages/Chat/components/RoomList.tsx` | create | Left sidebar room list |
 | `client/src/pages/Chat/components/RoomList.spec.tsx` | create | RoomList unit tests |
 | `client/src/pages/Chat/components/RoomItem.tsx` | create | Single room list entry |
@@ -65,15 +67,18 @@ Build the full-screen `/chat` page with a room list sidebar and conversation pan
 | `client/src/pages/Chat/components/ConversationPanel.spec.tsx` | create | ConversationPanel unit tests |
 | `client/src/pages/Chat/components/MessageInput.tsx` | create | Text input + send button |
 | `client/src/pages/Chat/components/MessageInput.spec.tsx` | create | MessageInput unit tests |
+| `client/src/pages/Chat/components/NewConversationModal.tsx` | create | Contact search + POST /rooms |
+| `client/src/pages/Chat/components/NewConversationModal.spec.tsx` | create | Modal unit tests |
 | `client/src/pages/Chat/index.spec.tsx` | create | Integration smoke tests |
 | `client/src/pages/Chat/styles.module.scss` | create | Scoped chat styles |
-| `client/src/services/rooms.ts` | create | API calls for rooms + messages |
-| `client/src/pages/Navbar/index.spec.tsx` | modify | Add Chat link visibility tests |
+| `client/src/services/rooms.ts` | create | getRooms, createRoom, getRoomMessages, sendMessage |
+| `client/src/pages/Navbar/index.spec.tsx` | modify | Chat link visibility tests |
 
 ### Do NOT Modify
 
-- `client/src/contexts/App/index.tsx` — no changes needed; read AppContext via hook
+- `client/src/contexts/App/index.tsx` — no changes needed
 - `client/src/pages/BaseLayout/index.tsx` — unchanged
+- `client/src/components/SelectContactsWithFilter/index.tsx` — reused as-is
 
 ## Implementation Steps
 
@@ -87,15 +92,17 @@ export default function PrivateRoute({ children, redirectTo, noLayout }: any) {
 }
 ```
 
-This is additive only — no existing callers change.
-
 ### Step 2: Create `client/src/services/rooms.ts`
 
-```ts
-import { api } from './api'  // adjust import to match existing auth/api pattern
+Match the `api()` import pattern from an existing service (e.g., `client/src/services/message.ts`).
 
+```ts
 export function getRooms(params: { page?: number; licensee?: string } = {}) {
   return api().get('/resources/rooms', { params })
+}
+
+export function createRoom(contactId: string) {
+  return api().post('/resources/rooms', { contactId })
 }
 
 export function getRoomMessages(roomId: string, params: { page?: number } = {}) {
@@ -107,76 +114,81 @@ export function sendRoomMessage(roomId: string, text: string) {
 }
 ```
 
-Check `client/src/services/message.ts` or another existing service to match the `api()` import pattern exactly.
+### Step 3: Build components
 
-### Step 3: Build `client/src/pages/Chat/` components
-
-**`styles.module.scss`** — all chat styles scoped here. Adapt colors from whatsapp-web-clone's `tokens.css` but use the Bootswatch Flatly palette where possible (primary #2C3E50, accent #18BC9C). Key layout:
+**`styles.module.scss`** — scope all chat styles inside `.chatLayout`. Use the Bootswatch Flatly palette (primary #2C3E50, accent #18BC9C). Core layout:
 ```scss
-.chatLayout {
-  display: flex;
-  height: 100vh;
-  overflow: hidden;
-}
-.sidebar {
-  width: 30%;
-  min-width: 280px;
-  border-right: 1px solid #dee2e6;
-  display: flex;
-  flex-direction: column;
-  overflow-y: auto;
-}
-.conversation {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-}
-.messageList {
-  flex: 1;
-  overflow-y: auto;
-  padding: 1rem;
-}
-.messageFooter {
-  padding: 0.5rem 1rem;
-  border-top: 1px solid #dee2e6;
-}
+.chatLayout { display: flex; height: 100vh; overflow: hidden; }
+.sidebar { width: 30%; min-width: 280px; border-right: 1px solid #dee2e6; display: flex; flex-direction: column; overflow-y: auto; }
+.conversation { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
+.messageList { flex: 1; overflow-y: auto; padding: 1rem; }
+.messageFooter { padding: 0.5rem 1rem; border-top: 1px solid #dee2e6; }
 ```
 
-**`RoomItem.tsx`** — props: `room`, `isSelected`, `onClick`. Renders contact name, number, last message preview, and timestamp. Adapted from `Sidebar/Contact.jsx`.
+**`RoomItem.tsx`** — props: `room`, `isSelected`, `onClick`, `unreadCount`. Adapted from `Sidebar/Contact.jsx`. Renders contact name, number, last message preview, timestamp, and unread badge (`badge bg-success rounded-pill`) when `unreadCount > 0`.
 
-**`RoomList.tsx`** — props: `rooms`, `selectedRoomId`, `onSelect`. Renders a list of `RoomItem`. Shows "Nenhuma conversa." when empty.
+**`RoomList.tsx`** — props: `rooms`, `selectedRoomId`, `onSelect`, `onNewConversation`. Renders list of `RoomItem`. "Nenhuma conversa." empty state. "+" button at the top calling `onNewConversation`.
 
-**`MessageInput.tsx`** — props: `onSend: (text: string) => void`, `disabled`. Controlled text input + "Enviar" button. Clears on submit. Adapted from `ChatInput.jsx`.
+**`MessageInput.tsx`** — props: `onSend: (text: string) => void`, `disabled`. Controlled input + "Enviar" button. Clears on submit. Blocks submit on empty input. Adapted from `ChatInput.jsx`.
 
 **`ConversationPanel.tsx`** — props: `room`, `messages`, `onSend`. Renders:
-- Header: contact name + status badge
-- Scrollable message list (align right = fromMe, align left = from contact)
+- Header: contact name + status badge (`pending` / `open`)
+- Scrollable message list (`fromMe` → right-aligned, inbound → left-aligned)
 - `MessageInput` at the bottom
-- Empty state when no room selected
+- "Selecione uma conversa." empty state when `room` is null
+- Auto-scrolls to latest message when `messages` updates
 
-**`index.tsx`** — main page:
+**`NewConversationModal.tsx`** — props: `show`, `onClose`, `onRoomCreated(room)`. Renders a Bootstrap modal:
+- Uses `SelectContactsWithFilter` for contact search (pass `licensee` from `AppContext`)
+- On contact selection, calls `createRoom(contactId)` from the rooms service
+- On success: calls `onRoomCreated(room)` then closes
+- Shows error toast on failure
+
+**`index.tsx`** — full-screen page:
 ```tsx
 export default function ChatPage() {
   const { currentUser, activeLicensee } = useContext(AppContext)
   const effectiveLicensee = activeLicensee ?? currentUser?.licensee
-  
-  const [rooms, setRooms] = useState([])
-  const [selectedRoom, setSelectedRoom] = useState(null)
-  const [messages, setMessages] = useState([])
+  const effectiveLicenseeId = (effectiveLicensee?._id ?? effectiveLicensee)?.toString()
 
-  // Load rooms on mount
-  useEffect(() => { ... }, [effectiveLicensee])
+  const [rooms, setRooms] = useState<any[]>([])
+  const [selectedRoom, setSelectedRoom] = useState<any>(null)
+  const [messages, setMessages] = useState<any[]>([])
+  const [showNewConvo, setShowNewConvo] = useState(false)
+
+  // Load rooms on mount / licensee change
+  useEffect(() => { /* call getRooms, setRooms */ }, [effectiveLicenseeId])
 
   // Load messages when room changes
-  useEffect(() => { ... }, [selectedRoom])
+  useEffect(() => { /* call getRoomMessages, setMessages */ }, [selectedRoom])
 
-  async function handleSend(text) { ... }
+  function handleRoomSelect(room: any) {
+    setSelectedRoom({ ...room, unreadCount: 0 })
+    setRooms(prev => prev.map(r => r._id === room._id ? { ...r, unreadCount: 0 } : r))
+  }
+
+  async function handleSend(text: string) { /* sendRoomMessage, append to messages */ }
+
+  function handleRoomCreated(room: any) {
+    setRooms(prev => [room, ...prev.filter(r => r._id !== room._id)])
+    handleRoomSelect(room)
+    setShowNewConvo(false)
+  }
 
   return (
     <div className={styles.chatLayout}>
-      <RoomList rooms={rooms} selectedRoomId={selectedRoom?._id} onSelect={handleRoomSelect} />
+      <RoomList
+        rooms={rooms}
+        selectedRoomId={selectedRoom?._id}
+        onSelect={handleRoomSelect}
+        onNewConversation={() => setShowNewConvo(true)}
+      />
       <ConversationPanel room={selectedRoom} messages={messages} onSend={handleSend} />
+      <NewConversationModal
+        show={showNewConvo}
+        onClose={() => setShowNewConvo(false)}
+        onRoomCreated={handleRoomCreated}
+      />
     </div>
   )
 }
@@ -184,11 +196,10 @@ export default function ChatPage() {
 
 ### Step 4: Register the `/chat` route
 
-In `client/src/pages/routes.tsx`, add after the `/messages` route:
+In `client/src/pages/routes.tsx`:
 ```tsx
 import ChatPage from './Chat'
 
-// inside <Routes>:
 <Route
   path='/chat'
   element={
@@ -202,18 +213,9 @@ import ChatPage from './Chat'
 ### Step 5: Add Navbar link
 
 In `client/src/pages/Navbar/index.tsx`:
-
-1. Extend the `useContext(AppContext)` destructure to include `activeLicensee`:
-```tsx
-const { resetLicenseeModal, activeLicensee } = useContext(AppContext)
-```
-
-2. Derive effective licensee at the top of the component:
-```tsx
-const effectiveLicensee = activeLicensee ?? currentUser?.licensee
-```
-
-3. Add Chat link after the "Mensagens" link:
+1. Extend `useContext(AppContext)` to include `activeLicensee`
+2. `const effectiveLicensee = activeLicensee ?? currentUser?.licensee`
+3. After the "Mensagens" link:
 ```tsx
 {effectiveLicensee?.chatDefault === 'local' && (
   <li className='nav-item'>
@@ -224,70 +226,80 @@ const effectiveLicensee = activeLicensee ?? currentUser?.licensee
 
 ### Step 6: Write tests
 
-Write one spec file per component. Follow the pattern in existing specs (e.g., `client/src/pages/Licensees/scenes/Form/panels/ChatPanel.spec.tsx`): use `@testing-library/react`, `vi.mock` for services, `render` + `screen` + `fireEvent`.
-
 **`RoomItem.spec.tsx`**:
 - Renders contact name and number
 - Renders last message text and timestamp when present
-- Renders unread badge when `unreadCount > 0`
+- Renders unread badge when `unreadCount > 0`; badge hidden when 0
 - Calls `onClick` when clicked
 
 **`RoomList.spec.tsx`**:
-- Renders all rooms passed as props
+- Renders all room items
 - Shows "Nenhuma conversa." when `rooms` is empty
 - Passes `isSelected=true` only to the selected room
+- "+" button calls `onNewConversation`
 
 **`MessageInput.spec.tsx`**:
-- Renders the text input and send button
-- Calls `onSend` with the current input value on button click
-- Clears the input after send
-- Send button is disabled when `disabled` prop is true
+- Calls `onSend` with input value on button click
+- Clears input after send
+- Send button disabled when `disabled` prop is true
 - Does NOT call `onSend` on empty input
 
 **`ConversationPanel.spec.tsx`**:
-- Renders "Selecione uma conversa" empty state when `room` is null
-- Renders contact name in the header when a room is provided
-- Renders all messages — `fromMe` messages aligned right, inbound messages aligned left
-- Delegates send to `MessageInput` (fires `onSend` callback)
+- Shows "Selecione uma conversa." when `room` is null
+- Renders contact name in header when room is provided
+- `fromMe` messages are present in the DOM
+- Inbound messages are present in the DOM
+- Delegates send to `onSend` callback
 
-**`client/src/pages/Chat/index.spec.tsx`** — integration smoke tests (mock `client/src/services/rooms.ts` with `vi.mock`):
+**`NewConversationModal.spec.tsx`**:
+- Modal is not visible when `show` is false
+- Modal is visible when `show` is true
+- Calls `createRoom` when a contact is selected
+- Calls `onRoomCreated` with the returned room on success
+- Calls `onClose` after successful room creation
+- Shows an error when `createRoom` rejects
+
+**`Chat/index.spec.tsx`** — mock `client/src/services/rooms.ts` with `vi.mock`:
 - Calls `getRooms` on mount
 - Renders rooms returned by `getRooms`
 - Clicking a room calls `getRoomMessages` with that roomId
 - Messages from `getRoomMessages` render in the conversation panel
 - Submitting the input calls `sendRoomMessage` with roomId + text
+- `handleRoomCreated` prepends the new room and auto-selects it
 
-**`client/src/pages/Navbar/index.spec.tsx`** — add to existing spec:
-- "Chat" link is NOT rendered when `effectiveLicensee.chatDefault` is not `'local'`
+**`Navbar/index.spec.tsx`** — add:
+- "Chat" link NOT rendered when `chatDefault` is not `'local'`
 - "Chat" link IS rendered when `effectiveLicensee.chatDefault === 'local'`
-- "Chat" link resolves to `/#/chat`
+- "Chat" link href is `/#/chat`
 
 ## Testing
 
-- [ ] `RoomItem.spec.tsx` — renders name/number/last message/unread badge; fires onClick
-- [ ] `RoomList.spec.tsx` — renders all rooms; empty state; isSelected propagation
-- [ ] `MessageInput.spec.tsx` — calls onSend with text; clears after send; disabled state; blocks empty send
-- [ ] `ConversationPanel.spec.tsx` — empty state; header; fromMe vs inbound alignment; delegates send
-- [ ] `Chat/index.spec.tsx` — getRooms on mount; room click triggers getRoomMessages; send calls sendRoomMessage
-- [ ] `Navbar/index.spec.tsx` — Chat link shown/hidden based on chatDefault; link href is `/#/chat`
+- [ ] `RoomItem.spec.tsx` — renders, unread badge, click handler
+- [ ] `RoomList.spec.tsx` — renders, empty state, selected state, new conversation button
+- [ ] `MessageInput.spec.tsx` — send, clear, disabled, empty-input guard
+- [ ] `ConversationPanel.spec.tsx` — empty state, header, message alignment, send delegation
+- [ ] `NewConversationModal.spec.tsx` — visibility, createRoom call, onRoomCreated, onClose, error
+- [ ] `Chat/index.spec.tsx` — getRooms on mount, room click, send, new room prepend
+- [ ] `Navbar/index.spec.tsx` — Chat link shown/hidden, href correct
 - [ ] `npx vitest run` inside `client/` — all existing tests still pass
-- [ ] Manual: run `yarn run dev`, navigate to `/#/chat`, verify full-screen layout renders
+- [ ] Manual: `yarn run dev` → navigate to `/#/chat`, verify full-screen layout, test Nova conversa flow
 
 ## Documentation / KB Updates
 
-- [ ] No new KB doc required — pattern follows existing page conventions. If the full-screen layout pattern is reused later, run `document-solution` then.
+- [ ] No new KB doc required for this task.
 
 ## Completion Criteria
 
 - [ ] `/chat` route renders full-screen chat layout when authenticated
 - [ ] Navbar shows "Chat" link only when `effectiveLicensee.chatDefault === 'local'`
-- [ ] Room list loads from `GET /resources/rooms`
-- [ ] Selecting a room loads messages from `GET /resources/rooms/:roomId/messages`
+- [ ] Room list loads and displays open rooms with last message
+- [ ] Selecting a room loads its message history
 - [ ] Sending a message calls `POST /v1/chat/rooms/:roomId/messages`
+- [ ] "Nova conversa" opens contact search, creates a room via `POST /resources/rooms`, auto-selects it
 - [ ] All frontend tests pass
 - [ ] Lint clean
 - [ ] Status updated to `complete` in `status.md`
-- [ ] Changes committed to `plan/local-chat-ui/phase-2/task-02-chat-page`
+- [ ] Changes committed to `plan/local-chat-ui/phase-2/task-03-chat-page`
 
 ## Conflict Avoidance Notes
 

--- a/.plans/local-chat-ui/phase-2/task-02-chat-page/task.md
+++ b/.plans/local-chat-ui/phase-2/task-02-chat-page/task.md
@@ -53,14 +53,21 @@ Build the full-screen `/chat` page with a room list sidebar and conversation pan
 | `client/src/pages/PrivateRoute/index.tsx` | modify | Add `noLayout` prop |
 | `client/src/pages/routes.tsx` | modify | Add `/chat` route |
 | `client/src/pages/Navbar/index.tsx` | modify | Add conditional Chat link |
+| `client/src/pages/PrivateRoute/index.tsx` | modify | Add `noLayout` prop |
+| `client/src/pages/routes.tsx` | modify | Add `/chat` route |
+| `client/src/pages/Navbar/index.tsx` | modify | Add conditional Chat link |
 | `client/src/pages/Chat/index.tsx` | create | Full-screen page entry |
 | `client/src/pages/Chat/components/RoomList.tsx` | create | Left sidebar room list |
+| `client/src/pages/Chat/components/RoomList.spec.tsx` | create | RoomList unit tests |
 | `client/src/pages/Chat/components/RoomItem.tsx` | create | Single room list entry |
+| `client/src/pages/Chat/components/RoomItem.spec.tsx` | create | RoomItem unit tests |
 | `client/src/pages/Chat/components/ConversationPanel.tsx` | create | Right panel: messages + input |
+| `client/src/pages/Chat/components/ConversationPanel.spec.tsx` | create | ConversationPanel unit tests |
 | `client/src/pages/Chat/components/MessageInput.tsx` | create | Text input + send button |
+| `client/src/pages/Chat/components/MessageInput.spec.tsx` | create | MessageInput unit tests |
+| `client/src/pages/Chat/index.spec.tsx` | create | Integration smoke tests |
 | `client/src/pages/Chat/styles.module.scss` | create | Scoped chat styles |
 | `client/src/services/rooms.ts` | create | API calls for rooms + messages |
-| `client/src/pages/Chat/index.spec.tsx` | create | Smoke tests |
 | `client/src/pages/Navbar/index.spec.tsx` | modify | Add Chat link visibility tests |
 
 ### Do NOT Modify
@@ -217,23 +224,54 @@ const effectiveLicensee = activeLicensee ?? currentUser?.licensee
 
 ### Step 6: Write tests
 
-**`client/src/pages/Chat/index.spec.tsx`** — smoke tests:
-- Renders the room list sidebar
-- Clicking a room item loads messages
-- Submitting the input calls `sendRoomMessage`
+Write one spec file per component. Follow the pattern in existing specs (e.g., `client/src/pages/Licensees/scenes/Form/panels/ChatPanel.spec.tsx`): use `@testing-library/react`, `vi.mock` for services, `render` + `screen` + `fireEvent`.
 
-Mock `client/src/services/rooms.ts` using `vi.mock`.
+**`RoomItem.spec.tsx`**:
+- Renders contact name and number
+- Renders last message text and timestamp when present
+- Renders unread badge when `unreadCount > 0`
+- Calls `onClick` when clicked
 
-**`client/src/pages/Navbar/index.spec.tsx`** — add:
-- "Chat" link NOT rendered when `chatDefault` is not `'local'`
+**`RoomList.spec.tsx`**:
+- Renders all rooms passed as props
+- Shows "Nenhuma conversa." when `rooms` is empty
+- Passes `isSelected=true` only to the selected room
+
+**`MessageInput.spec.tsx`**:
+- Renders the text input and send button
+- Calls `onSend` with the current input value on button click
+- Clears the input after send
+- Send button is disabled when `disabled` prop is true
+- Does NOT call `onSend` on empty input
+
+**`ConversationPanel.spec.tsx`**:
+- Renders "Selecione uma conversa" empty state when `room` is null
+- Renders contact name in the header when a room is provided
+- Renders all messages — `fromMe` messages aligned right, inbound messages aligned left
+- Delegates send to `MessageInput` (fires `onSend` callback)
+
+**`client/src/pages/Chat/index.spec.tsx`** — integration smoke tests (mock `client/src/services/rooms.ts` with `vi.mock`):
+- Calls `getRooms` on mount
+- Renders rooms returned by `getRooms`
+- Clicking a room calls `getRoomMessages` with that roomId
+- Messages from `getRoomMessages` render in the conversation panel
+- Submitting the input calls `sendRoomMessage` with roomId + text
+
+**`client/src/pages/Navbar/index.spec.tsx`** — add to existing spec:
+- "Chat" link is NOT rendered when `effectiveLicensee.chatDefault` is not `'local'`
 - "Chat" link IS rendered when `effectiveLicensee.chatDefault === 'local'`
+- "Chat" link resolves to `/#/chat`
 
 ## Testing
 
+- [ ] `RoomItem.spec.tsx` — renders name/number/last message/unread badge; fires onClick
+- [ ] `RoomList.spec.tsx` — renders all rooms; empty state; isSelected propagation
+- [ ] `MessageInput.spec.tsx` — calls onSend with text; clears after send; disabled state; blocks empty send
+- [ ] `ConversationPanel.spec.tsx` — empty state; header; fromMe vs inbound alignment; delegates send
+- [ ] `Chat/index.spec.tsx` — getRooms on mount; room click triggers getRoomMessages; send calls sendRoomMessage
+- [ ] `Navbar/index.spec.tsx` — Chat link shown/hidden based on chatDefault; link href is `/#/chat`
 - [ ] `npx vitest run` inside `client/` — all existing tests still pass
-- [ ] New Chat page spec passes: rooms render, room selection triggers message fetch, send calls API
-- [ ] Navbar spec covers: Chat link shown/hidden based on `chatDefault`
-- [ ] Manual: run `yarn run dev` and navigate to `/#/chat` — full-screen layout renders correctly
+- [ ] Manual: run `yarn run dev`, navigate to `/#/chat`, verify full-screen layout renders
 
 ## Documentation / KB Updates
 

--- a/.plans/local-chat-ui/phase-2/task-02-chat-page/task.md
+++ b/.plans/local-chat-ui/phase-2/task-02-chat-page/task.md
@@ -1,0 +1,256 @@
+# Task: Chat page UI + routing + navbar
+
+**Plan**: Local Chat UI
+**Phase**: 2
+**Task ID (phase-local)**: task-02
+**Task Path**: phase-2/task-02-chat-page
+**Depends On**: phase-1/task-01-rooms-api
+**JIRA**: N/A
+
+## Objective
+
+Build the full-screen `/chat` page with a room list sidebar and conversation panel (adapted from whatsapp-web-clone), wire it into the React router, and add a conditional "Chat" link to the navbar.
+
+## Context
+
+**Whatsapp-web-clone reference** (`/Users/alan/Developer/pessoal/whatsapp-web-clone/src`):
+- `pages/Chat/index.jsx` — top-level chat layout (sidebar + main panel)
+- `pages/Chat/components/ChatInput.jsx` — message input bar
+- `pages/Chat/components/Convo.jsx` — message list (scrollable)
+- `pages/Chat/components/Header.jsx` — conversation header
+- `components/Sidebar/index.jsx` — contact list sidebar
+- `components/Sidebar/Contact.jsx` — single contact/room item
+- CSS in `pages/Chat/styles/main.css` and `components/Sidebar/styles/main.css`
+
+**Existing ecomanda patterns:**
+- Pages live at `client/src/pages/{PageName}/index.tsx`; sub-components at `client/src/pages/{PageName}/components/`
+- Services live at `client/src/services/{noun}.ts` and use `api()` from `../services/api`
+- `AppContext` provides `currentUser` + `activeLicensee`; effective licensee = `activeLicensee ?? currentUser?.licensee`
+- `PrivateRoute` (`client/src/pages/PrivateRoute/index.tsx`) currently always wraps children in `BaseLayout`. Add a `noLayout` prop (default `false`) that skips `BaseLayout` wrapping for the full-screen chat route.
+- `client/src/pages/Navbar/index.tsx` already imports `AppContext`; extend to read `activeLicensee` and show the Chat link when `effectiveLicensee?.chatDefault === 'local'`
+
+**API endpoints available after task-01:**
+- `GET /resources/rooms?page=1` — `{ rooms: [...], hasMore: bool }`
+- `GET /resources/rooms/:roomId/messages?page=1` — `{ messages: [...], total, page, hasMore }`
+- `POST /v1/chat/rooms/:roomId/messages` body `{ text }` — send agent reply
+
+**Auth headers:** all requests use `x-access-token` header (see `client/src/services/api.ts` for the axios instance).
+
+## Before You Start
+
+- [ ] `git switch main && git pull --rebase origin main`
+- [ ] Verify `phase-1/task-01-rooms-api/status.md` shows `complete`
+- [ ] Read `client/src/pages/PrivateRoute/index.tsx` — current implementation
+- [ ] Read `client/src/pages/Navbar/index.tsx` — current navbar structure
+- [ ] Read `client/src/pages/routes.tsx` — current route list
+- [ ] Skim `/Users/alan/Developer/pessoal/whatsapp-web-clone/src/pages/Chat/` — identify which components to adapt
+- [ ] Mark this task `in-progress` in `status.md`
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `client/src/pages/PrivateRoute/index.tsx` | modify | Add `noLayout` prop |
+| `client/src/pages/routes.tsx` | modify | Add `/chat` route |
+| `client/src/pages/Navbar/index.tsx` | modify | Add conditional Chat link |
+| `client/src/pages/Chat/index.tsx` | create | Full-screen page entry |
+| `client/src/pages/Chat/components/RoomList.tsx` | create | Left sidebar room list |
+| `client/src/pages/Chat/components/RoomItem.tsx` | create | Single room list entry |
+| `client/src/pages/Chat/components/ConversationPanel.tsx` | create | Right panel: messages + input |
+| `client/src/pages/Chat/components/MessageInput.tsx` | create | Text input + send button |
+| `client/src/pages/Chat/styles.module.scss` | create | Scoped chat styles |
+| `client/src/services/rooms.ts` | create | API calls for rooms + messages |
+| `client/src/pages/Chat/index.spec.tsx` | create | Smoke tests |
+| `client/src/pages/Navbar/index.spec.tsx` | modify | Add Chat link visibility tests |
+
+### Do NOT Modify
+
+- `client/src/contexts/App/index.tsx` — no changes needed; read AppContext via hook
+- `client/src/pages/BaseLayout/index.tsx` — unchanged
+
+## Implementation Steps
+
+### Step 1: Add `noLayout` prop to `PrivateRoute`
+
+```tsx
+export default function PrivateRoute({ children, redirectTo, noLayout }: any) {
+  if (!isAuthenticated()) return <Navigate to={redirectTo} />
+  if (noLayout) return children
+  return <BaseLayout>{children}</BaseLayout>
+}
+```
+
+This is additive only — no existing callers change.
+
+### Step 2: Create `client/src/services/rooms.ts`
+
+```ts
+import { api } from './api'  // adjust import to match existing auth/api pattern
+
+export function getRooms(params: { page?: number; licensee?: string } = {}) {
+  return api().get('/resources/rooms', { params })
+}
+
+export function getRoomMessages(roomId: string, params: { page?: number } = {}) {
+  return api().get(`/resources/rooms/${roomId}/messages`, { params })
+}
+
+export function sendRoomMessage(roomId: string, text: string) {
+  return api().post(`/v1/chat/rooms/${roomId}/messages`, { text })
+}
+```
+
+Check `client/src/services/message.ts` or another existing service to match the `api()` import pattern exactly.
+
+### Step 3: Build `client/src/pages/Chat/` components
+
+**`styles.module.scss`** — all chat styles scoped here. Adapt colors from whatsapp-web-clone's `tokens.css` but use the Bootswatch Flatly palette where possible (primary #2C3E50, accent #18BC9C). Key layout:
+```scss
+.chatLayout {
+  display: flex;
+  height: 100vh;
+  overflow: hidden;
+}
+.sidebar {
+  width: 30%;
+  min-width: 280px;
+  border-right: 1px solid #dee2e6;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+.conversation {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.messageList {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+}
+.messageFooter {
+  padding: 0.5rem 1rem;
+  border-top: 1px solid #dee2e6;
+}
+```
+
+**`RoomItem.tsx`** — props: `room`, `isSelected`, `onClick`. Renders contact name, number, last message preview, and timestamp. Adapted from `Sidebar/Contact.jsx`.
+
+**`RoomList.tsx`** — props: `rooms`, `selectedRoomId`, `onSelect`. Renders a list of `RoomItem`. Shows "Nenhuma conversa." when empty.
+
+**`MessageInput.tsx`** — props: `onSend: (text: string) => void`, `disabled`. Controlled text input + "Enviar" button. Clears on submit. Adapted from `ChatInput.jsx`.
+
+**`ConversationPanel.tsx`** — props: `room`, `messages`, `onSend`. Renders:
+- Header: contact name + status badge
+- Scrollable message list (align right = fromMe, align left = from contact)
+- `MessageInput` at the bottom
+- Empty state when no room selected
+
+**`index.tsx`** — main page:
+```tsx
+export default function ChatPage() {
+  const { currentUser, activeLicensee } = useContext(AppContext)
+  const effectiveLicensee = activeLicensee ?? currentUser?.licensee
+  
+  const [rooms, setRooms] = useState([])
+  const [selectedRoom, setSelectedRoom] = useState(null)
+  const [messages, setMessages] = useState([])
+
+  // Load rooms on mount
+  useEffect(() => { ... }, [effectiveLicensee])
+
+  // Load messages when room changes
+  useEffect(() => { ... }, [selectedRoom])
+
+  async function handleSend(text) { ... }
+
+  return (
+    <div className={styles.chatLayout}>
+      <RoomList rooms={rooms} selectedRoomId={selectedRoom?._id} onSelect={handleRoomSelect} />
+      <ConversationPanel room={selectedRoom} messages={messages} onSend={handleSend} />
+    </div>
+  )
+}
+```
+
+### Step 4: Register the `/chat` route
+
+In `client/src/pages/routes.tsx`, add after the `/messages` route:
+```tsx
+import ChatPage from './Chat'
+
+// inside <Routes>:
+<Route
+  path='/chat'
+  element={
+    <PrivateRoute redirectTo='/signin' noLayout>
+      <ChatPage />
+    </PrivateRoute>
+  }
+/>
+```
+
+### Step 5: Add Navbar link
+
+In `client/src/pages/Navbar/index.tsx`:
+
+1. Extend the `useContext(AppContext)` destructure to include `activeLicensee`:
+```tsx
+const { resetLicenseeModal, activeLicensee } = useContext(AppContext)
+```
+
+2. Derive effective licensee at the top of the component:
+```tsx
+const effectiveLicensee = activeLicensee ?? currentUser?.licensee
+```
+
+3. Add Chat link after the "Mensagens" link:
+```tsx
+{effectiveLicensee?.chatDefault === 'local' && (
+  <li className='nav-item'>
+    <a className='nav-link' href='/#/chat'>Chat</a>
+  </li>
+)}
+```
+
+### Step 6: Write tests
+
+**`client/src/pages/Chat/index.spec.tsx`** — smoke tests:
+- Renders the room list sidebar
+- Clicking a room item loads messages
+- Submitting the input calls `sendRoomMessage`
+
+Mock `client/src/services/rooms.ts` using `vi.mock`.
+
+**`client/src/pages/Navbar/index.spec.tsx`** — add:
+- "Chat" link NOT rendered when `chatDefault` is not `'local'`
+- "Chat" link IS rendered when `effectiveLicensee.chatDefault === 'local'`
+
+## Testing
+
+- [ ] `npx vitest run` inside `client/` — all existing tests still pass
+- [ ] New Chat page spec passes: rooms render, room selection triggers message fetch, send calls API
+- [ ] Navbar spec covers: Chat link shown/hidden based on `chatDefault`
+- [ ] Manual: run `yarn run dev` and navigate to `/#/chat` — full-screen layout renders correctly
+
+## Documentation / KB Updates
+
+- [ ] No new KB doc required — pattern follows existing page conventions. If the full-screen layout pattern is reused later, run `document-solution` then.
+
+## Completion Criteria
+
+- [ ] `/chat` route renders full-screen chat layout when authenticated
+- [ ] Navbar shows "Chat" link only when `effectiveLicensee.chatDefault === 'local'`
+- [ ] Room list loads from `GET /resources/rooms`
+- [ ] Selecting a room loads messages from `GET /resources/rooms/:roomId/messages`
+- [ ] Sending a message calls `POST /v1/chat/rooms/:roomId/messages`
+- [ ] All frontend tests pass
+- [ ] Lint clean
+- [ ] Status updated to `complete` in `status.md`
+- [ ] Changes committed to `plan/local-chat-ui/phase-2/task-02-chat-page`
+
+## Conflict Avoidance Notes
+
+No sibling tasks in Phase 2.

--- a/.plans/local-chat-ui/phase-3/task-03-socket-realtime/status.md
+++ b/.plans/local-chat-ui/phase-3/task-03-socket-realtime/status.md
@@ -1,0 +1,25 @@
+# Status: Socket.IO real-time integration
+
+**Current Status**: not-started
+**Last Updated**: 2026-06-15
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-06-15 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/local-chat-ui/phase-3/task-03-socket-realtime/task.md
+++ b/.plans/local-chat-ui/phase-3/task-03-socket-realtime/task.md
@@ -1,0 +1,197 @@
+# Task: Socket.IO real-time integration
+
+**Plan**: Local Chat UI
+**Phase**: 3
+**Task ID (phase-local)**: task-03
+**Task Path**: phase-3/task-03-socket-realtime
+**Depends On**: phase-2/task-02-chat-page
+**JIRA**: N/A
+
+## Objective
+
+Wire the existing backend `new-room-message` Socket.IO event to the chat page: add a server-side `join-licensee` handler so clients can subscribe to their licensee's room, then build a `useChatSocket` hook that connects the frontend and updates the conversation in real time.
+
+## Context
+
+**Backend socket setup** (`src/config/http.ts`):
+```ts
+const io = new Server(server)
+io.on('connection', (_) => {})   // currently empty
+setIo(io)
+```
+
+**Existing emit** (`LocalChat.ts`):
+```ts
+emitToLicensee(this.licensee._id, 'new-room-message', {
+  roomId: room._id,
+  messageId: message._id,
+  licenseeId: this.licensee._id,
+})
+// emitToLicensee does: io.to(`licensee:${licenseeId}`).emit(event, data)
+```
+
+So clients must join `licensee:{id}` to receive events. The join happens via a custom `join-licensee` event from the client.
+
+**Frontend socket.io-client** is already installed: `client/package.json` has `"socket.io-client": "4.8.3"`. Server is `"socket.io": "4.8.3"`.
+
+**Security note**: the server currently accepts unauthenticated connections. For this plan, require the JWT token in the Socket.IO handshake (`auth.token`) and validate it server-side before allowing `join-licensee`. This prevents arbitrary clients from joining licensee rooms.
+
+The `new-room-message` payload is `{ roomId, messageId, licenseeId }`. The frontend needs to fetch the full message (or use the existing REST endpoint) and append it to the conversation. The simplest approach: on receiving the event, if `roomId` matches the selected room, call `GET /resources/rooms/:roomId/messages` to reload messages (or fetch only the new message by adding a `GET /resources/messages/:id` endpoint).
+
+**Simpler approach**: reload the last page of messages for the current room when a `new-room-message` event arrives for that room. Alternatively, call the existing rooms messages endpoint. This avoids a new `/messages/:id` endpoint.
+
+**For rooms the agent is NOT currently viewing**: bump an unread count badge on the `RoomItem` in the sidebar.
+
+## Before You Start
+
+- [ ] `git switch main && git pull --rebase origin main`
+- [ ] Verify `phase-2/task-02-chat-page/status.md` shows `complete`
+- [ ] Read `src/config/http.ts` — current socket.io server setup
+- [ ] Read `src/app/services/socketEmitter.ts` — `emitToLicensee` pattern
+- [ ] Read `client/src/pages/Chat/index.tsx` (created in task-02) — understand state structure
+- [ ] Mark this task `in-progress` in `status.md`
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/config/http.ts` | modify | Add `join-licensee` event handler with JWT validation |
+| `client/src/hooks/useChatSocket.ts` | create | Socket.IO hook |
+| `client/src/pages/Chat/index.tsx` | modify | Use `useChatSocket` hook |
+| `client/src/pages/Chat/components/RoomList.tsx` | modify | Accept + display unread count per room |
+| `client/src/pages/Chat/components/RoomItem.tsx` | modify | Render unread badge |
+| `client/src/hooks/useChatSocket.spec.ts` | create | Hook tests |
+
+### Do NOT Modify
+
+- `src/app/services/socketEmitter.ts` — stable; emit side is already correct
+- `src/app/plugins/chats/LocalChat.ts` — stable
+
+## Implementation Steps
+
+### Step 1: Add `join-licensee` handler to `src/config/http.ts`
+
+Add JWT validation on the handshake and a room-join handler:
+
+```ts
+import jwt from 'jsonwebtoken'
+
+const SECRET = process.env.SECRET as string
+
+io.use((socket, next) => {
+  const token = socket.handshake.auth?.token
+  if (!token) return next(new Error('Authentication required'))
+  jwt.verify(token, SECRET, (err: any) => {
+    if (err) return next(new Error('Invalid token'))
+    next()
+  })
+})
+
+io.on('connection', (socket) => {
+  socket.on('join-licensee', (licenseeId: string) => {
+    if (typeof licenseeId === 'string' && licenseeId.match(/^[a-f0-9]{24}$/)) {
+      socket.join(`licensee:${licenseeId}`)
+    }
+  })
+})
+```
+
+The ObjectId format check (`/^[a-f0-9]{24}$/`) prevents joining arbitrary room names.
+
+### Step 2: Create `client/src/hooks/useChatSocket.ts`
+
+```ts
+import { useEffect } from 'react'
+import { io } from 'socket.io-client'
+import { getToken } from '../services/auth'  // adjust import path to match existing pattern
+
+export function useChatSocket(
+  licenseeId: string | undefined,
+  onNewRoomMessage: (data: { roomId: string; messageId: string; licenseeId: string }) => void,
+) {
+  useEffect(() => {
+    if (!licenseeId) return
+
+    const socket = io({ auth: { token: getToken() } })
+    socket.emit('join-licensee', licenseeId)
+    socket.on('new-room-message', onNewRoomMessage)
+
+    return () => {
+      socket.disconnect()
+    }
+  }, [licenseeId]) // eslint-disable-line react-hooks/exhaustive-deps
+}
+```
+
+Check `client/src/services/auth.ts` for the `getToken` export name.
+
+### Step 3: Update `client/src/pages/Chat/index.tsx`
+
+1. Import and call `useChatSocket`:
+```ts
+const effectiveLicenseeId = (activeLicensee?._id ?? currentUser?.licensee?._id)?.toString()
+
+useChatSocket(effectiveLicenseeId, ({ roomId }) => {
+  if (selectedRoom && selectedRoom._id === roomId) {
+    // Reload messages for the active conversation
+    loadMessages(selectedRoom._id)
+  } else {
+    // Bump unread count for that room in the sidebar
+    setRooms(prev =>
+      prev.map(r => r._id === roomId ? { ...r, unreadCount: (r.unreadCount ?? 0) + 1 } : r)
+    )
+  }
+})
+```
+
+2. When a room is selected, clear its `unreadCount`:
+```ts
+function handleRoomSelect(room: any) {
+  setSelectedRoom({ ...room, unreadCount: 0 })
+  setRooms(prev => prev.map(r => r._id === room._id ? { ...r, unreadCount: 0 } : r))
+  loadMessages(room._id)
+}
+```
+
+### Step 4: Update `RoomItem.tsx` for unread badge
+
+Accept `unreadCount` prop; render a badge when > 0:
+```tsx
+{unreadCount > 0 && <span className="badge bg-success rounded-pill">{unreadCount}</span>}
+```
+
+### Step 5: Write `useChatSocket.spec.ts`
+
+Mock `socket.io-client` with `vi.mock`. Tests:
+- Does not connect when `licenseeId` is undefined
+- Connects and emits `join-licensee` when `licenseeId` is provided
+- Calls `onNewRoomMessage` when `new-room-message` is received
+- Disconnects on cleanup (return of useEffect)
+
+## Testing
+
+- [ ] `useChatSocket.spec.ts` passes with mocked socket.io-client
+- [ ] `npx vitest run` inside `client/` — all existing tests still pass
+- [ ] `npx jest` (backend) — all tests still pass
+- [ ] Manual smoke: open `/chat`, open a second browser tab and trigger an inbound message via the v1 webhook endpoint; message appears in real time
+
+## Documentation / KB Updates
+
+- [ ] After completion, run `document-solution` — the Socket.IO join pattern (server-side JWT validation + licensee room) is non-obvious and reusable.
+- [ ] Run `check-kb-index` after the KB doc is added.
+
+## Completion Criteria
+
+- [ ] Server accepts `join-licensee` event only from JWT-authenticated clients; validates ObjectId format
+- [ ] `useChatSocket` hook connects, subscribes, and cleans up correctly
+- [ ] New messages appear in the active conversation without page refresh
+- [ ] Rooms with new messages show an unread count badge in the sidebar
+- [ ] All tests pass (backend + frontend)
+- [ ] Lint clean
+- [ ] `document-solution` run; KB index updated
+- [ ] Status updated to `complete` in `status.md`
+- [ ] Changes committed to `plan/local-chat-ui/phase-3/task-03-socket-realtime`
+
+## Conflict Avoidance Notes
+
+No sibling tasks in Phase 3.

--- a/.plans/local-chat-ui/phase-3/task-03-socket-realtime/task.md
+++ b/.plans/local-chat-ui/phase-3/task-03-socket-realtime/task.md
@@ -2,9 +2,9 @@
 
 **Plan**: Local Chat UI
 **Phase**: 3
-**Task ID (phase-local)**: task-03
-**Task Path**: phase-3/task-03-socket-realtime
-**Depends On**: phase-2/task-02-chat-page
+**Task ID (phase-local)**: task-04
+**Task Path**: phase-3/task-04-socket-realtime
+**Depends On**: phase-2/task-03-chat-page
 **JIRA**: N/A
 
 ## Objective
@@ -45,7 +45,7 @@ The `new-room-message` payload is `{ roomId, messageId, licenseeId }`. The front
 ## Before You Start
 
 - [ ] `git switch main && git pull --rebase origin main`
-- [ ] Verify `phase-2/task-02-chat-page/status.md` shows `complete`
+- [ ] Verify `phase-2/task-03-chat-page/status.md` shows `complete`
 - [ ] Read `src/config/http.ts` — current socket.io server setup
 - [ ] Read `src/app/services/socketEmitter.ts` — `emitToLicensee` pattern
 - [ ] Read `client/src/pages/Chat/index.tsx` (created in task-02) — understand state structure
@@ -190,7 +190,7 @@ Mock `socket.io-client` with `vi.mock`. Tests:
 - [ ] Lint clean
 - [ ] `document-solution` run; KB index updated
 - [ ] Status updated to `complete` in `status.md`
-- [ ] Changes committed to `plan/local-chat-ui/phase-3/task-03-socket-realtime`
+- [ ] Changes committed to `plan/local-chat-ui/phase-3/task-04-socket-realtime`
 
 ## Conflict Avoidance Notes
 


### PR DESCRIPTION
## Plan: Local Chat UI

Full-screen agent chat page at `/chat`, conditionally shown when the active licensee uses `chatDefault: local`. Components adapted from whatsapp-web-clone. Socket.IO real-time updates using the existing `new-room-message` event.

**Type**: Type 1 (Product)
**Phases**: 3  **Tasks**: 3
**PR Strategy**: per-wave
**Assigned Dev**: Alan Costa Facchini

### Phase summary
| Phase | Task | Description |
|-------|------|-------------|
| 1 | task-01-rooms-api | `GET /resources/rooms` + `GET /resources/rooms/:id/messages` — new RoomsController |
| 2 | task-02-chat-page | Full-screen Chat page, PrivateRoute noLayout prop, Navbar link |
| 3 | task-03-socket-realtime | Server-side JWT socket auth + `join-licensee` handler; `useChatSocket` hook |

> Merge this PR before running `/execute-plan local-chat-ui` or any `/execute-task`.