### PR TITLE
plan(chat-widget): Chat Widget

### DIFF
--- a/.plans/README.md
+++ b/.plans/README.md
@@ -24,6 +24,7 @@ Git-native Markdown plans for multi-step work.
 |---|------|--------|--------|-------------|
 | 2 | [MongoDB → PostgreSQL](./mongo-to-postgres/overview.md) | `mongo-to-postgres/` | not-started | Migrate all persistent data from MongoDB/Mongoose to PostgreSQL/Prisma using dual-write strategy; prerequisite: remove-pdv complete |
 | 3 | [Backend Type Narrowing](./type-backend/overview.md) | `type-backend/` | not-started | Replace `any` with interfaces across models, repositories, use cases, controllers, and plugins — 3 phases, 11 tasks |
+| 4 | [Chat Widget](./chat-widget/overview.md) | `chat-widget/` | not-started | Embeddable Intercom-style widget for external sites; React+Vite IIFE bundle, 3 public API endpoints, polling replies, LocalChat integration — 4 phases, 11 tasks |
 
 ---
 

--- a/.plans/chat-widget/overview.md
+++ b/.plans/chat-widget/overview.md
@@ -17,7 +17,9 @@ Build an embeddable chat widget that visitors on external client websites can us
 - Three public backend endpoints (session, send message, poll messages) under `/widget/:apiToken/*`
 - Guard in `SendMessageToMessenger` to skip messenger delivery for web contacts
 - React + Vite widget bundle (IIFE) served as `/widget.js` from Express static
-- Visitor identification via name + email form shown on first open
+- **Mode 1 — Anonymous (landing page)**: visitor fills name + email + optional phone form before chatting
+- **Mode 2 — Authenticated (support)**: host page calls `EcomandaWidget.init({ name, email, phone? })` after login; session is created automatically and the form is skipped
+- `window.EcomandaWidget.init()` buffered API — safe to call before or after the async script loads
 - Reply delivery to widget via polling (GET every 5 seconds)
 
 ### Out of Scope
@@ -26,6 +28,7 @@ Build an embeddable chat widget that visitors on external client websites can us
 - Branding customisation by licensee (colours, logo) — not in this iteration
 - Conversation history across sessions (beyond current open room) — cleared on new session
 - Mobile-specific optimisations for the widget popup
+- Auto-opening the widget when `init()` is called — session is pre-created silently; user must click the button
 
 ## Kill Criteria
 
@@ -91,7 +94,9 @@ Base branch: `main`
 ## Success Criteria
 
 - [ ] Widget loads via `<script src="/widget.js" data-licensee="TOKEN">` on any HTML page
-- [ ] Visitor submits name + email → session persists in localStorage
+- [ ] **Mode 1**: Visitor submits name + email (+ optional phone) → session persists in localStorage, chat opens
+- [ ] **Mode 2**: Calling `EcomandaWidget.init({ name, email, phone? })` after page load skips the form and pre-creates the session silently
+- [ ] Mode 2 is safe to call before or after the widget script finishes loading (buffered)
 - [ ] Visitor sends message → appears in agent's LocalChat dashboard within 2s
 - [ ] Agent replies in dashboard → appears in widget within 10s (polling interval)
 - [ ] Web contacts do NOT trigger a WhatsApp messenger send attempt

--- a/.plans/chat-widget/overview.md
+++ b/.plans/chat-widget/overview.md
@@ -1,0 +1,106 @@
+# Plan: Chat Widget
+
+**Status**: not-started
+**Created**: 2026-06-22
+**Last Updated**: 2026-06-22
+**Assigned Dev**: Alan Costa Facchini
+**PR Strategy**: single
+
+## Objective
+
+Build an embeddable chat widget that visitors on external client websites can use to send and receive messages with a licensee's ecomanda agents. The widget is installed via a single `<script>` tag, pops open an Intercom-style chat, and routes messages through the existing LocalChat plugin.
+
+## Scope
+
+### In Scope
+- `web` contact type on the Contact model + `widgetSessionToken` identifier field
+- Three public backend endpoints (session, send message, poll messages) under `/widget/:apiToken/*`
+- Guard in `SendMessageToMessenger` to skip messenger delivery for web contacts
+- React + Vite widget bundle (IIFE) served as `/widget.js` from Express static
+- Visitor identification via name + email form shown on first open
+- Reply delivery to widget via polling (GET every 5 seconds)
+
+### Out of Scope
+- Real-time Socket.IO delivery to widget — polling is sufficient for MVP
+- File/image upload from widget — text-only
+- Branding customisation by licensee (colours, logo) — not in this iteration
+- Conversation history across sessions (beyond current open room) — cleared on new session
+- Mobile-specific optimisations for the widget popup
+
+## Kill Criteria
+
+- If Socket.IO real-time delivery becomes a hard requirement before Phase 4 ships — revisit architecture
+- If licensee count grows to a point where polling creates measurable backend load — switch to Server-Sent Events or Socket.IO
+
+## Phases
+
+| Phase | Name | Tasks | Dependencies | Description |
+|-------|------|-------|--------------|-------------|
+| 1 | Foundation | task-01, task-02 | None | Contact model extension + message query method |
+| 2 | Use Cases | task-03, task-04, task-05 | Phase 1 | Three widget use cases (session, send, poll) |
+| 3 | Backend Routes & Guard | task-06, task-07 | Phase 2 | Widget router + web-contact messenger bypass |
+| 4 | Widget Frontend | task-08, task-09, task-10, task-11 | Phase 3 | React+Vite bundle, UI, hooks, Express static serve |
+
+## Task Summary
+
+| Task Path | Title | Phase | Status | Depends On |
+|-----------|-------|-------|--------|------------|
+| phase-1/task-01-contact-web-type | Contact: web type + widgetSessionToken | 1 | not-started | — |
+| phase-1/task-02-message-findbyroom | MessageRepository: findByRoom query | 1 | not-started | — |
+| phase-2/task-03-create-widget-session | Use case: CreateWidgetSession | 2 | not-started | phase-1/task-01-contact-web-type |
+| phase-2/task-04-send-widget-message | Use case: SendWidgetMessage | 2 | not-started | phase-1/task-01-contact-web-type |
+| phase-2/task-05-get-widget-messages | Use case: GetWidgetMessages | 2 | not-started | phase-1/task-02-message-findbyroom |
+| phase-3/task-06-widget-router | Widget router + CORS + 3 endpoints | 3 | not-started | phase-2/task-03, task-04, task-05 |
+| phase-3/task-07-web-contact-guard | SendMessageToMessenger: skip web contacts | 3 | not-started | phase-2/task-03-create-widget-session |
+| phase-4/task-08-widget-skeleton | Widget project skeleton (Vite IIFE) | 4 | not-started | phase-3/task-06-widget-router |
+| phase-4/task-09-widget-components | Widget React UI components | 4 | not-started | phase-4/task-08-widget-skeleton |
+| phase-4/task-10-widget-hooks-mount | Widget hooks + IIFE mount script | 4 | not-started | phase-4/task-09-widget-components |
+| phase-4/task-11-express-static | Express static serve widget.js | 4 | not-started | phase-4/task-10-widget-hooks-mount |
+
+## Branch Convention
+
+Pattern: `plan/chat-widget/{task-path}`
+
+Example branches:
+- `plan/chat-widget/phase-1/task-01-contact-web-type`
+- `plan/chat-widget/phase-3/task-06-widget-router`
+
+Base branch: `main`
+
+## Key Files
+
+| File/Directory | Relevance |
+|----------------|-----------|
+| `src/app/models/Contact.ts` | Add `web` type + `widgetSessionToken` field |
+| `src/app/models/Contact.spec.ts` | Tests for new fields |
+| `src/app/repositories/contact.ts` | NormalizePhone bypass for web type in memory repo |
+| `src/app/repositories/message.ts` | Add `findByRoom` query method |
+| `src/app/services/SendMessageToMessenger.ts` | Guard: skip messenger send for web contacts |
+| `src/app/usecases/widget/` | New use case directory (3 classes) |
+| `src/app/routes/widget-routes.ts` | New router for widget API |
+| `src/config/routes.ts` | Register widget router at `/widget` |
+| `widget/` | New top-level directory: React+Vite widget bundle |
+
+## Risks
+
+- `ContactRepositoryMemory.normalizeContactFields` and `Contact.ts` pre-save hook both apply NormalizePhone based on `number.includes('@')` — email addresses trigger this. Both must be patched to guard for `type === 'web'`.
+- `SendMessageToMessenger` currently only populates `licensee` on the message. To check contact type, the populate call must also include `contact`. Verify this doesn't break existing tests.
+- The widget's IIFE bundle must not pollute the host page's global scope beyond a single `window.EcomandaWidget` namespace.
+- Vite IIFE build targeting a single `widget.js` file requires `build.lib` config — verify CSS is either inlined or injected into Shadow DOM to avoid host-page style conflicts.
+
+## Success Criteria
+
+- [ ] Widget loads via `<script src="/widget.js" data-licensee="TOKEN">` on any HTML page
+- [ ] Visitor submits name + email → session persists in localStorage
+- [ ] Visitor sends message → appears in agent's LocalChat dashboard within 2s
+- [ ] Agent replies in dashboard → appears in widget within 10s (polling interval)
+- [ ] Web contacts do NOT trigger a WhatsApp messenger send attempt
+- [ ] All existing tests pass
+- [ ] `yarn typecheck` and `yarn linter` pass
+
+## References
+
+- **JIRA Epic**: N/A
+- **Weekly Plan Brief**: N/A
+- **Related Plans**: [local-chat-infra](../local-chat-infra/overview.md), [local-chat-ui](../local-chat-ui/overview.md)
+- **Rock Alignment**: N/A

--- a/.plans/chat-widget/phase-1/task-01-contact-web-type/status.md
+++ b/.plans/chat-widget/phase-1/task-01-contact-web-type/status.md
@@ -1,0 +1,25 @@
+# Status: Contact — web type + widgetSessionToken
+
+**Current Status**: not-started
+**Last Updated**: 2026-06-22
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-06-22 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/chat-widget/phase-1/task-01-contact-web-type/task.md
+++ b/.plans/chat-widget/phase-1/task-01-contact-web-type/task.md
@@ -23,7 +23,7 @@ Widget visitors provide name + email (required) and optionally a phone. The cont
 - `email` = visitor email (field already exists in the schema)
 - `type` = `'web'`
 
-Since `type: 'web'` is set explicitly before saving, both guards must short-circuit when `type === 'web'` to prevent NormalizePhone from mangling the number.
+Since `type: 'web'` is always set explicitly before saving, the existing condition `number.includes('@') || !type` already evaluates to `false` — NormalizePhone never runs for web contacts. No additional bypass guards are needed in the pre-save hook or the memory repository.
 
 The `widgetSessionToken` is a UUID stored on the Contact and returned to the widget's localStorage. It acts as the session identifier for all subsequent widget API calls.
 
@@ -38,14 +38,14 @@ The `widgetSessionToken` is a UUID stored on the Contact and returned to the wid
 
 | File | Action | Notes |
 |------|--------|-------|
-| `src/app/models/Contact.ts` | modify | Add `widgetSessionToken` field; guard pre-save hook |
+| `src/app/models/Contact.ts` | modify | Add `widgetSessionToken` field |
 | `src/app/models/Contact.spec.ts` | modify | Add specs for web type and widgetSessionToken |
-| `src/app/repositories/contact.ts` | modify | Guard `normalizeContactFields` for `type === 'web'` |
 
 ### Do NOT Modify
 
+- `src/app/repositories/contact.ts` — no bypass guard needed; existing condition already handles `type === 'web'`
 - `src/app/repositories/message.ts` — owned by phase-1/task-02-message-findbyroom
-- `src/app/helpers/NormalizePhone.ts` — no changes needed; guards go in callers
+- `src/app/helpers/NormalizePhone.ts` — no changes needed
 
 ## Implementation Steps
 
