### PR TITLE
feat(users): add blockedLicensees field to restrict licensee visibility per user

### DIFF
--- a/src/app/controllers/LicenseesController.spec.ts
+++ b/src/app/controllers/LicenseesController.spec.ts
@@ -20,6 +20,7 @@ async function runValidations(controller, req) {
 
 function buildController() {
   const licenseeRepository = new LicenseeRepositoryMemory()
+  const userRepository = { findFirst: jest.fn().mockResolvedValue({ blockedLicensees: [] }) }
   const licenseesQueryInstance = {
     page: jest.fn(),
     limit: jest.fn(),
@@ -28,6 +29,7 @@ function buildController() {
     filterByWhatsappDefault: jest.fn(),
     filterByExpression: jest.fn(),
     filterByActive: jest.fn(),
+    filterExcludeLicensees: jest.fn(),
     all: jest.fn(),
   }
   const createLicenseesQuery = jest.fn().mockReturnValue(licenseesQueryInstance)
@@ -43,6 +45,7 @@ function buildController() {
 
   const controller = new LicenseesController({
     licenseeRepository,
+    userRepository,
     createLicenseesQuery,
     createLicensee,
     updateLicensee,
@@ -52,6 +55,7 @@ function buildController() {
   return {
     controller,
     licenseeRepository,
+    userRepository,
     createLicenseesQuery,
     licenseesQueryInstance,
     createLicensee,
@@ -233,7 +237,7 @@ describe('LicenseesController delegation', () => {
     const licensees = [{ _id: 'licensee-id' }]
     licenseesQueryInstance.all.mockResolvedValue(licensees)
 
-    const req = { query: { page: '1', limit: '3', expression: 'Alca' } }
+    const req = { query: { page: '1', limit: '3', expression: 'Alca' }, userId: 'user-id' }
     const res = buildResponse()
 
     await controller.index(req, res)
@@ -243,6 +247,32 @@ describe('LicenseesController delegation', () => {
     expect(licenseesQueryInstance.filterByExpression).toHaveBeenCalledWith('Alca')
     expect(res.status).toHaveBeenCalledWith(200)
     expect(res.send).toHaveBeenCalledWith(licensees)
+  })
+
+  it('applies filterExcludeLicensees when user has blockedLicensees', async () => {
+    const { controller, licenseesQueryInstance, userRepository } = buildController()
+    const blockedId = 'blocked-licensee-id'
+    userRepository.findFirst.mockResolvedValue({ blockedLicensees: [blockedId] })
+    licenseesQueryInstance.all.mockResolvedValue([])
+
+    const req = { query: {}, userId: 'user-id' }
+    const res = buildResponse()
+
+    await controller.index(req, res)
+
+    expect(licenseesQueryInstance.filterExcludeLicensees).toHaveBeenCalledWith([blockedId])
+  })
+
+  it('does not call filterExcludeLicensees when user has no blockedLicensees', async () => {
+    const { controller, licenseesQueryInstance } = buildController()
+    licenseesQueryInstance.all.mockResolvedValue([])
+
+    const req = { query: {}, userId: 'user-id' }
+    const res = buildResponse()
+
+    await controller.index(req, res)
+
+    expect(licenseesQueryInstance.filterExcludeLicensees).not.toHaveBeenCalled()
   })
 
   it('delegates setDialogWebhook to the use case and returns status 200', async () => {

--- a/src/app/controllers/LicenseesController.ts
+++ b/src/app/controllers/LicenseesController.ts
@@ -6,6 +6,7 @@ import { SyncBaileysDirectory } from '../usecases/licensees/SyncBaileysDirectory
 
 class LicenseesController {
   licenseeRepository: any
+  userRepository: any
   createLicenseesQuery: any
   createLicensee: any
   updateLicensee: any
@@ -16,6 +17,7 @@ class LicenseesController {
 
   constructor({
     licenseeRepository,
+    userRepository,
     createLicenseesQuery,
     createLicensee,
     updateLicensee,
@@ -27,6 +29,7 @@ class LicenseesController {
     socketManager,
   }: Record<string, any> = {}) {
     this.licenseeRepository = licenseeRepository
+    this.userRepository = userRepository
     this.createLicenseesQuery = createLicenseesQuery
     this.createLicensee = createLicensee
     this.updateLicensee = updateLicensee
@@ -143,6 +146,11 @@ class LicenseesController {
 
       if (req.query.active) {
         licenseesQuery.filterByActive()
+      }
+
+      const user = await this.userRepository.findFirst({ _id: req.userId })
+      if (user?.blockedLicensees?.length) {
+        licenseesQuery.filterExcludeLicensees(user.blockedLicensees)
       }
 
       const licensees = await licenseesQuery.all()

--- a/src/app/models/User.spec.ts
+++ b/src/app/models/User.spec.ts
@@ -53,6 +53,7 @@ describe('User', () => {
       const user = new User()
 
       expect(user.active).toEqual(true)
+      expect(user.blockedLicensees).toEqual([])
     })
   })
 

--- a/src/app/models/User.ts
+++ b/src/app/models/User.ts
@@ -48,6 +48,10 @@ const userSchema = new Schema(
         'Licensee: Você deve preencher o campo',
       ],
     },
+    blockedLicensees: {
+      type: [{ type: ObjectId, ref: 'Licensee' }],
+      default: [],
+    },
   },
   { timestamps: true },
 )

--- a/src/app/queries/LicenseesQuery.spec.ts
+++ b/src/app/queries/LicenseesQuery.spec.ts
@@ -222,4 +222,34 @@ describe('LicenseesQuery', () => {
       expect(records).not.toEqual(expect.arrayContaining([expect.objectContaining({ _id: licenseeInactive._id })]))
     })
   })
+
+  describe('filterExcludeLicensees', () => {
+    it('excludes licensees whose ids are in the blocked list', async () => {
+      const licenseeRepository = new LicenseeRepositoryDatabase()
+      const licensee1 = await licenseeRepository.create(licenseeFactory.build())
+      const licensee2 = await licenseeRepository.create(licenseeFactory.build())
+      const licensee3 = await licenseeRepository.create(licenseeFactory.build())
+
+      const licenseesQuery = buildLicenseesQuery()
+      licenseesQuery.filterExcludeLicensees([licensee2._id])
+      const records = await licenseesQuery.all()
+
+      expect(records.length).toEqual(2)
+      expect(records).toEqual(expect.arrayContaining([expect.objectContaining({ _id: licensee1._id })]))
+      expect(records).toEqual(expect.arrayContaining([expect.objectContaining({ _id: licensee3._id })]))
+      expect(records).not.toEqual(expect.arrayContaining([expect.objectContaining({ _id: licensee2._id })]))
+    })
+
+    it('returns all licensees when the excluded list is empty', async () => {
+      const licenseeRepository = new LicenseeRepositoryDatabase()
+      await licenseeRepository.create(licenseeFactory.build())
+      await licenseeRepository.create(licenseeFactory.build())
+
+      const licenseesQuery = buildLicenseesQuery()
+      licenseesQuery.filterExcludeLicensees([])
+      const records = await licenseesQuery.all()
+
+      expect(records.length).toEqual(2)
+    })
+  })
 })

--- a/src/app/queries/LicenseesQuery.ts
+++ b/src/app/queries/LicenseesQuery.ts
@@ -9,6 +9,7 @@ class LicenseesQuery {
   whatsappClause: any
   expressionClause: any
   expressionActive: any
+  excludedIdsClause: any[]
 
   constructor({ licenseeRepository }: { licenseeRepository?: any } = {}) {
     this.licenseeRepository = licenseeRepository
@@ -42,6 +43,10 @@ class LicenseesQuery {
     this.expressionActive = true
   }
 
+  filterExcludeLicensees(ids: any[]) {
+    this.excludedIdsClause = ids
+  }
+
   async all() {
     const query = new QueryBuilder(this.licenseeRepository.model())
     query.sortBy('createdAt', 1)
@@ -58,7 +63,13 @@ class LicenseesQuery {
 
     if (this.expressionClause) query.filterByExpression(['name', 'email', 'phone'], this.expressionClause)
 
-    return await query.getQuery().exec()
+    const mongooseQuery = query.getQuery()
+
+    if (this.excludedIdsClause?.length) {
+      mongooseQuery.where('_id').nin(this.excludedIdsClause)
+    }
+
+    return await mongooseQuery.exec()
   }
 }
 

--- a/src/app/routes/resources-routes.ts
+++ b/src/app/routes/resources-routes.ts
@@ -61,6 +61,7 @@ const usersController = new UsersController({
 })
 const licenseesController = new LicenseesController({
   licenseeRepository,
+  userRepository,
   createLicenseesQuery: () => new LicenseesQuery({ licenseeRepository }),
   createLicensee: new CreateLicensee({ licenseeRepository }),
   updateLicensee: new UpdateLicensee({ licenseeRepository }),


### PR DESCRIPTION
## Summary

- Adds `blockedLicensees: [ObjectId]` array field to the `User` model (defaults to `[]`)
- Adds `filterExcludeLicensees(ids)` method to `LicenseesQuery` using MongoDB `$nin`
- `LicenseesController.index` loads the authenticated user's `blockedLicensees` and applies the filter for **all roles** — covers the listing page, combobox searches, and `SelectLicenseeModal` (all route through `GET /resources/licensees`)
- No UI changes needed — blocked licensees are managed directly via MongoDB shell/Compass

**How to add a blocked licensee via Mongo shell:**
```js
db.users.updateOne(
  { _id: ObjectId("<user-id>") },
  { $addToSet: { blockedLicensees: ObjectId("<licensee-id>") } }
)
```

## Test plan

- [ ] `LicenseesQuery` — `filterExcludeLicensees` excludes blocked ids; returns all when list is empty
- [ ] `LicenseesController` — applies `filterExcludeLicensees` when user has blocked licensees; skips when none
- [ ] `User` model — `blockedLicensees` defaults to `[]`