@@ -62,47 +62,7 @@ widgetSessionToken: {
 
 `sparse: true` allows multiple documents to have `null`/undefined while still enforcing uniqueness among set values if you add `unique: true` (optional for MVP — add if desired).
 
-### Step 2: Guard the pre-save hook
-
-In the same file, update the pre-save hook to skip normalization for web contacts:
-
-```ts
-contactSchema.pre('save', function () {
-  const contact = this
-
-  if (!contact._id) {
-    contact._id = new mongoose.Types.ObjectId()
-  }
-
-  // Web contacts store phone (or placeholder) as-is — skip normalization
-  if (contact.type === 'web') return
-
-  if (contact.number.includes('@') || !contact.type) {
-    const normalizedPhone = new NormalizePhone(contact.number)
-    contact.number = normalizedPhone.number
-    contact.type = normalizedPhone.type
-  }
-})
-```
-
-### Step 3: Guard ContactRepositoryMemory.normalizeContactFields
-
-In `src/app/repositories/contact.ts`, update the normalization block:
-
-```ts
-// Web contacts store phone (or placeholder) as-is — skip normalization
-if (normalizedFields.type === 'web') return normalizedFields
-
-if (normalizedFields.number?.includes('@') || !normalizedFields.type) {
-  const normalizedPhone = new NormalizePhone(normalizedFields.number)
-  normalizedFields.number = normalizedPhone.number
-  normalizedFields.type = normalizedPhone.type
-}
-```
-
-The guard must be placed immediately before the existing `if (normalizedFields.number?.includes('@')` block.
-
-### Step 4: Add specs
+### Step 2: Add specs
 
 In `src/app/models/Contact.spec.ts`, add a describe block covering:
 - A web contact created with `{ number: '11999990000', type: 'web', talkingWithChatBot: false, licensee }` saves with number unchanged (no normalization)
@@ -126,7 +86,6 @@ No KB/doc updates required — this is a model field addition; the pattern is st
 
 - [ ] `web` type saves without NormalizePhone clobbering the number
 - [ ] `widgetSessionToken` field present in schema
-- [ ] Memory repo normalization guard in place
 - [ ] New specs pass; existing tests unaffected
 - [ ] Status updated to `complete` in `status.md`
 

--- a/.plans/chat-widget/phase-1/task-01-contact-web-type/task.md
+++ b/.plans/chat-widget/phase-1/task-01-contact-web-type/task.md
@@ -1,0 +1,129 @@
+# Task: Contact — web type + widgetSessionToken
+
+**Plan**: Chat Widget
+**Phase**: 1
+**Task ID (phase-local)**: task-01
+**Task Path**: phase-1/task-01-contact-web-type
+**Depends On**: None
+**JIRA**: N/A
+
+## Objective
+
+Add `web` as a valid Contact type and introduce a `widgetSessionToken` field. Patch both the Mongoose pre-save hook and the in-memory repository's normalization helper so that email-address numbers are not passed through `NormalizePhone` for web contacts.
+
+## Context
+
+`Contact.type` is currently set implicitly by `NormalizePhone` in two places:
+
+1. **`src/app/models/Contact.ts` pre-save hook** — runs `NormalizePhone` when `number.includes('@') || !type`.
+2. **`src/app/repositories/contact.ts` `ContactRepositoryMemory.normalizeContactFields`** — same condition.
+
+Widget visitors are identified by email (their `number` will be an email string like `user@example.com`). Since email contains `@`, both guards currently trigger `NormalizePhone`, which would clobber the intended `type: 'web'`. Both places must short-circuit when `type === 'web'` is already set.
+
+The `widgetSessionToken` is a UUID stored on the Contact and returned to the widget's localStorage. It acts as the session identifier for all subsequent widget API calls.
+
+## Before You Start
+
+- [ ] `git switch main && git pull --rebase origin main`
+- [ ] Check `status.md` — must be `not-started` before proceeding
+- [ ] Read `docs/kb/architecture/project-overview.md` — folder layout and plugin overview
+- [ ] Mark this task `in-progress` in `status.md` before writing code
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/app/models/Contact.ts` | modify | Add `widgetSessionToken` field; guard pre-save hook |
+| `src/app/models/Contact.spec.ts` | modify | Add specs for web type and widgetSessionToken |
+| `src/app/repositories/contact.ts` | modify | Guard `normalizeContactFields` for `type === 'web'` |
+
+### Do NOT Modify
+
+- `src/app/repositories/message.ts` — owned by phase-1/task-02-message-findbyroom
+- `src/app/helpers/NormalizePhone.ts` — no changes needed; guards go in callers
+
+## Implementation Steps
+
+### Step 1: Add `widgetSessionToken` to contactSchema
+
+In `src/app/models/Contact.ts`, add to `contactSchema`:
+
+```ts
+widgetSessionToken: {
+  type: String,
+  sparse: true,
+},
+```
+
+`sparse: true` allows multiple documents to have `null`/undefined while still enforcing uniqueness among set values if you add `unique: true` (optional for MVP — add if desired).
+
+### Step 2: Guard the pre-save hook
+
+In the same file, update the pre-save hook to skip normalization for web contacts:
+
+```ts
+contactSchema.pre('save', function () {
+  const contact = this
+
+  if (!contact._id) {
+    contact._id = new mongoose.Types.ObjectId()
+  }
+
+  // Web contacts use email as number — skip phone normalization
+  if (contact.type === 'web') return
+
+  if (contact.number.includes('@') || !contact.type) {
+    const normalizedPhone = new NormalizePhone(contact.number)
+    contact.number = normalizedPhone.number
+    contact.type = normalizedPhone.type
+  }
+})
+```
+
+### Step 3: Guard ContactRepositoryMemory.normalizeContactFields
+
+In `src/app/repositories/contact.ts`, update the normalization block:
+
+```ts
+// Web contacts use email as number — skip phone normalization
+if (normalizedFields.type === 'web') return normalizedFields
+
+if (normalizedFields.number?.includes('@') || !normalizedFields.type) {
+  const normalizedPhone = new NormalizePhone(normalizedFields.number)
+  normalizedFields.number = normalizedPhone.number
+  normalizedFields.type = normalizedPhone.type
+}
+```
+
+The guard must be placed immediately before the existing `if (normalizedFields.number?.includes('@')` block.
+
+### Step 4: Add specs
+
+In `src/app/models/Contact.spec.ts`, add a describe block covering:
+- A web contact created with `{ number: 'user@example.com', type: 'web', talkingWithChatBot: false, licensee }` saves successfully without normalizing the number
+- `widgetSessionToken` can be set and retrieved
+- A phone-type contact still normalizes correctly (regression)
+
+## Testing
+
+- [ ] New specs pass: web contact saves with email as `number`, type remains `'web'`
+- [ ] `widgetSessionToken` field persists on save
+- [ ] Existing Contact specs still pass (no regression on phone normalization)
+- [ ] `yarn test src/app/models/Contact.spec.ts` green
+- [ ] `yarn typecheck` passes
+
+## Documentation / KB Updates
+
+No KB/doc updates required — this is a model field addition; the pattern is straightforward.
+
+## Completion Criteria
+
+- [ ] `web` type saves without NormalizePhone clobbering email number
+- [ ] `widgetSessionToken` field present in schema
+- [ ] Memory repo normalization guards in place
+- [ ] New specs pass; existing tests unaffected
+- [ ] Status updated to `complete` in `status.md`
+
+## Conflict Avoidance Notes
+
+- task-02-message-findbyroom runs in parallel — no shared files.

--- a/.plans/chat-widget/phase-1/task-01-contact-web-type/task.md
+++ b/.plans/chat-widget/phase-1/task-01-contact-web-type/task.md
@@ -9,7 +9,7 @@
 
 ## Objective
 
-Add `web` as a valid Contact type and introduce a `widgetSessionToken` field. Patch both the Mongoose pre-save hook and the in-memory repository's normalization helper so that email-address numbers are not passed through `NormalizePhone` for web contacts.
+Add `web` as a valid Contact type and introduce a `widgetSessionToken` field. Patch both the Mongoose pre-save hook and the in-memory repository's normalization helper so that web contacts bypass `NormalizePhone` entirely — their `number` is a raw phone string (or `'00000000000'` when the visitor didn't provide one) and must not be reformatted.
 
 ## Context
 
@@ -18,7 +18,12 @@ Add `web` as a valid Contact type and introduce a `widgetSessionToken` field. Pa
 1. **`src/app/models/Contact.ts` pre-save hook** — runs `NormalizePhone` when `number.includes('@') || !type`.
 2. **`src/app/repositories/contact.ts` `ContactRepositoryMemory.normalizeContactFields`** — same condition.
 
-Widget visitors are identified by email (their `number` will be an email string like `user@example.com`). Since email contains `@`, both guards currently trigger `NormalizePhone`, which would clobber the intended `type: 'web'`. Both places must short-circuit when `type === 'web'` is already set.
+Widget visitors provide name + email (required) and optionally a phone. The contact is stored as:
+- `number` = visitor phone if provided, else `'00000000000'` (placeholder that satisfies the required field without triggering a real WhatsApp lookup)
+- `email` = visitor email (field already exists in the schema)
+- `type` = `'web'`
+
+Since `type: 'web'` is set explicitly before saving, both guards must short-circuit when `type === 'web'` to prevent NormalizePhone from mangling the number.
 
 The `widgetSessionToken` is a UUID stored on the Contact and returned to the widget's localStorage. It acts as the session identifier for all subsequent widget API calls.
 
@@ -69,7 +74,7 @@ contactSchema.pre('save', function () {
     contact._id = new mongoose.Types.ObjectId()
   }
 
-  // Web contacts use email as number — skip phone normalization
+  // Web contacts store phone (or placeholder) as-is — skip normalization
   if (contact.type === 'web') return
 
   if (contact.number.includes('@') || !contact.type) {
@@ -85,7 +90,7 @@ contactSchema.pre('save', function () {
 In `src/app/repositories/contact.ts`, update the normalization block:
 
 ```ts
-// Web contacts use email as number — skip phone normalization
+// Web contacts store phone (or placeholder) as-is — skip normalization
 if (normalizedFields.type === 'web') return normalizedFields
 
 if (normalizedFields.number?.includes('@') || !normalizedFields.type) {
@@ -100,13 +105,14 @@ The guard must be placed immediately before the existing `if (normalizedFields.n
 ### Step 4: Add specs
 
 In `src/app/models/Contact.spec.ts`, add a describe block covering:
-- A web contact created with `{ number: 'user@example.com', type: 'web', talkingWithChatBot: false, licensee }` saves successfully without normalizing the number
+- A web contact created with `{ number: '11999990000', type: 'web', talkingWithChatBot: false, licensee }` saves with number unchanged (no normalization)
+- A web contact created with `{ number: '00000000000', type: 'web', ... }` saves without error
 - `widgetSessionToken` can be set and retrieved
-- A phone-type contact still normalizes correctly (regression)
+- A regular phone contact still normalizes correctly (regression guard)
 
 ## Testing
 
-- [ ] New specs pass: web contact saves with email as `number`, type remains `'web'`
+- [ ] New specs pass: web contact saves with `number` unchanged, `type` remains `'web'`
 - [ ] `widgetSessionToken` field persists on save
 - [ ] Existing Contact specs still pass (no regression on phone normalization)
 - [ ] `yarn test src/app/models/Contact.spec.ts` green
@@ -118,9 +124,9 @@ No KB/doc updates required — this is a model field addition; the pattern is st
 
 ## Completion Criteria
 
-- [ ] `web` type saves without NormalizePhone clobbering email number
+- [ ] `web` type saves without NormalizePhone clobbering the number
 - [ ] `widgetSessionToken` field present in schema
-- [ ] Memory repo normalization guards in place
+- [ ] Memory repo normalization guard in place
 - [ ] New specs pass; existing tests unaffected
 - [ ] Status updated to `complete` in `status.md`
 

--- a/.plans/chat-widget/phase-1/task-02-message-findbyroom/status.md
+++ b/.plans/chat-widget/phase-1/task-02-message-findbyroom/status.md
@@ -1,0 +1,25 @@
+# Status: MessageRepository — findByRoom query
+
+**Current Status**: not-started
+**Last Updated**: 2026-06-22
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-06-22 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/chat-widget/phase-1/task-02-message-findbyroom/task.md
+++ b/.plans/chat-widget/phase-1/task-02-message-findbyroom/task.md
@@ -1,0 +1,108 @@
+# Task: MessageRepository — findByRoom query
+
+**Plan**: Chat Widget
+**Phase**: 1
+**Task ID (phase-local)**: task-02
+**Task Path**: phase-1/task-02-message-findbyroom
+**Depends On**: None
+**JIRA**: N/A
+
+## Objective
+
+Add a `findByRoom(roomId, options?)` method to both `MessageRepositoryDatabase` and `MessageRepositoryMemory`. This method is the data layer for the widget's polling endpoint — it returns messages for a given room, ordered ascending by `createdAt`, optionally filtered to only messages newer than a given timestamp.
+
+## Context
+
+The existing `MessageRepositoryDatabase.find(params)` is a generic `Message.find(params)` with no ordering or date filtering. The widget's `GetWidgetMessages` use case (Phase 2 task-05) needs to efficiently fetch the conversation history and incremental updates.
+
+The method signature:
+
+```ts
+findByRoom(roomId: string, options?: { since?: Date }): Promise<Message[]>
+```
+
+- Returns messages where `room === roomId`, sorted by `createdAt ASC`
+- If `options.since` is provided, adds `createdAt > since` filter
+- Both DB and Memory implementations required
+
+## Before You Start
+
+- [ ] `git switch main && git pull --rebase origin main`
+- [ ] Check `status.md` — must be `not-started` before proceeding
+- [ ] Read `src/app/repositories/repository.ts` to understand the base class interface
+- [ ] Mark this task `in-progress` in `status.md` before writing code
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/app/repositories/message.ts` | modify | Add `findByRoom` to both classes |
+| `src/app/repositories/message.spec.ts` | modify | Add specs for `findByRoom` |
+
+### Do NOT Modify
+
+- `src/app/models/Contact.ts` — owned by phase-1/task-01-contact-web-type
+- `src/app/repositories/contact.ts` — owned by phase-1/task-01-contact-web-type
+
+## Implementation Steps
+
+### Step 1: Add to MessageRepositoryDatabase
+
+```ts
+async findByRoom(roomId: any, options: { since?: Date } = {}) {
+  const query: Record<string, any> = { room: roomId }
+  if (options.since) {
+    query.createdAt = { $gt: options.since }
+  }
+  return await Message.find(query).sort({ createdAt: 1 })
+}
+```
+
+### Step 2: Add to MessageRepositoryMemory
+
+Use the existing `sortRecords` helper (already imported from `./repository`):
+
+```ts
+async findByRoom(roomId: any, options: { since?: Date } = {}) {
+  const messages = this.items.filter((m: any) => {
+    const roomMatch = comparableValue(m.room) === comparableValue(roomId)
+    if (!roomMatch) return false
+    if (options.since && m.createdAt) {
+      return new Date(m.createdAt) > options.since
+    }
+    return true
+  })
+  return sortRecords(messages, { createdAt: 'asc' })
+}
+```
+
+Import `comparableValue` and `sortRecords` — they are already imported at the top of `message.ts` via the `Repository` import.
+
+### Step 3: Add specs
+
+In `src/app/repositories/message.spec.ts`, cover:
+- Returns messages for the given room in ascending `createdAt` order
+- Returns empty array when no messages exist for room
+- Filters by `since` — only returns messages newer than the given timestamp
+- Does not return messages from a different room
+
+## Testing
+
+- [ ] All four cases covered in spec
+- [ ] `yarn test src/app/repositories/message.spec.ts` green
+- [ ] Existing message repository specs still pass
+
+## Documentation / KB Updates
+
+No KB/doc updates required.
+
+## Completion Criteria
+
+- [ ] `findByRoom` implemented in both DB and Memory classes
+- [ ] Specs cover room filter, sort order, and `since` filter
+- [ ] No regressions in existing message repository tests
+- [ ] Status updated to `complete` in `status.md`
+
+## Conflict Avoidance Notes
+
+- task-01-contact-web-type runs in parallel — no shared files.

--- a/.plans/chat-widget/phase-2/task-03-create-widget-session/status.md
+++ b/.plans/chat-widget/phase-2/task-03-create-widget-session/status.md
@@ -1,0 +1,25 @@
+# Status: Use Case — CreateWidgetSession
+
+**Current Status**: not-started
+**Last Updated**: 2026-06-22
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-06-22 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/chat-widget/phase-2/task-03-create-widget-session/task.md
+++ b/.plans/chat-widget/phase-2/task-03-create-widget-session/task.md
@@ -1,0 +1,129 @@
+# Task: Use Case — CreateWidgetSession
+
+**Plan**: Chat Widget
+**Phase**: 2
+**Task ID (phase-local)**: task-03
+**Task Path**: phase-2/task-03-create-widget-session
+**Depends On**: phase-1/task-01-contact-web-type
+**JIRA**: N/A
+
+## Objective
+
+Implement `CreateWidgetSession` — the use case that finds or creates a `web` Contact for a widget visitor (identified by name + email) and returns a `widgetSessionToken` for subsequent API calls.
+
+## Context
+
+This is the first call a widget makes after the visitor submits the name/email form. The use case:
+
+1. Looks up the Licensee by `apiToken`
+2. Finds or creates a Contact with `{ number: email, type: 'web', licensee }`
+3. If the Contact lacks a `widgetSessionToken`, generates one (UUID v4) and persists it
+4. Returns `{ widgetSessionToken, contactId, licenseeId }`
+
+The `widgetSessionToken` is stored in the visitor's `localStorage` and sent with every subsequent widget API request.
+
+Existing pattern to follow: `src/app/usecases/onboarding/OnboardAccount.ts` — see how it composes repositories in the constructor and exposes a single `execute(input)` method.
+
+## Before You Start
+
+- [ ] `git switch main && git pull --rebase origin main`
+- [ ] Verify `phase-1/task-01-contact-web-type` status is `complete` (widgetSessionToken field exists)
+- [ ] Read `src/app/usecases/onboarding/OnboardAccount.ts` — constructor + execute pattern
+- [ ] Read `src/app/repositories/contact.ts` — `findFirst` and `create` signatures
+- [ ] Mark this task `in-progress` in `status.md`
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/app/usecases/widget/CreateWidgetSession.ts` | create | Use case implementation |
+| `src/app/usecases/widget/CreateWidgetSession.spec.ts` | create | Unit tests with memory repos |
+
+### Do NOT Modify
+
+- `src/app/usecases/widget/SendWidgetMessage.ts` — owned by task-04
+- `src/app/usecases/widget/GetWidgetMessages.ts` — owned by task-05
+- `src/app/repositories/contact.ts` — owned by Phase 1
+
+## Implementation Steps
+
+### Step 1: Create the use case
+
+`src/app/usecases/widget/CreateWidgetSession.ts`:
+
+```ts
+import { v4 as uuidv4 } from 'uuid'
+
+class CreateWidgetSession {
+  licenseeRepository: any
+  contactRepository: any
+
+  constructor({ licenseeRepository, contactRepository }: Record<string, any> = {}) {
+    this.licenseeRepository = licenseeRepository
+    this.contactRepository = contactRepository
+  }
+
+  async execute({ apiToken, name, email }: { apiToken: string; name: string; email: string }) {
+    const licensee = await this.licenseeRepository.findFirst({ apiToken })
+    if (!licensee) throw new Error(`Licensee not found for token: ${apiToken}`)
+
+    let contact = await this.contactRepository.findFirst({
+      number: email,
+      type: 'web',
+      licensee: licensee._id,
+    })
+
+    if (!contact) {
+      contact = await this.contactRepository.create({
+        number: email,
+        type: 'web',
+        name,
+        talkingWithChatBot: false,
+        licensee: licensee._id,
+        widgetSessionToken: uuidv4(),
+      })
+    } else if (!contact.widgetSessionToken) {
+      contact.widgetSessionToken = uuidv4()
+      await this.contactRepository.save(contact)
+    }
+
+    return {
+      widgetSessionToken: contact.widgetSessionToken,
+      contactId: contact._id.toString(),
+      licenseeId: licensee._id.toString(),
+    }
+  }
+}
+
+export { CreateWidgetSession }
+```
+
+### Step 2: Write specs
+
+`src/app/usecases/widget/CreateWidgetSession.spec.ts`:
+
+- When licensee not found → throws with helpful message
+- When no existing contact → creates web contact with email as number and returns token
+- When contact exists but has no widgetSessionToken → generates one and returns it
+- When contact exists with widgetSessionToken → returns existing token (idempotent)
+- Uses `LicenseeRepositoryDatabase` + `ContactRepositoryDatabase` with `installMemoryRepositories()`
+
+## Testing
+
+- [ ] 4 spec cases pass
+- [ ] `yarn test src/app/usecases/widget/CreateWidgetSession.spec.ts` green
+- [ ] `yarn typecheck` passes
+
+## Documentation / KB Updates
+
+No KB/doc updates required for this task alone. After Phase 3 ships (when the full widget API is wired), run `document-solution` to capture the widget session pattern.
+
+## Completion Criteria
+
+- [ ] Use case created and all specs pass
+- [ ] Idempotent: calling twice with same email returns same token
+- [ ] Status updated to `complete` in `status.md`
+
+## Conflict Avoidance Notes
+
+- task-04 and task-05 run in parallel — they create sibling files in `src/app/usecases/widget/`. No shared files.

--- a/.plans/chat-widget/phase-2/task-03-create-widget-session/task.md
+++ b/.plans/chat-widget/phase-2/task-03-create-widget-session/task.md
@@ -13,14 +13,16 @@ Implement `CreateWidgetSession` — the use case that finds or creates a `web` C
 
 ## Context
 
-This is the first call a widget makes after the visitor submits the name/email form. The use case:
+This is the first call a widget makes after the visitor submits the session form. The use case:
 
 1. Looks up the Licensee by `apiToken`
-2. Finds or creates a Contact with `{ number: email, type: 'web', licensee }`
+2. Finds or creates a Contact with `{ number: phone || '00000000000', type: 'web', email, name, licensee }`
 3. If the Contact lacks a `widgetSessionToken`, generates one (UUID v4) and persists it
 4. Returns `{ widgetSessionToken, contactId, licenseeId }`
 
 The `widgetSessionToken` is stored in the visitor's `localStorage` and sent with every subsequent widget API request.
+
+Contact lookup uses `{ email, type: 'web', licensee }` — email is the stable deduplication key. Phone is stored on the contact but not used for lookup (it may be `'00000000000'` if the visitor skipped it).
 
 Existing pattern to follow: `src/app/usecases/onboarding/OnboardAccount.ts` — see how it composes repositories in the constructor and exposes a single `execute(input)` method.
 
@@ -63,21 +65,22 @@ class CreateWidgetSession {
     this.contactRepository = contactRepository
   }
 
-  async execute({ apiToken, name, email }: { apiToken: string; name: string; email: string }) {
+  async execute({ apiToken, name, email, phone }: { apiToken: string; name: string; email: string; phone?: string }) {
     const licensee = await this.licenseeRepository.findFirst({ apiToken })
     if (!licensee) throw new Error(`Licensee not found for token: ${apiToken}`)
 
     let contact = await this.contactRepository.findFirst({
-      number: email,
+      email,
       type: 'web',
       licensee: licensee._id,
     })
 
     if (!contact) {
       contact = await this.contactRepository.create({
-        number: email,
+        number: phone || '00000000000',
         type: 'web',
         name,
+        email,
         talkingWithChatBot: false,
         licensee: licensee._id,
         widgetSessionToken: uuidv4(),
@@ -103,7 +106,8 @@ export { CreateWidgetSession }
 `src/app/usecases/widget/CreateWidgetSession.spec.ts`:
 
 - When licensee not found → throws with helpful message
-- When no existing contact → creates web contact with email as number and returns token
+- When no existing contact → creates web contact with `number: phone || '00000000000'`, email in email field, returns token
+- When phone provided → stored as `number`; when omitted → `'00000000000'` stored as placeholder
 - When contact exists but has no widgetSessionToken → generates one and returns it
 - When contact exists with widgetSessionToken → returns existing token (idempotent)
 - Uses `LicenseeRepositoryDatabase` + `ContactRepositoryDatabase` with `installMemoryRepositories()`

--- a/.plans/chat-widget/phase-2/task-04-send-widget-message/status.md
+++ b/.plans/chat-widget/phase-2/task-04-send-widget-message/status.md
@@ -1,0 +1,25 @@
+# Status: Use Case — SendWidgetMessage
+
+**Current Status**: not-started
+**Last Updated**: 2026-06-22
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-06-22 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/chat-widget/phase-2/task-04-send-widget-message/task.md
+++ b/.plans/chat-widget/phase-2/task-04-send-widget-message/task.md
@@ -1,0 +1,133 @@
+# Task: Use Case — SendWidgetMessage
+
+**Plan**: Chat Widget
+**Phase**: 2
+**Task ID (phase-local)**: task-04
+**Task Path**: phase-2/task-04-send-widget-message
+**Depends On**: phase-1/task-01-contact-web-type
+**JIRA**: N/A
+
+## Objective
+
+Implement `SendWidgetMessage` — the use case called when a widget visitor sends a chat message. It creates a `Message` record and calls `LocalChat.sendMessage()` directly to assign a Room and emit the `new-room-message` Socket.IO event to the licensee's agent dashboard.
+
+## Context
+
+Normal messenger inbound flow: webhook → BullMQ → `send-message-to-chat` job → `LocalChat.sendMessage`. For widget messages, BullMQ is bypassed for simplicity: this use case calls `LocalChat.sendMessage` synchronously after creating the Message. This is acceptable because:
+- Widget traffic is low volume
+- No ordering guarantee is needed for a single visitor sending messages sequentially
+
+**LocalChat.sendMessage** (`src/app/plugins/chats/LocalChat.ts`):
+- Accepts a `messageId`
+- Finds the message (with contact populated)
+- Finds or creates an open Room for the contact
+- Sets `message.room`, `message.sended = true`, saves
+- Emits `new-room-message` to the licensee's Socket.IO room
+
+The Message must be created with:
+- `number`: a UUID (matches existing MessageRepository.create default)
+- `licensee`: the licensee `_id`
+- `contact`: the contact `_id`
+- `destination`: `'to-chat'`
+- `kind`: `'text'`
+- `text`: the visitor's message text
+
+## Before You Start
+
+- [ ] `git switch main && git pull --rebase origin main`
+- [ ] Verify `phase-1/task-01-contact-web-type` status is `complete`
+- [ ] Read `src/app/plugins/chats/LocalChat.ts` — understand `sendMessage` signature
+- [ ] Read `src/app/plugins/chats/factory.ts` — understand `createChatPlugin` factory
+- [ ] Read `src/app/repositories/room.ts` — findOpenForContact signature
+- [ ] Mark this task `in-progress` in `status.md`
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/app/usecases/widget/SendWidgetMessage.ts` | create | Use case implementation |
+| `src/app/usecases/widget/SendWidgetMessage.spec.ts` | create | Unit tests |
+
+### Do NOT Modify
+
+- `src/app/plugins/chats/LocalChat.ts` — read-only, called as dependency
+- `src/app/usecases/widget/CreateWidgetSession.ts` — owned by task-03
+- `src/app/usecases/widget/GetWidgetMessages.ts` — owned by task-05
+
+## Implementation Steps
+
+### Step 1: Create the use case
+
+`src/app/usecases/widget/SendWidgetMessage.ts`:
+
+```ts
+import { LocalChat } from '../../plugins/chats/LocalChat'
+
+class SendWidgetMessage {
+  licenseeRepository: any
+  contactRepository: any
+  messageRepository: any
+  roomRepository: any
+
+  constructor({ licenseeRepository, contactRepository, messageRepository, roomRepository }: Record<string, any> = {}) {
+    this.licenseeRepository = licenseeRepository
+    this.contactRepository = contactRepository
+    this.messageRepository = messageRepository
+    this.roomRepository = roomRepository
+  }
+
+  async execute({ apiToken, widgetSessionToken, text }: { apiToken: string; widgetSessionToken: string; text: string }) {
+    const licensee = await this.licenseeRepository.findFirst({ apiToken })
+    if (!licensee) throw new Error(`Licensee not found for token: ${apiToken}`)
+
+    const contact = await this.contactRepository.findFirst({ widgetSessionToken, licensee: licensee._id })
+    if (!contact) throw new Error(`Widget session not found: ${widgetSessionToken}`)
+
+    const message = await this.messageRepository.create({
+      licensee: licensee._id,
+      contact: contact._id,
+      destination: 'to-chat',
+      kind: 'text',
+      text,
+    })
+
+    const localChat = new LocalChat(licensee, { roomRepository: this.roomRepository, messageRepository: this.messageRepository })
+    await localChat.sendMessage(message._id)
+
+    return message
+  }
+}
+
+export { SendWidgetMessage }
+```
+
+### Step 2: Write specs
+
+`src/app/usecases/widget/SendWidgetMessage.spec.ts`:
+
+- Licensee not found → throws
+- Session token not found → throws
+- Happy path: creates message + room, emits via LocalChat
+  - Mock `LocalChat.prototype.sendMessage` with `jest.spyOn`
+  - Verify spy called with the created message's `_id`
+- Uses `installMemoryRepositories()` pattern
+
+## Testing
+
+- [ ] 3 spec cases pass
+- [ ] `yarn test src/app/usecases/widget/SendWidgetMessage.spec.ts` green
+- [ ] `yarn typecheck` passes
+
+## Documentation / KB Updates
+
+No KB/doc updates required.
+
+## Completion Criteria
+
+- [ ] Use case created and specs pass
+- [ ] `LocalChat.sendMessage` called with correct message ID
+- [ ] Status updated to `complete` in `status.md`
+
+## Conflict Avoidance Notes
+
+- task-03 and task-05 run in parallel — they create sibling files in `src/app/usecases/widget/`. No shared files.

--- a/.plans/chat-widget/phase-2/task-05-get-widget-messages/status.md
+++ b/.plans/chat-widget/phase-2/task-05-get-widget-messages/status.md
@@ -1,0 +1,25 @@
+# Status: Use Case — GetWidgetMessages
+
+**Current Status**: not-started
+**Last Updated**: 2026-06-22
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-06-22 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/chat-widget/phase-2/task-05-get-widget-messages/task.md
+++ b/.plans/chat-widget/phase-2/task-05-get-widget-messages/task.md
@@ -1,0 +1,122 @@
+# Task: Use Case — GetWidgetMessages
+
+**Plan**: Chat Widget
+**Phase**: 2
+**Task ID (phase-local)**: task-05
+**Task Path**: phase-2/task-05-get-widget-messages
+**Depends On**: phase-1/task-02-message-findbyroom
+**JIRA**: N/A
+
+## Objective
+
+Implement `GetWidgetMessages` — the use case called by the widget's polling GET request. It returns all messages in the visitor's open room, optionally filtered to only messages newer than a given timestamp (for incremental polling).
+
+## Context
+
+The widget polls `GET /widget/:apiToken/messages?sessionToken=...&since=...` every 5 seconds. This use case:
+
+1. Resolves the licensee from `apiToken`
+2. Finds the Contact by `widgetSessionToken`
+3. Finds the open Room for that contact
+4. Returns messages via `messageRepository.findByRoom(roomId, { since? })` (added in Phase 1, task-02)
+
+The response includes both visitor-originated messages (`destination: 'to-chat'`) and agent replies. Agent replies are stored as Messages in the same room with `destination: 'to-messenger'` and `senderName` set by the agent. The widget uses `fromMe` or `senderName` to distinguish sides.
+
+If no open room exists, returns an empty array — the visitor hasn't sent a first message yet.
+
+## Before You Start
+
+- [ ] `git switch main && git pull --rebase origin main`
+- [ ] Verify `phase-1/task-02-message-findbyroom` status is `complete`
+- [ ] Read `src/app/repositories/room.ts` — `findOpenForContact` method
+- [ ] Read `src/app/repositories/message.ts` — `findByRoom` method added in task-02
+- [ ] Mark this task `in-progress` in `status.md`
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/app/usecases/widget/GetWidgetMessages.ts` | create | Use case implementation |
+| `src/app/usecases/widget/GetWidgetMessages.spec.ts` | create | Unit tests |
+
+### Do NOT Modify
+
+- `src/app/usecases/widget/CreateWidgetSession.ts` — owned by task-03
+- `src/app/usecases/widget/SendWidgetMessage.ts` — owned by task-04
+
+## Implementation Steps
+
+### Step 1: Create the use case
+
+`src/app/usecases/widget/GetWidgetMessages.ts`:
+
+```ts
+class GetWidgetMessages {
+  licenseeRepository: any
+  contactRepository: any
+  roomRepository: any
+  messageRepository: any
+
+  constructor({ licenseeRepository, contactRepository, roomRepository, messageRepository }: Record<string, any> = {}) {
+    this.licenseeRepository = licenseeRepository
+    this.contactRepository = contactRepository
+    this.roomRepository = roomRepository
+    this.messageRepository = messageRepository
+  }
+
+  async execute({
+    apiToken,
+    widgetSessionToken,
+    since,
+  }: {
+    apiToken: string
+    widgetSessionToken: string
+    since?: Date
+  }) {
+    const licensee = await this.licenseeRepository.findFirst({ apiToken })
+    if (!licensee) throw new Error(`Licensee not found for token: ${apiToken}`)
+
+    const contact = await this.contactRepository.findFirst({ widgetSessionToken, licensee: licensee._id })
+    if (!contact) throw new Error(`Widget session not found: ${widgetSessionToken}`)
+
+    const room = await this.roomRepository.findOpenForContact(contact._id)
+    if (!room) return []
+
+    return await this.messageRepository.findByRoom(room._id, { since })
+  }
+}
+
+export { GetWidgetMessages }
+```
+
+### Step 2: Write specs
+
+`src/app/usecases/widget/GetWidgetMessages.spec.ts`:
+
+- Licensee not found → throws
+- Session token not found → throws
+- No open room → returns empty array
+- Happy path with no `since` → returns all room messages
+- Happy path with `since` → returns only messages after the timestamp
+- Uses `installMemoryRepositories()`
+
+## Testing
+
+- [ ] 5 spec cases pass
+- [ ] `yarn test src/app/usecases/widget/GetWidgetMessages.spec.ts` green
+- [ ] `yarn typecheck` passes
+
+## Documentation / KB Updates
+
+No KB/doc updates required.
+
+## Completion Criteria
+
+- [ ] Use case created and specs pass
+- [ ] Empty array returned when no room exists
+- [ ] `since` filter works correctly
+- [ ] Status updated to `complete` in `status.md`
+
+## Conflict Avoidance Notes
+
+- task-03 and task-04 run in parallel — sibling files in `src/app/usecases/widget/`. No shared files.

--- a/.plans/chat-widget/phase-3/task-06-widget-router/status.md
+++ b/.plans/chat-widget/phase-3/task-06-widget-router/status.md
@@ -1,0 +1,25 @@
+# Status: Widget Router + CORS + 3 Endpoints
+
+**Current Status**: not-started
+**Last Updated**: 2026-06-22
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-06-22 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/chat-widget/phase-3/task-06-widget-router/task.md
+++ b/.plans/chat-widget/phase-3/task-06-widget-router/task.md
@@ -1,0 +1,203 @@
+# Task: Widget Router + CORS + 3 Endpoints
+
+**Plan**: Chat Widget
+**Phase**: 3
+**Task ID (phase-local)**: task-06
+**Task Path**: phase-3/task-06-widget-router
+**Depends On**: phase-2/task-03-create-widget-session, phase-2/task-04-send-widget-message, phase-2/task-05-get-widget-messages
+**JIRA**: N/A
+
+## Objective
+
+Create `src/app/routes/widget-routes.ts` — an Express router that exposes three public endpoints for the embeddable widget, with per-route CORS headers that allow any origin. Register it in `src/config/routes.ts` at `/widget`.
+
+## Context
+
+The widget is loaded on arbitrary external websites, so all three endpoints must respond with `Access-Control-Allow-Origin: *`. The existing `enableCors(app)` in `src/config/cors.ts` already calls `cors()` globally, which sets `Access-Control-Allow-Origin: *` by default — but we should ensure the preflight OPTIONS requests are handled correctly for the widget path.
+
+**Router path**: `/widget` (registered in `src/config/routes.ts`)
+
+**Endpoints**:
+
+| Method | Path | Use Case | Body / Query |
+|--------|------|----------|--------------|
+| `POST` | `/widget/:apiToken/session` | `CreateWidgetSession` | body: `{ name, email }` |
+| `POST` | `/widget/:apiToken/messages` | `SendWidgetMessage` | body: `{ widgetSessionToken, text }` |
+| `GET`  | `/widget/:apiToken/messages` | `GetWidgetMessages` | query: `?sessionToken=...&since=...` |
+
+`apiToken` is the licensee's `apiToken` field (from `Licensee.apiToken`).
+
+Pattern to follow: `src/app/routes/v1/v1-routes.ts` — composition root, use case instantiation, request parsing.
+
+### Input Validation
+
+Use `express-validator`. Already installed and used in `v1-routes.ts`.
+
+POST `/session`: `body('name').notEmpty()`, `body('email').isEmail()`
+POST `/messages`: `body('widgetSessionToken').notEmpty()`, `body('text').notEmpty()`
+GET `/messages`: `query('sessionToken').notEmpty()`
+
+## Before You Start
+
+- [ ] `git switch main && git pull --rebase origin main`
+- [ ] Verify all three Phase 2 tasks are `complete`
+- [ ] Read `src/app/routes/v1/v1-routes.ts` — composition root pattern
+- [ ] Read `src/config/routes.ts` — where to register the new router
+- [ ] Read `src/app/runtime/dependencies.ts` — `createRuntimeDependencies` to wire repos
+- [ ] Mark this task `in-progress` in `status.md`
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/app/routes/widget-routes.ts` | create | Widget router with 3 endpoints |
+| `src/app/routes/widget-routes.spec.ts` | create | Integration tests |
+| `src/config/routes.ts` | modify | Register widget router at `/widget` |
+
+### Do NOT Modify
+
+- `src/app/routes/v1/v1-routes.ts` — existing API routes
+- `src/app/services/SendMessageToMessenger.ts` — owned by task-07
+- `src/config/cors.ts` — not needed; existing global cors() is sufficient
+
+## Implementation Steps
+
+### Step 1: Create widget-routes.ts
+
+```ts
+import express from 'express'
+import cors from 'cors'
+import { body, query, param, validationResult } from 'express-validator'
+import { sanitizeExpressErrors } from '../helpers/SanitizeErrors'
+import { CreateWidgetSession } from '../usecases/widget/CreateWidgetSession'
+import { SendWidgetMessage } from '../usecases/widget/SendWidgetMessage'
+import { GetWidgetMessages } from '../usecases/widget/GetWidgetMessages'
+import { createRuntimeDependencies } from '../runtime/dependencies'
+
+const router = express.Router()
+
+// Allow all origins — widget is loaded on external sites
+router.use(cors())
+
+function validate(req: any, res: any, next: any) {
+  const errors = validationResult(req)
+  if (!errors.isEmpty()) {
+    return res.status(422).json({ errors: sanitizeExpressErrors(errors.array()) })
+  }
+  next()
+}
+
+const { licenseeRepository, contactRepository, messageRepository, roomRepository } = createRuntimeDependencies()
+
+const createWidgetSession = new CreateWidgetSession({ licenseeRepository, contactRepository })
+const sendWidgetMessage = new SendWidgetMessage({ licenseeRepository, contactRepository, messageRepository, roomRepository })
+const getWidgetMessages = new GetWidgetMessages({ licenseeRepository, contactRepository, roomRepository, messageRepository })
+
+// POST /widget/:apiToken/session
+router.post(
+  '/:apiToken/session',
+  [param('apiToken').notEmpty(), body('name').notEmpty(), body('email').isEmail()],
+  validate,
+  async (req: any, res: any) => {
+    try {
+      const result = await createWidgetSession.execute({
+        apiToken: req.params.apiToken,
+        name: req.body.name,
+        email: req.body.email,
+      })
+      return res.status(200).json(result)
+    } catch (err: any) {
+      if (err.message?.includes('Licensee not found')) return res.status(404).json({ message: err.message })
+      return res.status(500).json({ message: 'Erro interno do servidor.' })
+    }
+  },
+)
+
+// POST /widget/:apiToken/messages
+router.post(
+  '/:apiToken/messages',
+  [param('apiToken').notEmpty(), body('widgetSessionToken').notEmpty(), body('text').notEmpty().trim()],
+  validate,
+  async (req: any, res: any) => {
+    try {
+      const message = await sendWidgetMessage.execute({
+        apiToken: req.params.apiToken,
+        widgetSessionToken: req.body.widgetSessionToken,
+        text: req.body.text,
+      })
+      return res.status(201).json({ messageId: message._id.toString() })
+    } catch (err: any) {
+      if (err.message?.includes('not found')) return res.status(404).json({ message: err.message })
+      return res.status(500).json({ message: 'Erro interno do servidor.' })
+    }
+  },
+)
+
+// GET /widget/:apiToken/messages
+router.get(
+  '/:apiToken/messages',
+  [param('apiToken').notEmpty(), query('sessionToken').notEmpty()],
+  validate,
+  async (req: any, res: any) => {
+    try {
+      const since = req.query.since ? new Date(req.query.since as string) : undefined
+      const messages = await getWidgetMessages.execute({
+        apiToken: req.params.apiToken,
+        widgetSessionToken: req.query.sessionToken as string,
+        since,
+      })
+      return res.status(200).json({ messages })
+    } catch (err: any) {
+      if (err.message?.includes('not found')) return res.status(404).json({ message: err.message })
+      return res.status(500).json({ message: 'Erro interno do servidor.' })
+    }
+  },
+)
+
+export default router
+```
+
+### Step 2: Register in routes.ts
+
+In `src/config/routes.ts`, add:
+
+```ts
+import widgetRoutes from '../app/routes/widget-routes'
+// ...
+function routes(app: any) {
+  app.use('/widget', widgetRoutes)   // ← add before existing routes
+  app.use('/resources', resourcesRoutes)
+  // ...
+}
+```
+
+### Step 3: Write integration specs
+
+`src/app/routes/widget-routes.spec.ts` — use `supertest` + `installMemoryRepositories()`. Cover:
+- POST `/widget/:token/session` 200 with valid body
+- POST `/widget/:token/session` 422 with missing email
+- POST `/widget/:token/messages` 201 with valid session token + text
+- GET `/widget/:token/messages` 200 returns messages array
+- GET `/widget/:token/messages` 422 when sessionToken missing
+
+## Testing
+
+- [ ] 5 integration specs pass
+- [ ] `yarn test src/app/routes/widget-routes.spec.ts` green
+- [ ] `yarn typecheck` passes
+
+## Documentation / KB Updates
+
+After this task completes, run `document-solution` to capture the widget API pattern (new public endpoint category with no JWT auth, apiToken in path).
+
+## Completion Criteria
+
+- [ ] All 3 endpoints respond correctly
+- [ ] 422 validation errors for bad input
+- [ ] CORS headers present (`Access-Control-Allow-Origin: *`)
+- [ ] Router registered in `src/config/routes.ts`
+- [ ] Status updated to `complete` in `status.md`
+
+## Conflict Avoidance Notes
+
+- task-07 runs in parallel — it modifies `src/app/services/SendMessageToMessenger.ts` which is not touched by this task.

--- a/.plans/chat-widget/phase-3/task-06-widget-router/task.md
+++ b/.plans/chat-widget/phase-3/task-06-widget-router/task.md
@@ -33,7 +33,7 @@ Pattern to follow: `src/app/routes/v1/v1-routes.ts` — composition root, use ca
 
 Use `express-validator`. Already installed and used in `v1-routes.ts`.
 
-POST `/session`: `body('name').notEmpty()`, `body('email').isEmail()`
+POST `/session`: `body('name').notEmpty()`, `body('email').isEmail()`, `body('phone').optional().isMobilePhone('any')`
 POST `/messages`: `body('widgetSessionToken').notEmpty()`, `body('text').notEmpty()`
 GET `/messages`: `query('sessionToken').notEmpty()`
 
@@ -104,6 +104,7 @@ router.post(
         apiToken: req.params.apiToken,
         name: req.body.name,
         email: req.body.email,
+        phone: req.body.phone,   // optional — undefined if not sent
       })
       return res.status(200).json(result)
     } catch (err: any) {

--- a/.plans/chat-widget/phase-3/task-07-web-contact-guard/status.md
+++ b/.plans/chat-widget/phase-3/task-07-web-contact-guard/status.md
@@ -1,0 +1,25 @@
+# Status: SendMessageToMessenger — skip web contacts
+
+**Current Status**: not-started
+**Last Updated**: 2026-06-22
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-06-22 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/chat-widget/phase-3/task-07-web-contact-guard/task.md
+++ b/.plans/chat-widget/phase-3/task-07-web-contact-guard/task.md
@@ -1,0 +1,121 @@
+# Task: SendMessageToMessenger — skip web contacts
+
+**Plan**: Chat Widget
+**Phase**: 3
+**Task ID (phase-local)**: task-07
+**Task Path**: phase-3/task-07-web-contact-guard
+**Depends On**: phase-2/task-03-create-widget-session
+**JIRA**: N/A
+
+## Objective
+
+Add a guard in `sendMessageToMessenger` so that when the message's contact type is `web`, the function skips the messenger plugin call and marks the message as sent. This prevents a job failure when an agent replies to a widget room (the `chat-message` job routes the reply through LocalChat which returns `action: 'send-message-to-messenger'`, but web contacts have no WhatsApp channel).
+
+## Context
+
+**Current flow for agent replies to a web contact's room**:
+1. Agent calls `POST /api/v1/chat/rooms/:roomId/messages` (ChatRoomsController.replyToRoom)
+2. `IngestChatMessage.execute` saves body, enqueues `chat-message` BullMQ job
+3. `transformChatBody` calls `LocalChat.parseMessage({ roomId, text })` → returns messages + action `'send-message-to-messenger'`
+4. Job system dispatches `send-message-to-messenger` job
+5. `sendMessageToMessenger` tries to call the WhatsApp messenger plugin → **FAILS** for web contacts (no whatsappDefault plugin)
+
+**Fix**: In `sendMessageToMessenger`, populate `contact` alongside `licensee`, then early-return for `contact.type === 'web'` after marking `message.sended = true`.
+
+**Current `findFirst` call**:
+```ts
+const message = await messageRepository.findFirst({ _id: messageId }, ['licensee'])
+```
+Must become:
+```ts
+const message = await messageRepository.findFirst({ _id: messageId }, ['licensee', 'contact'])
+```
+
+## Before You Start
+
+- [ ] `git switch main && git pull --rebase origin main`
+- [ ] Verify `phase-2/task-03-create-widget-session` status is `complete`
+- [ ] Read `src/app/services/SendMessageToMessenger.ts` — current implementation
+- [ ] Read `src/app/services/SendMessageToMessenger.spec.ts` — existing tests to preserve
+- [ ] Check `src/app/repositories/message.ts` `findFirst` — supports multiple populate values in array
+- [ ] Mark this task `in-progress` in `status.md`
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/app/services/SendMessageToMessenger.ts` | modify | Add contact populate + web guard |
+| `src/app/services/SendMessageToMessenger.spec.ts` | modify | Add spec for web contact guard |
+
+### Do NOT Modify
+
+- `src/app/routes/widget-routes.ts` — owned by task-06
+- `src/app/plugins/chats/LocalChat.ts` — not involved in this fix
+
+## Implementation Steps
+
+### Step 1: Update sendMessageToMessenger
+
+```ts
+async function sendMessageToMessenger(
+  data: any,
+  { messageRepository, createMessengerPlugin }: Record<string, any> = {},
+) {
+  const { messageId, url, token } = data
+  const message = await messageRepository.findFirst({ _id: messageId }, ['licensee', 'contact'])
+  const licensee = message.licensee
+
+  // Web contacts have no messenger channel — mark sent and skip delivery
+  if (message.contact?.type === 'web') {
+    message.sended = true
+    await messageRepository.save(message)
+    return
+  }
+
+  const extras: any = {}
+  if (message.sector) {
+    extras.sector = message.sector
+  }
+  const messengerPlugin = createMessengerPlugin(licensee, extras)
+  await messengerPlugin.sendMessage(messageId, url ?? licensee.whatsappUrl, token ?? licensee.whatsappToken)
+}
+```
+
+### Step 2: Add spec
+
+In `src/app/services/SendMessageToMessenger.spec.ts`, add a new `it` block:
+
+```
+it('skips messenger send and marks message as sent when contact type is web', async () => {
+  // Create licensee (any whatsappDefault)
+  // Create web contact (type: 'web')
+  // Create message linked to web contact
+  // Call sendMessageToMessenger
+  // Assert dialogSendMessageSpy NOT called
+  // Assert message.sended is true (reload from repo)
+})
+```
+
+Use `installMemoryRepositories()` + the existing factory pattern from the file.
+
+## Testing
+
+- [ ] New spec passes: spy not called, message.sended = true
+- [ ] Existing 2 specs still pass (no regression on regular contacts)
+- [ ] `yarn test src/app/services/SendMessageToMessenger.spec.ts` green
+- [ ] `yarn typecheck` passes
+
+## Documentation / KB Updates
+
+No KB/doc updates required.
+
+## Completion Criteria
+
+- [ ] Web contacts skip messenger send without throwing
+- [ ] `message.sended` set to `true` for web contact messages
+- [ ] Existing messenger specs unaffected
+- [ ] Status updated to `complete` in `status.md`
+
+## Conflict Avoidance Notes
+
+- task-06 runs in parallel — it does not touch this service file.

--- a/.plans/chat-widget/phase-4/task-08-widget-skeleton/status.md
+++ b/.plans/chat-widget/phase-4/task-08-widget-skeleton/status.md
@@ -1,0 +1,25 @@
+# Status: Widget Project Skeleton (Vite IIFE Build)
+
+**Current Status**: not-started
+**Last Updated**: 2026-06-22
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-06-22 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/chat-widget/phase-4/task-08-widget-skeleton/task.md
+++ b/.plans/chat-widget/phase-4/task-08-widget-skeleton/task.md
@@ -1,0 +1,176 @@
+# Task: Widget Project Skeleton (Vite IIFE Build)
+
+**Plan**: Chat Widget
+**Phase**: 4
+**Task ID (phase-local)**: task-08
+**Task Path**: phase-4/task-08-widget-skeleton
+**Depends On**: phase-3/task-06-widget-router
+**JIRA**: N/A
+
+## Objective
+
+Create the `widget/` top-level directory with its own `package.json`, `tsconfig.json`, and `vite.config.ts` configured to output a single IIFE bundle (`widget.js`). The bundle must be self-contained — no external script dependencies assumed on the host page.
+
+## Context
+
+The widget is a separate React app from the main `client/`. It has its own build pipeline producing `widget/dist/widget.js`. The IIFE format wraps the bundle in an immediately-invoked function expression, avoiding global scope pollution beyond a single `window.EcomandaWidget` namespace.
+
+**Key Vite settings**:
+- `build.lib.entry`: `widget/src/main.tsx`
+- `build.lib.formats`: `['iife']`
+- `build.lib.name`: `'EcomandaWidget'`
+- `build.lib.fileName`: `() => 'widget.js'`
+- CSS must be injected into Shadow DOM (handled in task-10) or inlined — configure `build.cssCodeSplit: false`
+
+**Dependencies needed** (look up current versions before installing):
+- `react`, `react-dom` — mark as `devDependencies` since they'll be bundled (not external)
+- `vite`, `@vitejs/plugin-react`
+- `typescript`
+
+The widget source lives in `widget/src/`. The React entry point is `widget/src/main.tsx`.
+
+## Before You Start
+
+- [ ] `git switch main && git pull --rebase origin main`
+- [ ] Verify `phase-3/task-06-widget-router` status is `complete`
+- [ ] Check current React and Vite versions used in `client/package.json` — use matching or newer
+- [ ] Run `npm show react version`, `npm show vite version` to verify latest
+- [ ] Mark this task `in-progress` in `status.md`
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `widget/package.json` | create | Project manifest + build script |
+| `widget/tsconfig.json` | create | TypeScript config |
+| `widget/vite.config.ts` | create | IIFE lib build config |
+| `widget/src/main.tsx` | create | Entry point placeholder (renders "Widget loaded") |
+| `widget/.gitignore` | create | Ignore dist/ and node_modules/ |
+
+### Do NOT Modify
+
+- `client/` — separate SPA, no changes
+- `package.json` (root) — widget has its own package.json
+
+## Implementation Steps
+
+### Step 1: Create widget/package.json
+
+```json
+{
+  "name": "ecomanda-widget",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite build --watch"
+  },
+  "dependencies": {
+    "react": "<latest>",
+    "react-dom": "<latest>"
+  },
+  "devDependencies": {
+    "@types/react": "<latest>",
+    "@types/react-dom": "<latest>",
+    "@vitejs/plugin-react": "<latest>",
+    "typescript": "<latest>",
+    "vite": "<latest>"
+  }
+}
+```
+
+Replace `<latest>` with actual versions resolved at task time via `npm show <pkg> version`.
+
+### Step 2: Create widget/tsconfig.json
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["ES2017", "DOM"],
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+```
+
+### Step 3: Create widget/vite.config.ts
+
+```ts
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import { resolve } from 'path'
+
+export default defineConfig({
+  plugins: [react()],
+  define: {
+    'process.env.NODE_ENV': '"production"',
+  },
+  build: {
+    lib: {
+      entry: resolve(__dirname, 'src/main.tsx'),
+      name: 'EcomandaWidget',
+      formats: ['iife'],
+      fileName: () => 'widget.js',
+    },
+    cssCodeSplit: false,
+    rollupOptions: {
+      // React is bundled — no externals
+    },
+  },
+})
+```
+
+### Step 4: Create widget/src/main.tsx placeholder
+
+```tsx
+console.log('[EcomandaWidget] loaded')
+```
+
+This will be replaced in task-09 and task-10.
+
+### Step 5: Create widget/.gitignore
+
+```
+dist/
+node_modules/
+```
+
+### Step 6: Install dependencies
+
+```bash
+cd widget && yarn install
+```
+
+### Step 7: Verify build
+
+```bash
+cd widget && yarn build
+```
+
+Confirm `widget/dist/widget.js` is produced and is a single IIFE file.
+
+## Testing
+
+- [ ] `yarn build` in `widget/` produces `widget/dist/widget.js`
+- [ ] File is a single IIFE (not ESM)
+- [ ] `yarn typecheck` passes (root backend typecheck unaffected)
+
+## Documentation / KB Updates
+
+No KB/doc updates required for skeleton alone.
+
+## Completion Criteria
+
+- [ ] `widget/dist/widget.js` produced by `yarn build`
+- [ ] No TypeScript errors in widget/src
+- [ ] Status updated to `complete` in `status.md`
+
+## Conflict Avoidance Notes
+
+- task-09, task-10, task-11 all depend on this task completing first.

--- a/.plans/chat-widget/phase-4/task-09-widget-components/status.md
+++ b/.plans/chat-widget/phase-4/task-09-widget-components/status.md
@@ -1,0 +1,25 @@
+# Status: Widget React UI Components
+
+**Current Status**: not-started
+**Last Updated**: 2026-06-22
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-06-22 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/chat-widget/phase-4/task-09-widget-components/task.md
+++ b/.plans/chat-widget/phase-4/task-09-widget-components/task.md
@@ -1,0 +1,211 @@
+# Task: Widget React UI Components
+
+**Plan**: Chat Widget
+**Phase**: 4
+**Task ID (phase-local)**: task-09
+**Task Path**: phase-4/task-09-widget-components
+**Depends On**: phase-4/task-08-widget-skeleton
+**JIRA**: N/A
+
+## Objective
+
+Build the five React components that form the widget UI: `FloatingButton`, `ChatPopup`, `SessionForm`, `MessageList`, and `MessageInput`. All components are purely presentational in this task — state and side-effects are wired in task-10.
+
+## Context
+
+The widget renders inside a Shadow DOM root (created in task-10) to isolate its CSS from the host page. Components must:
+- Use inline styles or CSS-in-JS — no external class names from the host page
+- Be accessible (keyboard navigable, ARIA labels)
+- Support a simple Intercom-style aesthetic: floating round button bottom-right, a popup card above it
+
+**Component tree**:
+```
+<App licenseeApiToken={string}>
+  <FloatingButton onClick isOpen />
+  {isOpen && (
+    <ChatPopup>
+      {!session && <SessionForm onSubmit />}
+      {session && (
+        <>
+          <MessageList messages />
+          <MessageInput onSend />
+        </>
+      )}
+    </ChatPopup>
+  )}
+</App>
+```
+
+**Props**:
+
+`FloatingButton`: `{ onClick: () => void; isOpen: boolean }`
+`ChatPopup`: `{ children: ReactNode }`
+`SessionForm`: `{ onSubmit: (name: string, email: string) => void; loading: boolean }`
+`MessageList`: `{ messages: WidgetMessage[] }`
+`MessageInput`: `{ onSend: (text: string) => void; disabled: boolean }`
+
+**WidgetMessage type** (define in `widget/src/types.ts`):
+```ts
+export interface WidgetMessage {
+  _id: string
+  text: string
+  senderName?: string | null
+  destination: 'to-chat' | 'to-messenger'
+  createdAt: string
+}
+```
+
+A message is from the visitor when `destination === 'to-chat'`. It's an agent reply when `destination === 'to-messenger'`.
+
+## Before You Start
+
+- [ ] `git switch main && git pull --rebase origin main`
+- [ ] Verify `phase-4/task-08-widget-skeleton` status is `complete`
+- [ ] Confirm `widget/dist/widget.js` builds successfully (run `cd widget && yarn build`)
+- [ ] Mark this task `in-progress` in `status.md`
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `widget/src/types.ts` | create | WidgetMessage interface |
+| `widget/src/components/FloatingButton.tsx` | create | Chat toggle button |
+| `widget/src/components/ChatPopup.tsx` | create | Popup container |
+| `widget/src/components/SessionForm.tsx` | create | Name + email form |
+| `widget/src/components/MessageList.tsx` | create | Scrollable messages |
+| `widget/src/components/MessageInput.tsx` | create | Text input + send |
+| `widget/src/App.tsx` | create | Root component (props only, no state yet) |
+
+### Do NOT Modify
+
+- `widget/src/main.tsx` — owned by task-10 (mount script)
+
+## Implementation Steps
+
+### Step 1: Create types.ts
+
+```ts
+export interface WidgetMessage {
+  _id: string
+  text: string
+  senderName?: string | null
+  destination: 'to-chat' | 'to-messenger'
+  createdAt: string
+}
+
+export interface WidgetSession {
+  widgetSessionToken: string
+  contactId: string
+  licenseeId: string
+}
+```
+
+### Step 2: FloatingButton
+
+```tsx
+const BUTTON_STYLE: React.CSSProperties = {
+  position: 'fixed',
+  bottom: 24,
+  right: 24,
+  width: 56,
+  height: 56,
+  borderRadius: '50%',
+  background: '#0070f3',
+  border: 'none',
+  cursor: 'pointer',
+  boxShadow: '0 4px 12px rgba(0,0,0,0.3)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 9999,
+}
+```
+
+Show a chat bubble SVG icon when closed, an X when open. Use inline SVG.
+
+### Step 3: ChatPopup
+
+Fixed-position card, 360×500px, bottom-right above the button. Use inline styles. Render `children` inside.
+
+### Step 4: SessionForm
+
+Two text inputs (name, email) + a submit button. Show a loading spinner while `loading` is true. Validate email format client-side before calling `onSubmit`.
+
+### Step 5: MessageList
+
+Scrollable `div` with `overflow-y: auto`. Map `messages` to message bubbles — visitor messages right-aligned (light blue), agent replies left-aligned (white). Auto-scroll to bottom when messages change (use `useEffect` + `useRef` on the container).
+
+### Step 6: MessageInput
+
+`textarea` (resizable 1–3 rows) + a send button. `onSend` called on button click or Enter key (Shift+Enter for newline). Clears input after send.
+
+### Step 7: App.tsx
+
+```tsx
+import { FloatingButton } from './components/FloatingButton'
+import { ChatPopup } from './components/ChatPopup'
+import { SessionForm } from './components/SessionForm'
+import { MessageList } from './components/MessageList'
+import { MessageInput } from './components/MessageInput'
+import type { WidgetMessage, WidgetSession } from './types'
+
+interface AppProps {
+  licenseeApiToken: string
+  isOpen: boolean
+  onToggle: () => void
+  session: WidgetSession | null
+  onSessionCreate: (name: string, email: string) => void
+  messages: WidgetMessage[]
+  onSend: (text: string) => void
+  sessionLoading: boolean
+  sendDisabled: boolean
+}
+
+export function App({ isOpen, onToggle, session, onSessionCreate, messages, onSend, sessionLoading, sendDisabled }: AppProps) {
+  return (
+    <>
+      <FloatingButton onClick={onToggle} isOpen={isOpen} />
+      {isOpen && (
+        <ChatPopup>
+          {!session
+            ? <SessionForm onSubmit={onSessionCreate} loading={sessionLoading} />
+            : (
+              <>
+                <MessageList messages={messages} />
+                <MessageInput onSend={onSend} disabled={sendDisabled} />
+              </>
+            )
+          }
+        </ChatPopup>
+      )}
+    </>
+  )
+}
+```
+
+### Step 8: Verify build
+
+```bash
+cd widget && yarn build
+```
+
+Confirm it compiles without TypeScript errors.
+
+## Testing
+
+- [ ] `cd widget && yarn build` succeeds with no TS errors
+- [ ] Visually inspect by opening `widget/dist/widget.js` as a script in a minimal HTML page
+
+## Documentation / KB Updates
+
+No KB/doc updates required.
+
+## Completion Criteria
+
+- [ ] All 5 components + App.tsx created
+- [ ] `yarn build` in widget/ succeeds
+- [ ] Status updated to `complete` in `status.md`
+
+## Conflict Avoidance Notes
+
+- task-10 owns `widget/src/main.tsx` and will complete App state wiring — do not add state to App.tsx in this task.

--- a/.plans/chat-widget/phase-4/task-09-widget-components/task.md
+++ b/.plans/chat-widget/phase-4/task-09-widget-components/task.md
@@ -40,7 +40,7 @@ The widget renders inside a Shadow DOM root (created in task-10) to isolate its 
 
 `FloatingButton`: `{ onClick: () => void; isOpen: boolean }`
 `ChatPopup`: `{ children: ReactNode }`
-`SessionForm`: `{ onSubmit: (name: string, email: string) => void; loading: boolean }`
+`SessionForm`: `{ onSubmit: (name: string, email: string, phone?: string) => void; loading: boolean }`
 `MessageList`: `{ messages: WidgetMessage[] }`
 `MessageInput`: `{ onSend: (text: string) => void; disabled: boolean }`
 
@@ -129,7 +129,7 @@ Fixed-position card, 360×500px, bottom-right above the button. Use inline style
 
 ### Step 4: SessionForm
 
-Two text inputs (name, email) + a submit button. Show a loading spinner while `loading` is true. Validate email format client-side before calling `onSubmit`.
+Three inputs: name (required), email (required), phone (optional, labeled "Telefone (opcional)") + a submit button. Show a loading spinner while `loading` is true. Validate email format client-side before calling `onSubmit`. Pass `phone` as `undefined` (not empty string) when the field is blank.
 
 ### Step 5: MessageList
 
@@ -154,7 +154,7 @@ interface AppProps {
   isOpen: boolean
   onToggle: () => void
   session: WidgetSession | null
-  onSessionCreate: (name: string, email: string) => void
+  onSessionCreate: (name: string, email: string, phone?: string) => void
   messages: WidgetMessage[]
   onSend: (text: string) => void
   sessionLoading: boolean

--- a/.plans/chat-widget/phase-4/task-10-widget-hooks-mount/status.md
+++ b/.plans/chat-widget/phase-4/task-10-widget-hooks-mount/status.md
@@ -1,0 +1,25 @@
+# Status: Widget Hooks + IIFE Mount Script
+
+**Current Status**: not-started
+**Last Updated**: 2026-06-22
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-06-22 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/chat-widget/phase-4/task-10-widget-hooks-mount/task.md
+++ b/.plans/chat-widget/phase-4/task-10-widget-hooks-mount/task.md
@@ -1,0 +1,183 @@
+# Task: Widget Hooks + IIFE Mount Script
+
+**Plan**: Chat Widget
+**Phase**: 4
+**Task ID (phase-local)**: task-10
+**Task Path**: phase-4/task-10-widget-hooks-mount
+**Depends On**: phase-4/task-09-widget-components
+**JIRA**: N/A
+
+## Objective
+
+Implement the three hooks (`useWidgetSession`, `useWidgetMessages`, `useWidgetSend`) that connect the UI to the backend API, then write the `main.tsx` IIFE mount script that reads `data-licensee` from the `<script>` tag and renders the widget into a Shadow DOM host element.
+
+## Context
+
+**Hooks**:
+
+`useWidgetSession(apiToken)` — manages session in localStorage
+- On first render, checks `localStorage.getItem('ecomanda_session_<apiToken>')` for an existing token
+- Exposes `createSession(name, email)` which POSTs to `/widget/:apiToken/session`, stores the result in localStorage
+- Returns `{ session, createSession, loading }`
+
+`useWidgetMessages(apiToken, session)` — polling loop
+- `setInterval` every 5 seconds calling `GET /widget/:apiToken/messages?sessionToken=...&since=...`
+- Tracks the latest `createdAt` to use as `since` on next poll
+- Merges new messages into state (no duplicates — use `_id` as key)
+- Returns `{ messages }`
+
+`useWidgetSend(apiToken, session)` — send a message
+- POSTs to `/widget/:apiToken/messages`
+- After successful send, triggers an immediate poll (call poll function once)
+- Returns `{ send, sending }`
+
+**Base URL**: The widget bundle is served from the same origin as the ecomanda server. The script tag URL (`document.currentScript.src`) gives us the origin — extract it to build API URLs dynamically.
+
+**Mount script** (`widget/src/main.tsx`):
+1. Read `data-licensee` from the `<script>` tag via `document.currentScript`
+2. Create a `div` host element and append to `document.body`
+3. Attach a Shadow DOM root to it
+4. Inject minimal CSS reset into shadow root
+5. Render `<WidgetRoot>` (stateful wrapper around `App`) into the shadow root via `ReactDOM.createRoot`
+
+**WidgetRoot** lives in `main.tsx` and holds all `useState` + the three hooks.
+
+## Before You Start
+
+- [ ] `git switch main && git pull --rebase origin main`
+- [ ] Verify `phase-4/task-09-widget-components` status is `complete`
+- [ ] Verify backend widget endpoints are running (Phase 3 complete)
+- [ ] Mark this task `in-progress` in `status.md`
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `widget/src/main.tsx` | modify | Replace placeholder with IIFE mount |
+| `widget/src/hooks/useWidgetSession.ts` | create | Session management + localStorage |
+| `widget/src/hooks/useWidgetMessages.ts` | create | Polling hook |
+| `widget/src/hooks/useWidgetSend.ts` | create | Send message hook |
+| `widget/src/api.ts` | create | Thin fetch wrappers for 3 endpoints |
+
+### Do NOT Modify
+
+- `widget/src/components/` — owned by task-09 (do not refactor components here)
+- `widget/src/App.tsx` — read-only in this task; only WidgetRoot (in main.tsx) holds state
+
+## Implementation Steps
+
+### Step 1: Create widget/src/api.ts
+
+Encapsulates all HTTP calls. Accepts `baseUrl` (derived from script src):
+
+```ts
+export async function createSession(baseUrl: string, apiToken: string, name: string, email: string) { ... }
+export async function sendMessage(baseUrl: string, apiToken: string, widgetSessionToken: string, text: string) { ... }
+export async function fetchMessages(baseUrl: string, apiToken: string, widgetSessionToken: string, since?: string) { ... }
+```
+
+All functions use `fetch()` — no external HTTP library needed.
+
+### Step 2: Create useWidgetSession
+
+```ts
+const SESSION_KEY = (token: string) => `ecomanda_session_${token}`
+```
+
+- Read from `localStorage` on init
+- `createSession` calls `api.createSession`, stores JSON stringified result, updates state
+
+### Step 3: Create useWidgetMessages
+
+```ts
+const POLL_INTERVAL_MS = 5000
+```
+
+- `useEffect` starts interval when `session` is not null
+- Clears interval on unmount
+- Tracks `lastSeenAt` ref (ISO string) — update after each poll with the max `createdAt` of returned messages
+- Handles empty response gracefully
+
+### Step 4: Create useWidgetSend
+
+- Sets `sending` state while POST in-flight
+- On success, returns from send call and lets polling pick up the new message (or triggers one immediate poll via a callback)
+
+### Step 5: Write main.tsx
+
+```tsx
+import ReactDOM from 'react-dom/client'
+import { App } from './App'
+import { useWidgetSession } from './hooks/useWidgetSession'
+import { useWidgetMessages } from './hooks/useWidgetMessages'
+import { useWidgetSend } from './hooks/useWidgetSend'
+import { useState } from 'react'
+
+// Resolve base URL from script tag src
+const scriptEl = document.currentScript as HTMLScriptElement | null
+const baseUrl = scriptEl ? new URL(scriptEl.src).origin : ''
+const apiToken = scriptEl?.dataset.licensee ?? ''
+
+function WidgetRoot() {
+  const [isOpen, setIsOpen] = useState(false)
+  const { session, createSession, loading: sessionLoading } = useWidgetSession(apiToken)
+  const { messages } = useWidgetMessages(baseUrl, apiToken, session)
+  const { send, sending } = useWidgetSend(baseUrl, apiToken, session)
+
+  return (
+    <App
+      licenseeApiToken={apiToken}
+      isOpen={isOpen}
+      onToggle={() => setIsOpen(o => !o)}
+      session={session}
+      onSessionCreate={createSession}
+      messages={messages}
+      onSend={send}
+      sessionLoading={sessionLoading}
+      sendDisabled={sending}
+    />
+  )
+}
+
+// Mount into Shadow DOM to isolate from host page styles
+const host = document.createElement('div')
+host.id = 'ecomanda-widget-host'
+document.body.appendChild(host)
+const shadow = host.attachShadow({ mode: 'open' })
+const mountPoint = document.createElement('div')
+shadow.appendChild(mountPoint)
+
+ReactDOM.createRoot(mountPoint).render(<WidgetRoot />)
+```
+
+### Step 6: Build and smoke test
+
+```bash
+cd widget && yarn build
+```
+
+Open a minimal HTML page that loads the built `widget.js` with a real `data-licensee` token. Verify:
+- Floating button appears
+- Clicking opens popup
+- SessionForm submits and stores in localStorage
+- Sending a message routes to the backend
+- Polling shows replies after agent responds
+
+## Testing
+
+- [ ] `cd widget && yarn build` succeeds
+- [ ] Manual smoke: widget loads on a test HTML page, form submits, message round-trip works
+- [ ] `localStorage` key persists session across page reload
+
+## Documentation / KB Updates
+
+After this task completes, run `document-solution` to capture the IIFE Shadow DOM mount pattern and the widget API integration.
+
+## Completion Criteria
+
+- [ ] Three hooks implemented and connected to App via WidgetRoot
+- [ ] IIFE mount reads `data-licensee` from script tag
+- [ ] Shadow DOM isolates widget styles from host page
+- [ ] `yarn build` succeeds
+- [ ] Manual smoke test confirms end-to-end flow
+- [ ] Status updated to `complete` in `status.md`

--- a/.plans/chat-widget/phase-4/task-10-widget-hooks-mount/task.md
+++ b/.plans/chat-widget/phase-4/task-10-widget-hooks-mount/task.md
@@ -17,7 +17,7 @@ Implement the three hooks (`useWidgetSession`, `useWidgetMessages`, `useWidgetSe
 
 `useWidgetSession(apiToken)` — manages session in localStorage
 - On first render, checks `localStorage.getItem('ecomanda_session_<apiToken>')` for an existing token
-- Exposes `createSession(name, email)` which POSTs to `/widget/:apiToken/session`, stores the result in localStorage
+- Exposes `createSession(name, email, phone?)` which POSTs to `/widget/:apiToken/session` (omits `phone` from body when undefined), stores the result in localStorage
 - Returns `{ session, createSession, loading }`
 
 `useWidgetMessages(apiToken, session)` — polling loop
@@ -71,7 +71,7 @@ Implement the three hooks (`useWidgetSession`, `useWidgetMessages`, `useWidgetSe
 Encapsulates all HTTP calls. Accepts `baseUrl` (derived from script src):
 
 ```ts
-export async function createSession(baseUrl: string, apiToken: string, name: string, email: string) { ... }
+export async function createSession(baseUrl: string, apiToken: string, name: string, email: string, phone?: string) { ... }
 export async function sendMessage(baseUrl: string, apiToken: string, widgetSessionToken: string, text: string) { ... }
 export async function fetchMessages(baseUrl: string, apiToken: string, widgetSessionToken: string, since?: string) { ... }
 ```
@@ -85,7 +85,7 @@ const SESSION_KEY = (token: string) => `ecomanda_session_${token}`
 ```
 
 - Read from `localStorage` on init
-- `createSession` calls `api.createSession`, stores JSON stringified result, updates state
+- `createSession(name, email, phone?)` calls `api.createSession` — `phone` passed through if provided, omitted if undefined — stores JSON result, updates state
 
 ### Step 3: Create useWidgetMessages
 

--- a/.plans/chat-widget/phase-4/task-10-widget-hooks-mount/task.md
+++ b/.plans/chat-widget/phase-4/task-10-widget-hooks-mount/task.md
@@ -9,38 +9,62 @@
 
 ## Objective
 
-Implement the three hooks (`useWidgetSession`, `useWidgetMessages`, `useWidgetSend`) that connect the UI to the backend API, then write the `main.tsx` IIFE mount script that reads `data-licensee` from the `<script>` tag and renders the widget into a Shadow DOM host element.
+Implement the three hooks (`useWidgetSession`, `useWidgetMessages`, `useWidgetSend`) that connect the UI to the backend API, then write the `main.tsx` IIFE mount script. The script mounts the widget into a Shadow DOM, exposes a global `window.EcomandaWidget.init()` API for authenticated (support) mode, and falls back to the SessionForm in anonymous (landing page) mode.
 
 ## Context
 
-**Hooks**:
+### Two operating modes
 
-`useWidgetSession(apiToken)` — manages session in localStorage
-- On first render, checks `localStorage.getItem('ecomanda_session_<apiToken>')` for an existing token
-- Exposes `createSession(name, email, phone?)` which POSTs to `/widget/:apiToken/session` (omits `phone` from body when undefined), stores the result in localStorage
+**Mode 1 — Anonymous (landing page)**
+- No data provided at embed time
+- Widget shows a SessionForm (name + email + optional phone) on first open
+- Session stored in `localStorage` after form submission
+
+**Mode 2 — Authenticated (support)**
+- Host page calls `EcomandaWidget.init({ name, email, phone? })` after the user logs in
+- Widget creates the session silently in the background
+- Floating button is available; clicking opens the chat directly (no form)
+
+### Global API: `window.EcomandaWidget`
+
+The IIFE bundle sets `window.EcomandaWidget` **before** React mounts. The object starts with a pending-call buffer to handle the race between the `async` script loading and the host page calling `init()`:
+
+```ts
+window.EcomandaWidget = {
+  init(data) {
+    if (this._handler) {
+      this._handler(data)   // React already mounted — call directly
+    } else {
+      this._pending = data  // buffer until React mounts
+    }
+  },
+  _handler: null,
+  _pending: null,
+}
+```
+
+`WidgetRoot` registers `_handler` on mount and processes `_pending` if it exists.
+
+### Hooks
+
+`useWidgetSession(apiToken)` — session lifecycle
+- On init: reads `localStorage.getItem('ecomanda_session_<apiToken>')` for existing token
+- `createSession(name, email, phone?)` POSTs to `/widget/:apiToken/session`, stores result in localStorage
 - Returns `{ session, createSession, loading }`
 
-`useWidgetMessages(apiToken, session)` — polling loop
-- `setInterval` every 5 seconds calling `GET /widget/:apiToken/messages?sessionToken=...&since=...`
-- Tracks the latest `createdAt` to use as `since` on next poll
-- Merges new messages into state (no duplicates — use `_id` as key)
+`useWidgetMessages(baseUrl, apiToken, session)` — polling
+- `setInterval` every 5 s calling `GET /widget/:apiToken/messages?sessionToken=...&since=...`
+- Tracks `lastSeenAt` ref — send as `since` on next poll for incremental updates
+- Merges into state by `_id` (no duplicates)
+- Starts only when `session` is non-null; clears interval on unmount
 - Returns `{ messages }`
 
-`useWidgetSend(apiToken, session)` — send a message
+`useWidgetSend(baseUrl, apiToken, session)` — send
 - POSTs to `/widget/:apiToken/messages`
-- After successful send, triggers an immediate poll (call poll function once)
+- Exposes `triggerPoll` ref so it can immediately refresh after sending
 - Returns `{ send, sending }`
 
-**Base URL**: The widget bundle is served from the same origin as the ecomanda server. The script tag URL (`document.currentScript.src`) gives us the origin — extract it to build API URLs dynamically.
-
-**Mount script** (`widget/src/main.tsx`):
-1. Read `data-licensee` from the `<script>` tag via `document.currentScript`
-2. Create a `div` host element and append to `document.body`
-3. Attach a Shadow DOM root to it
-4. Inject minimal CSS reset into shadow root
-5. Render `<WidgetRoot>` (stateful wrapper around `App`) into the shadow root via `ReactDOM.createRoot`
-
-**WidgetRoot** lives in `main.tsx` and holds all `useState` + the three hooks.
+**Base URL** is derived from `document.currentScript.src` — same origin as the ecomanda server.
 
 ## Before You Start
 
@@ -53,7 +77,7 @@ Implement the three hooks (`useWidgetSession`, `useWidgetMessages`, `useWidgetSe
 
 | File | Action | Notes |
 |------|--------|-------|
-| `widget/src/main.tsx` | modify | Replace placeholder with IIFE mount |
+| `widget/src/main.tsx` | modify | Replace placeholder; Shadow DOM mount + global API |
 | `widget/src/hooks/useWidgetSession.ts` | create | Session management + localStorage |
 | `widget/src/hooks/useWidgetMessages.ts` | create | Polling hook |
 | `widget/src/hooks/useWidgetSend.ts` | create | Send message hook |
@@ -68,15 +92,48 @@ Implement the three hooks (`useWidgetSession`, `useWidgetMessages`, `useWidgetSe
 
 ### Step 1: Create widget/src/api.ts
 
-Encapsulates all HTTP calls. Accepts `baseUrl` (derived from script src):
+Thin `fetch()` wrappers — no external HTTP library:
 
 ```ts
-export async function createSession(baseUrl: string, apiToken: string, name: string, email: string, phone?: string) { ... }
-export async function sendMessage(baseUrl: string, apiToken: string, widgetSessionToken: string, text: string) { ... }
-export async function fetchMessages(baseUrl: string, apiToken: string, widgetSessionToken: string, since?: string) { ... }
-```
+export async function createSession(
+  baseUrl: string, apiToken: string,
+  name: string, email: string, phone?: string,
+) {
+  const body: Record<string, string> = { name, email }
+  if (phone) body.phone = phone
+  const res = await fetch(`${baseUrl}/widget/${apiToken}/session`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) throw new Error(`Session error ${res.status}`)
+  return res.json()
+}
 
-All functions use `fetch()` — no external HTTP library needed.
+export async function sendMessage(
+  baseUrl: string, apiToken: string,
+  widgetSessionToken: string, text: string,
+) {
+  const res = await fetch(`${baseUrl}/widget/${apiToken}/messages`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ widgetSessionToken, text }),
+  })
+  if (!res.ok) throw new Error(`Send error ${res.status}`)
+  return res.json()
+}
+
+export async function fetchMessages(
+  baseUrl: string, apiToken: string,
+  widgetSessionToken: string, since?: string,
+) {
+  const params = new URLSearchParams({ sessionToken: widgetSessionToken })
+  if (since) params.set('since', since)
+  const res = await fetch(`${baseUrl}/widget/${apiToken}/messages?${params}`)
+  if (!res.ok) throw new Error(`Fetch error ${res.status}`)
+  return res.json() as Promise<{ messages: any[] }>
+}
+```
 
 ### Step 2: Create useWidgetSession
 
@@ -84,8 +141,9 @@ All functions use `fetch()` — no external HTTP library needed.
 const SESSION_KEY = (token: string) => `ecomanda_session_${token}`
 ```
 
-- Read from `localStorage` on init
-- `createSession(name, email, phone?)` calls `api.createSession` — `phone` passed through if provided, omitted if undefined — stores JSON result, updates state
+- Read from `localStorage` on init (parse JSON, fall back to `null`)
+- `createSession(name, email, phone?)` calls `api.createSession`, stores result as JSON string, updates state
+- Returns `{ session, createSession, loading }`
 
 ### Step 3: Create useWidgetMessages
 
@@ -93,36 +151,71 @@ const SESSION_KEY = (token: string) => `ecomanda_session_${token}`
 const POLL_INTERVAL_MS = 5000
 ```
 
-- `useEffect` starts interval when `session` is not null
-- Clears interval on unmount
-- Tracks `lastSeenAt` ref (ISO string) — update after each poll with the max `createdAt` of returned messages
-- Handles empty response gracefully
+- `useEffect` with `session` dependency — starts interval only when `session !== null`
+- `lastSeenAt` via `useRef<string | undefined>` — updated to max `createdAt` after each poll
+- Merges new messages into state: `prev => [...prev, ...newOnes]` after deduplication by `_id`
+- Cleanup: `clearInterval` on unmount / session change
 
 ### Step 4: Create useWidgetSend
 
-- Sets `sending` state while POST in-flight
-- On success, returns from send call and lets polling pick up the new message (or triggers one immediate poll via a callback)
+- `sending` boolean state
+- `pollNow` ref (a function set by `useWidgetMessages` via a shared ref) — call after successful send for immediate refresh
+- Returns `{ send, sending }`
 
 ### Step 5: Write main.tsx
 
 ```tsx
 import ReactDOM from 'react-dom/client'
+import { useState, useEffect } from 'react'
 import { App } from './App'
 import { useWidgetSession } from './hooks/useWidgetSession'
 import { useWidgetMessages } from './hooks/useWidgetMessages'
 import { useWidgetSend } from './hooks/useWidgetSend'
-import { useState } from 'react'
+import type { WidgetSession } from './types'
 
-// Resolve base URL from script tag src
+// Capture script context before async rendering
 const scriptEl = document.currentScript as HTMLScriptElement | null
 const baseUrl = scriptEl ? new URL(scriptEl.src).origin : ''
 const apiToken = scriptEl?.dataset.licensee ?? ''
+
+// Expose global API surface with pending-call buffer
+type InitData = { name: string; email: string; phone?: string }
+interface EcomandaWidgetAPI {
+  init: (data: InitData) => void
+  _handler: ((data: InitData) => void) | null
+  _pending: InitData | null
+}
+
+;(window as any).EcomandaWidget = {
+  init(data: InitData) {
+    if (this._handler) {
+      this._handler(data)
+    } else {
+      this._pending = data
+    }
+  },
+  _handler: null,
+  _pending: null,
+} as EcomandaWidgetAPI
 
 function WidgetRoot() {
   const [isOpen, setIsOpen] = useState(false)
   const { session, createSession, loading: sessionLoading } = useWidgetSession(apiToken)
   const { messages } = useWidgetMessages(baseUrl, apiToken, session)
   const { send, sending } = useWidgetSend(baseUrl, apiToken, session)
+
+  // Register init handler and process any buffered call
+  useEffect(() => {
+    const api = (window as any).EcomandaWidget as EcomandaWidgetAPI
+    api._handler = ({ name, email, phone }) => {
+      createSession(name, email, phone)
+    }
+    if (api._pending) {
+      const { name, email, phone } = api._pending
+      api._pending = null
+      createSession(name, email, phone)
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <App
@@ -139,7 +232,7 @@ function WidgetRoot() {
   )
 }
 
-// Mount into Shadow DOM to isolate from host page styles
+// Mount into Shadow DOM to isolate widget styles from host page
 const host = document.createElement('div')
 host.id = 'ecomanda-widget-host'
 document.body.appendChild(host)
@@ -156,28 +249,59 @@ ReactDOM.createRoot(mountPoint).render(<WidgetRoot />)
 cd widget && yarn build
 ```
 
-Open a minimal HTML page that loads the built `widget.js` with a real `data-licensee` token. Verify:
-- Floating button appears
-- Clicking opens popup
-- SessionForm submits and stores in localStorage
-- Sending a message routes to the backend
-- Polling shows replies after agent responds
+**Mode 1 test** — anonymous, open a minimal HTML page:
+```html
+<script src="http://localhost:5001/widget.js" data-licensee="YOUR_TOKEN" async></script>
+```
+- Floating button appears → click → SessionForm shown → submit → chat opens
+
+**Mode 2 test** — authenticated, same page with extra script:
+```html
+<script src="http://localhost:5001/widget.js" data-licensee="YOUR_TOKEN" async></script>
+<script>
+  // Simulates calling init() after login — may run before or after widget script
+  setTimeout(() => {
+    EcomandaWidget.init({ name: 'Test User', email: 'test@example.com' })
+  }, 500)
+</script>
+```
+- Floating button appears → click → **no form**, chat opens directly
+
+**Buffered init test** — call `EcomandaWidget.init()` synchronously before async script finishes:
+```html
+<script>
+  window.EcomandaWidget = window.EcomandaWidget || { _pending: null, _handler: null }
+  window.EcomandaWidget.init = function(d) { this._pending = d }
+  EcomandaWidget.init({ name: 'Early User', email: 'early@example.com' })
+</script>
+<script src="http://localhost:5001/widget.js" data-licensee="YOUR_TOKEN" async></script>
+```
+- Widget mounts and processes the buffered call — form still skipped
 
 ## Testing
 
-- [ ] `cd widget && yarn build` succeeds
-- [ ] Manual smoke: widget loads on a test HTML page, form submits, message round-trip works
-- [ ] `localStorage` key persists session across page reload
+- [ ] `cd widget && yarn build` succeeds with no TS errors
+- [ ] Mode 1 smoke: form shown for anonymous visitor, session stored in localStorage
+- [ ] Mode 2 smoke: `init()` called after script load skips form, session created silently
+- [ ] Buffered smoke: `init()` called before script load still works after mount
+- [ ] `localStorage` key persists session across page reload (both modes)
+- [ ] Polling picks up agent reply within 10s
 
 ## Documentation / KB Updates
 
-After this task completes, run `document-solution` to capture the IIFE Shadow DOM mount pattern and the widget API integration.
+After this task completes, run `document-solution` to create `docs/kb/features/chat-widget.md` covering:
+- Two modes (anonymous vs authenticated)
+- `EcomandaWidget.init()` API and buffering pattern
+- IIFE Shadow DOM mount
+- Backend API endpoints
+- Web contact guard
 
 ## Completion Criteria
 
 - [ ] Three hooks implemented and connected to App via WidgetRoot
+- [ ] `window.EcomandaWidget.init()` works in both call-order scenarios (before and after mount)
 - [ ] IIFE mount reads `data-licensee` from script tag
 - [ ] Shadow DOM isolates widget styles from host page
 - [ ] `yarn build` succeeds
-- [ ] Manual smoke test confirms end-to-end flow
+- [ ] All three smoke tests pass
 - [ ] Status updated to `complete` in `status.md`

--- a/.plans/chat-widget/phase-4/task-11-express-static/status.md
+++ b/.plans/chat-widget/phase-4/task-11-express-static/status.md
@@ -1,0 +1,25 @@
+# Status: Express Static Serve widget.js
+
+**Current Status**: not-started
+**Last Updated**: 2026-06-22
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-06-22 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/chat-widget/phase-4/task-11-express-static/task.md
+++ b/.plans/chat-widget/phase-4/task-11-express-static/task.md
@@ -1,0 +1,137 @@
+# Task: Express Static Serve widget.js
+
+**Plan**: Chat Widget
+**Phase**: 4
+**Task ID (phase-local)**: task-11
+**Task Path**: phase-4/task-11-express-static
+**Depends On**: phase-4/task-10-widget-hooks-mount
+**JIRA**: N/A
+
+## Objective
+
+Serve `widget/dist/widget.js` as a static file at `/widget.js` from the Express server, update the Heroku Procfile/build step to compile the widget on deploy, and document the embed snippet for licensees.
+
+## Context
+
+The Express app already serves the React SPA from `client/build` or `client/dist` via `express.static(frontendDistDir)`. The widget bundle needs an additional static serve pointing at `widget/dist/`.
+
+`src/config/frontend-paths.ts` defines `frontendDistDir`. We'll add a widget equivalent and wire it in `src/config/http.ts`.
+
+**Heroku build**: `package.json` (root) needs a `heroku-postbuild` (or `build`) script that runs `cd widget && yarn install && yarn build` after the main build.
+
+**Embed snippet** (to show licensees):
+```html
+<script src="https://your-ecomanda-domain.com/widget.js" data-licensee="YOUR_API_TOKEN" async></script>
+```
+
+## Before You Start
+
+- [ ] `git switch main && git pull --rebase origin main`
+- [ ] Verify `phase-4/task-10-widget-hooks-mount` status is `complete`
+- [ ] Verify `widget/dist/widget.js` exists after running `cd widget && yarn build`
+- [ ] Read `src/config/frontend-paths.ts` — pattern for static path resolution
+- [ ] Read `src/config/http.ts` — where `express.static` is called
+- [ ] Mark this task `in-progress` in `status.md`
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/config/frontend-paths.ts` | modify | Add `widgetDistDir` export |
+| `src/config/http.ts` | modify | Add `express.static(widgetDistDir)` before SPA catch-all |
+| `package.json` (root) | modify | Add widget build to postbuild/build script |
+| `widget/.gitignore` | verify | Confirm `dist/` is ignored |
+
+### Do NOT Modify
+
+- `widget/src/` — owned by task-09 and task-10
+- `src/config/routes.ts` — widget API routes already registered in task-06
+
+## Implementation Steps
+
+### Step 1: Update frontend-paths.ts
+
+```ts
+import path from 'path'
+
+export const frontendDistDir = path.join(__dirname, '..', '..', 'client', 'dist')
+export const widgetDistDir = path.join(__dirname, '..', '..', 'widget', 'dist')
+```
+
+(Adjust relative path depth based on actual file location — verify with `__dirname` at runtime.)
+
+### Step 2: Serve widget static in http.ts
+
+In `src/config/http.ts`, after the existing `app.use(express.static(frontendDistDir))` line:
+
+```ts
+import { frontendDistDir, widgetDistDir } from './frontend-paths'
+// ...
+app.use(express.static(frontendDistDir))
+app.use(express.static(widgetDistDir))   // serves widget.js at /widget.js
+```
+
+The `/widget.js` path is served before the SPA catch-all route, so it won't be intercepted.
+
+### Step 3: Add widget build to root package.json
+
+In root `package.json`, find the `build` or `heroku-postbuild` script and add the widget step:
+
+```json
+"scripts": {
+  "build": "tsc && cd client && yarn build && cd ../widget && yarn install --frozen-lockfile && yarn build",
+  "heroku-postbuild": "cd client && yarn install && yarn build && cd ../widget && yarn install --frozen-lockfile && yarn build"
+}
+```
+
+Verify what the existing build script looks like before modifying — match the pattern.
+
+### Step 4: Add widget/dist to .gitignore
+
+Confirm `widget/dist/` is in `widget/.gitignore`. The built artifact is not committed — it's built at deploy time.
+
+### Step 5: Smoke test
+
+```bash
+# Start dev server
+yarn dev:server
+```
+
+```bash
+curl http://localhost:5001/widget.js | head -5
+```
+
+Confirm the response is JavaScript (not 404 or HTML).
+
+Create a minimal `test.html`:
+```html
+<!DOCTYPE html>
+<html>
+<body>
+  <h1>Widget test host page</h1>
+  <script src="http://localhost:5001/widget.js" data-licensee="YOUR_TEST_API_TOKEN" async></script>
+</body>
+</html>
+```
+
+Open in browser and verify the widget floating button appears.
+
+## Testing
+
+- [ ] `curl /widget.js` returns JS content (not 404)
+- [ ] Widget loads on a test HTML page opened from a different origin
+- [ ] Existing SPA routes still work (no regression)
+- [ ] `yarn build` (root) compiles both client and widget
+
+## Documentation / KB Updates
+
+- [ ] Run `document-solution` to create a KB doc: `docs/kb/features/chat-widget.md` covering the full architecture (Contact web type, 3 API endpoints, polling, IIFE bundle, Shadow DOM mount, embed snippet, web contact guard).
+- [ ] Run `check-kb-index` after creating the KB doc
+
+## Completion Criteria
+
+- [ ] `GET /widget.js` returns the widget bundle
+- [ ] Widget renders on external HTML page
+- [ ] Heroku build script includes widget compilation step
+- [ ] KB doc created for the chat widget feature
+- [ ] Status updated to `complete` in `status.md`


### PR DESCRIPTION
## Plan: Chat Widget

Embeddable Intercom-style chat widget served as `/widget.js` from the ecomanda Express server. Visitors on external client websites fill a name/email form and chat with the licensee's agents via the existing LocalChat plugin. Agent replies reach the widget via 5-second polling.

**Type**: Type 1 (Product)
**Phases**: 4 **Tasks**: 11
**PR Strategy**: single
**Assigned Dev**: Alan Costa Facchini

### Task Summary

| Phase | Tasks |
|-------|-------|
| 1 — Foundation | Contact `web` type + `widgetSessionToken`; MessageRepository `findByRoom` |
| 2 — Use Cases | `CreateWidgetSession`, `SendWidgetMessage`, `GetWidgetMessages` |
| 3 — Routes & Guard | Widget router (`/widget/:apiToken/*`); `SendMessageToMessenger` web-contact bypass |
| 4 — Frontend | Vite IIFE bundle; React components; hooks + mount; Express static serve |

> Merge this PR before running `/execute-plan chat-widget` or any `/execute-task`.