### PR TITLE
plan(app-i18n): App Internationalization PT/EN

### DIFF
--- a/.plans/README.md
+++ b/.plans/README.md
@@ -24,6 +24,7 @@ Git-native Markdown plans for multi-step work.
 |---|------|--------|--------|-------------|
 | 2 | [MongoDB → PostgreSQL](./mongo-to-postgres/overview.md) | `mongo-to-postgres/` | not-started | Migrate all persistent data from MongoDB/Mongoose to PostgreSQL/Prisma using dual-write strategy; prerequisite: remove-pdv complete |
 | 3 | [Backend Type Narrowing](./type-backend/overview.md) | `type-backend/` | not-started | Replace `any` with interfaces across models, repositories, use cases, controllers, and plugins — 3 phases, 11 tasks |
+| 4 | [App Internationalization (PT/EN)](./app-i18n/overview.md) | `app-i18n/` | not-started | PT/EN language selection on login + onboarding, persisted in user.language, applied app-wide — 3 phases, 8 tasks |
 
 ---
 

--- a/.plans/app-i18n/overview.md
+++ b/.plans/app-i18n/overview.md
@@ -1,0 +1,111 @@
+# Plan: App Internationalization (PT/EN)
+
+**Status**: not-started
+**Created**: 2026-06-24
+**Last Updated**: 2026-06-24
+**Assigned Dev**: Alan Costa Facchini
+**PR Strategy**: single
+
+## Objective
+
+Add Portuguese/English language selection throughout the app. Users choose their language on the login page (persisted in localStorage) and during onboarding (persisted in the User document); after login the app renders in the user's saved language. Every hardcoded string in the frontend is externalized to translation files.
+
+## Scope
+
+### In Scope
+- Install `react-i18next` + `i18next` on the client
+- `client/src/i18n/` — locale files (`pt.json`, `en.json`), i18next config, `LanguageSwitcher` component
+- `IUser.language` field — type, backend model, OnboardingController
+- MongoDB migration script to backfill `language: 'pt'` on existing users
+- Language switcher on login page (persisted to localStorage)
+- Language switcher on onboarding wizard (sent in POST /login/onboarding payload)
+- Post-login language hydration: call `i18n.changeLanguage(user.language)` after `fetchLoggedUser()` in both `SignIn/index.tsx` and `routes.tsx`
+- All user-facing strings in `client/src/`: labels, placeholders, error messages, validation errors, nav items, empty states
+
+### Out of Scope
+- Backend i18n (error messages remain in English/neutral; frontend maps keys to human-readable text in pt.json/en.json)
+- Languages beyond Portuguese and English — enum is `'pt' | 'en'` only for this plan
+- Email templates or external notification strings
+- Admin-only routes in Express (backend API responses, not end-user text)
+
+## Kill Criteria
+- If `react-i18next` or `i18next` ships a breaking API change before this plan completes that would invalidate the wiring approach
+- If a decision is made to adopt a full server-side rendering strategy that changes how i18n is initialized client-side
+
+## Phases
+
+| Phase | Name | Tasks | Dependencies | Description |
+|-------|------|-------|--------------|-------------|
+| 1 | Infrastructure | task-01, task-02 | None | i18n client setup + backend language field (parallel) |
+| 2 | Public Entry Points | task-03, task-04 | Phase 1 | Login page + onboarding wizard (sequential — both write to locale files) |
+| 3 | Full App Translation | task-05 → task-08 | Phase 2 | Navbar, all authenticated pages (sequential chain — all write to locale files) |
+
+## Task Summary
+
+| Task Path | Title | Phase | Status | Depends On |
+|-----------|-------|-------|--------|------------|
+| phase-1/task-01-i18n-setup | i18n Client Infrastructure | 1 | not-started | — |
+| phase-1/task-02-user-model-backend | User Model Language Field + Migration Script | 1 | not-started | — |
+| phase-2/task-03-login-i18n | Login Page i18n + Language Switcher | 2 | not-started | phase-1/task-01-i18n-setup, phase-1/task-02-user-model-backend |
+| phase-2/task-04-onboarding-i18n | Onboarding Wizard i18n + Language Switcher | 2 | not-started | phase-2/task-03-login-i18n |
+| phase-3/task-05-navbar-layout | Navbar + BaseLayout i18n | 3 | not-started | phase-2/task-04-onboarding-i18n |
+| phase-3/task-06-licensees | Licensees Pages i18n | 3 | not-started | phase-3/task-05-navbar-layout |
+| phase-3/task-07-users-sectors-dashboard | Users + Sectors + Dashboard i18n | 3 | not-started | phase-3/task-06-licensees |
+| phase-3/task-08-remaining-pages | Contacts + Templates + Triggers + Messages + Chat + Reports i18n | 3 | not-started | phase-3/task-07-users-sectors-dashboard |
+
+> **Note on phase-3 sequencing**: Tasks 05–08 form a sequential chain even though they are all in Phase 3. They cannot run in parallel because all of them append to `pt.json` and `en.json`. Each task must complete before the next starts to avoid merge conflicts in the locale files.
+
+## Branch Convention
+
+Pattern: `plan/app-i18n/{task-path}`
+
+Example branches:
+- `plan/app-i18n/phase-1/task-01-i18n-setup`
+- `plan/app-i18n/phase-2/task-03-login-i18n`
+
+Base branch: `main`
+
+## Key Files
+
+| File/Directory | Relevance |
+|----------------|-----------|
+| `client/src/i18n/` | New directory — i18next config + locale files (created in task-01) |
+| `client/src/i18n/locales/pt.json` | Portuguese translations — ALL tasks in phases 2-3 append to this file |
+| `client/src/i18n/locales/en.json` | English translations — ALL tasks in phases 2-3 append to this file |
+| `client/src/components/LanguageSwitcher/index.tsx` | Reusable PT/EN toggle (created in task-01, consumed in task-03 + task-04) |
+| `client/src/index.tsx` | App entry — wrap with `I18nextProvider` (task-01) |
+| `client/src/types/user.ts` | Add `language: 'pt' \| 'en'` to `IUser` (task-01) |
+| `client/src/pages/routes.tsx` | Language hydration on session restore (task-03) |
+| `client/src/pages/SignIn/index.tsx` | Login page — strings + language switcher + post-login hydration (task-03) |
+| `client/src/pages/SignIn/OnboardingModal.tsx` | Onboarding — strings + Yup schemas + switcher + language payload (task-04) |
+| `src/app/models/User.ts` | Add `language` field (task-02) |
+| `src/app/controllers/OnboardingController.ts` | Accept + persist `language` in POST /login/onboarding (task-02) |
+| `scripts/migrate-user-language.js` | MongoDB shell script — backfill `language: 'pt'` (task-02) |
+
+## Risks
+
+- **Yup schemas are static** — Yup validation error messages are created once at module level. To make them react to language changes, schemas must be recreated inside the component or via a factory function called with `t`. Mitigation: use `useMemo(() => buildSchema(t), [t])` pattern in OnboardingModal.
+- **Locale file merge conflicts** — Multiple phase-3 tasks all append to the same `pt.json`/`en.json`. Mitigation: tasks are sequenced, each completing before the next starts.
+- **Session restore language** — `routes.tsx` calls `fetchLoggedUser()` on mount; if the user refreshes mid-session, i18n must re-apply `user.language`. Mitigation: task-03 adds the `i18n.changeLanguage(user.language)` call in the `routes.tsx` effect.
+- **Existing tests** — OnboardingModal tests use static Yup snapshots; if schemas become dynamic, specs may need updating. Mitigation: task-04 owns the spec update.
+
+## Success Criteria
+
+- [ ] Language switcher visible and functional on login page (localStorage-persisted)
+- [ ] Language switcher visible and functional on onboarding wizard
+- [ ] Onboarding submits selected language; `user.language` is stored in MongoDB
+- [ ] After login, the app renders in the language stored in `user.language`
+- [ ] After page refresh (session restore), language is correctly re-applied
+- [ ] All user-facing strings across the app are translated in both `pt.json` and `en.json`
+- [ ] No hardcoded Portuguese strings remain in `client/src/`
+- [ ] MongoDB migration script provided and documented
+- [ ] All pre-existing Vitest tests pass
+- [ ] New i18n logic and LanguageSwitcher component have test coverage
+- [ ] `pre-commit-check` passes on final commit
+
+## References
+
+- **JIRA Epic**: N/A
+- **Weekly Plan Brief**: N/A
+- **Related Plans**: [Onboarding Wizard](../onboarding-wizard/overview.md) (prerequisite — completed 2026-06-05)
+- **Rock Alignment**: N/A

--- a/.plans/app-i18n/overview.md
+++ b/.plans/app-i18n/overview.md
@@ -38,7 +38,7 @@ Add Portuguese/English language selection throughout the app. Users choose their
 |-------|------|-------|--------------|-------------|
 | 1 | Infrastructure | task-01, task-02 | None | i18n client setup + backend language field (parallel) |
 | 2 | Public Entry Points | task-03, task-04 | Phase 1 | Login page + onboarding wizard (sequential — both write to locale files) |
-| 3 | Full App Translation | task-05 → task-08 | Phase 2 | Navbar, all authenticated pages (sequential chain — all write to locale files) |
+| 3 | Full App Translation | task-05 → task-09 | Phase 2 | Navbar, all authenticated pages, chat widget (task-05→08 sequential chain; task-09 independent) |
 
 ## Task Summary
 
@@ -52,8 +52,9 @@ Add Portuguese/English language selection throughout the app. Users choose their
 | phase-3/task-06-licensees | Licensees Pages i18n | 3 | not-started | phase-3/task-05-navbar-layout |
 | phase-3/task-07-users-sectors-dashboard | Users + Sectors + Dashboard i18n | 3 | not-started | phase-3/task-06-licensees |
 | phase-3/task-08-remaining-pages | Contacts + Templates + Triggers + Messages + Chat + Reports i18n | 3 | not-started | phase-3/task-07-users-sectors-dashboard |
+| phase-3/task-09-widget-i18n | Chat Widget i18n (translations map + language prop threading) | 3 | not-started | phase-1/task-01-i18n-setup |
 
-> **Note on phase-3 sequencing**: Tasks 05–08 form a sequential chain even though they are all in Phase 3. They cannot run in parallel because all of them append to `pt.json` and `en.json`. Each task must complete before the next starts to avoid merge conflicts in the locale files.
+> **Note on phase-3 sequencing**: Tasks 05–08 form a sequential chain because all of them append to `pt.json` and `en.json` — they cannot run in parallel. Task-09 is independent (owns only `widget/src/`) and can run alongside any of tasks 05–08.
 
 ## Branch Convention
 
@@ -81,6 +82,8 @@ Base branch: `main`
 | `src/app/models/User.ts` | Add `language` field (task-02) |
 | `src/app/controllers/OnboardingController.ts` | Accept + persist `language` in POST /login/onboarding (task-02) |
 | `scripts/migrate-user-language.js` | MongoDB shell script — backfill `language: 'pt'` (task-02) |
+| `widget/src/translations.ts` | New file — lightweight `{ pt, en }` string map (no react-i18next) — task-09 |
+| `widget/src/main.tsx` | Add `language` to `InitData`, read `data-language` from script tag — task-09 |
 
 ## Risks
 
@@ -99,6 +102,8 @@ Base branch: `main`
 - [ ] All user-facing strings across the app are translated in both `pt.json` and `en.json`
 - [ ] No hardcoded Portuguese strings remain in `client/src/`
 - [ ] MongoDB migration script provided and documented
+- [ ] Chat widget renders in PT/EN via `data-language` and `EcomandaWidget.init({ language })`
+- [ ] No i18n library added to `widget/package.json`
 - [ ] All pre-existing Vitest tests pass
 - [ ] New i18n logic and LanguageSwitcher component have test coverage
 - [ ] `pre-commit-check` passes on final commit

--- a/.plans/app-i18n/phase-1/task-01-i18n-setup/status.md
+++ b/.plans/app-i18n/phase-1/task-01-i18n-setup/status.md
@@ -1,0 +1,25 @@
+# Status: i18n Client Infrastructure
+
+**Current Status**: not-started
+**Last Updated**: 2026-06-24
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-06-24 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/app-i18n/phase-1/task-01-i18n-setup/task.md
+++ b/.plans/app-i18n/phase-1/task-01-i18n-setup/task.md
@@ -1,0 +1,240 @@
+# Task: i18n Client Infrastructure
+
+**Plan**: App Internationalization (PT/EN)
+**Phase**: 1
+**Task ID (phase-local)**: task-01
+**Task Path**: phase-1/task-01-i18n-setup
+**Depends On**: None
+**JIRA**: N/A
+
+## Objective
+
+Install `react-i18next` + `i18next`, create the locale file structure, configure i18next, create the reusable `LanguageSwitcher` component, and update `IUser` with the language field — so every subsequent task can import `useTranslation` and the switcher without any setup work.
+
+## Context
+
+The app has zero i18n infrastructure. All strings are hardcoded Portuguese. This task lays the foundation every other task depends on.
+
+Key conventions to match:
+- Context pattern: `client/src/contexts/App/index.tsx` — `createContext` + `useContext` + typed interface + named `Provider` export
+- Entry file: `client/src/index.tsx` — wraps `<App />` with `<AppContextProvider>`. Add `<I18nextProvider>` here as well.
+- Types: `client/src/types/user.ts` — `IUser` interface, currently has no `language` field.
+- Bootstrap Flatly theme is active — LanguageSwitcher should use Bootstrap button styles (`btn btn-sm btn-outline-secondary` / `btn btn-sm btn-secondary` for active).
+- Package manager: `yarn` (run `yarn add` inside `client/`).
+
+Look up the latest versions before installing:
+```bash
+cd client && npm show react-i18next version && npm show i18next version
+```
+
+## Before You Start
+
+- [ ] Switch to the task branch: `git switch main && git pull --rebase origin main && git switch -c plan/app-i18n/phase-1/task-01-i18n-setup`
+- [ ] Verify task-02 is NOT a dependency (tasks 01 and 02 are parallel — start independently)
+- [ ] Check this task's `status.md` — must be `not-started`
+- [ ] Mark this task `in-progress` in `status.md` before proceeding
+- [ ] Look up current package versions (never install from memory — see CLAUDE.md)
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `client/package.json` | modify | Add `react-i18next` and `i18next` dependencies |
+| `client/src/i18n/index.ts` | create | i18next configuration and init |
+| `client/src/i18n/locales/pt.json` | create | Scaffolded with empty section keys only — tasks 03–08 populate content |
+| `client/src/i18n/locales/en.json` | create | Same structure as pt.json, empty sections |
+| `client/src/components/LanguageSwitcher/index.tsx` | create | PT/EN toggle component |
+| `client/src/components/LanguageSwitcher/index.spec.tsx` | create | Component tests |
+| `client/src/types/user.ts` | modify | Add `language: 'pt' \| 'en'` to `IUser` |
+| `client/src/index.tsx` | modify | Wrap `<App>` with `<I18nextProvider i18n={i18n}>` |
+
+### Do NOT Modify
+
+- `client/src/pages/SignIn/index.tsx` — owned by phase-2/task-03-login-i18n
+- `client/src/pages/SignIn/OnboardingModal.tsx` — owned by phase-2/task-04-onboarding-i18n
+- `client/src/contexts/App/index.tsx` — language concerns live in i18n module, not AppContext
+- `src/app/models/User.ts` — owned by phase-1/task-02-user-model-backend
+
+## Implementation Steps
+
+### Step 1: Install packages
+
+```bash
+# Look up versions first
+cd client && npm show react-i18next version && npm show i18next version
+# Then install with exact versions retrieved
+yarn add react-i18next@<version> i18next@<version>
+```
+
+### Step 2: Create i18n configuration (`client/src/i18n/index.ts`)
+
+```typescript
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+import pt from './locales/pt.json'
+import en from './locales/en.json'
+
+const LANGUAGE_KEY = '@ecomanda-delivery-language'
+
+export function saveLanguage(lang: 'pt' | 'en'): void {
+  localStorage.setItem(LANGUAGE_KEY, lang)
+}
+
+export function loadLanguage(): 'pt' | 'en' {
+  const stored = localStorage.getItem(LANGUAGE_KEY)
+  return stored === 'en' ? 'en' : 'pt'
+}
+
+i18n
+  .use(initReactI18next)
+  .init({
+    resources: {
+      pt: { translation: pt },
+      en: { translation: en },
+    },
+    lng: loadLanguage(),
+    fallbackLng: 'pt',
+    interpolation: { escapeValue: false },
+  })
+
+i18n.on('languageChanged', (lang) => {
+  saveLanguage(lang as 'pt' | 'en')
+})
+
+export default i18n
+```
+
+### Step 3: Create scaffolded locale files
+
+`client/src/i18n/locales/pt.json` — empty sections as placeholders (tasks 03–08 fill in the keys):
+```json
+{
+  "login": {},
+  "onboarding": {},
+  "navbar": {},
+  "licensees": {},
+  "users": {},
+  "sectors": {},
+  "dashboard": {},
+  "contacts": {},
+  "templates": {},
+  "triggers": {},
+  "messages": {},
+  "chat": {},
+  "reports": {},
+  "common": {}
+}
+```
+
+`client/src/i18n/locales/en.json` — identical structure, empty sections.
+
+### Step 4: Create LanguageSwitcher component (`client/src/components/LanguageSwitcher/index.tsx`)
+
+The switcher must:
+- Call `i18n.changeLanguage(lang)` (which also fires `languageChanged` → `saveLanguage`)
+- Visually differentiate the active language
+- Accept an optional `className` prop for layout flexibility
+
+```tsx
+import { useTranslation } from 'react-i18next'
+
+interface LanguageSwitcherProps {
+  className?: string
+}
+
+export function LanguageSwitcher({ className }: LanguageSwitcherProps) {
+  const { i18n } = useTranslation()
+  const active = i18n.language as 'pt' | 'en'
+
+  return (
+    <div className={`btn-group ${className ?? ''}`} role="group" aria-label="Language">
+      <button
+        type="button"
+        className={`btn btn-sm ${active === 'pt' ? 'btn-secondary' : 'btn-outline-secondary'}`}
+        onClick={() => i18n.changeLanguage('pt')}
+      >
+        PT
+      </button>
+      <button
+        type="button"
+        className={`btn btn-sm ${active === 'en' ? 'btn-secondary' : 'btn-outline-secondary'}`}
+        onClick={() => i18n.changeLanguage('en')}
+      >
+        EN
+      </button>
+    </div>
+  )
+}
+```
+
+### Step 5: Update `IUser` type (`client/src/types/user.ts`)
+
+Add `language` to the interface:
+```typescript
+export interface IUser {
+  id: string
+  name: string
+  email: string
+  active: boolean
+  role: UserRole
+  language: 'pt' | 'en'
+  licensee: Pick<ILicensee, 'id' | 'name' | 'chatDefault' | 'useSectors'> | string | null
+}
+```
+
+Also export a type alias for reuse:
+```typescript
+export type Language = 'pt' | 'en'
+```
+
+### Step 6: Wire I18nextProvider in entry file (`client/src/index.tsx`)
+
+Import and wrap before `<AppContextProvider>` or inside it — either order works since they are independent providers. Wrapping outside is simplest:
+
+```tsx
+import i18n from './i18n'
+import { I18nextProvider } from 'react-i18next'
+
+root.render(
+  <I18nextProvider i18n={i18n}>
+    <AppContextProvider>
+      <App />
+    </AppContextProvider>
+  </I18nextProvider>
+)
+```
+
+## Testing
+
+- [ ] Write `client/src/components/LanguageSwitcher/index.spec.tsx`:
+  - Renders PT and EN buttons
+  - Clicking EN calls `i18n.changeLanguage('en')`
+  - Clicking PT calls `i18n.changeLanguage('pt')`
+  - Active language button has `btn-secondary` class; inactive has `btn-outline-secondary`
+  - Mock `react-i18next` using `vi.mock` following existing spec patterns
+- [ ] Run `npx vitest run client/src/components/LanguageSwitcher` — must pass
+- [ ] Run `npx vitest run client/src` — full client suite must still pass
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] No existing KB docs cover i18n — after this plan completes, run `document-solution` to capture the overall i18n setup pattern
+- [ ] If `check-kb-index` is needed after KB file changes, run it
+
+## Completion Criteria
+
+- [ ] `react-i18next` and `i18next` installed in `client/package.json`
+- [ ] `client/src/i18n/index.ts` exists and configures i18next with pt/en resources
+- [ ] `client/src/i18n/locales/pt.json` and `en.json` exist with scaffolded section keys
+- [ ] `LanguageSwitcher` component renders, toggles language, and persists via `saveLanguage`
+- [ ] `IUser.language: 'pt' | 'en'` added; `Language` type exported
+- [ ] `I18nextProvider` wraps `<App>` in `client/src/index.tsx`
+- [ ] LanguageSwitcher tests pass
+- [ ] Full client test suite passes
+- [ ] Changes committed to `plan/app-i18n/phase-1/task-01-i18n-setup`
+- [ ] `status.md` updated to `complete`
+
+## Conflict Avoidance Notes
+
+- This task runs in parallel with phase-1/task-02-user-model-backend. Task-02 modifies backend files only — no overlap.
+- The scaffolded locale files created here are intentionally empty. Tasks 03–08 exclusively append content to them. Do not add translation key content in this task.

--- a/.plans/app-i18n/phase-1/task-02-user-model-backend/status.md
+++ b/.plans/app-i18n/phase-1/task-02-user-model-backend/status.md
@@ -1,0 +1,25 @@
+# Status: User Model Language Field + Migration Script
+
+**Current Status**: not-started
+**Last Updated**: 2026-06-24
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-06-24 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/app-i18n/phase-1/task-02-user-model-backend/task.md
+++ b/.plans/app-i18n/phase-1/task-02-user-model-backend/task.md
@@ -1,0 +1,137 @@
+# Task: User Model Language Field + Migration Script
+
+**Plan**: App Internationalization (PT/EN)
+**Phase**: 1
+**Task ID (phase-local)**: task-02
+**Task Path**: phase-1/task-02-user-model-backend
+**Depends On**: None
+**JIRA**: N/A
+
+## Objective
+
+Add a `language` field to the `User` Mongoose model, update `OnboardingController` (and its underlying use case/route validation) to accept and persist `language` in the POST /login/onboarding payload, and provide a MongoDB shell migration script to backfill `language: 'pt'` on all existing users.
+
+## Context
+
+Backend stack: Express 5 / TypeScript, Mongoose. Architecture follows use-case pattern — controllers are thin HTTP adapters that call a use case. The onboarding flow is:
+
+- Route: `POST /login/onboarding` (defined in `src/app/routes/login-route.ts`)
+- Controller: `src/app/controllers/OnboardingController.ts`
+- Use case: likely `src/app/usecases/` — read the controller to find the use case class it calls
+
+The `User` model lives at `src/app/models/User.ts`. There is no existing `language` field.
+
+The frontend `IUser` type gets the `language` field added by task-01 (phase-1/task-01-i18n-setup). This task is the backend counterpart.
+
+Validation: `OnboardingController` uses `express-validator`. The `language` field should be validated as an optional string `oneOf(['pt', 'en'])`, defaulting to `'pt'` if omitted. This keeps the API backwards-compatible with older clients.
+
+## Before You Start
+
+- [ ] Switch to the task branch: `git switch main && git pull --rebase origin main && git switch -c plan/app-i18n/phase-1/task-02-user-model-backend`
+- [ ] Verify task-01 is NOT a dependency (tasks 01 and 02 run in parallel)
+- [ ] Check this task's `status.md` — must be `not-started`
+- [ ] Read `src/app/controllers/OnboardingController.ts` to find the use case it calls
+- [ ] Read that use case file to understand the User creation flow
+- [ ] Read `src/app/routes/login-route.ts` to see the existing validation chain
+- [ ] Mark this task `in-progress` in `status.md` before proceeding
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `src/app/models/User.ts` | modify | Add `language` field to schema |
+| `src/app/controllers/OnboardingController.ts` | modify | Add `language` to validator + pass to use case |
+| `src/app/routes/login-route.ts` | modify | Add `body('language')` validator if not in controller |
+| `src/app/usecases/<CreateLicenseeAndUser or equivalent>.ts` | modify | Thread `language` from input to User creation |
+| `scripts/migrate-user-language.js` | create | MongoDB shell script |
+
+> Verify the exact use case filename by reading `OnboardingController.ts` — adapt if it differs.
+
+### Do NOT Modify
+
+- `client/src/types/user.ts` — owned by phase-1/task-01-i18n-setup
+- `client/src/pages/SignIn/OnboardingModal.tsx` — owned by phase-2/task-04-onboarding-i18n
+- Any other backend model or controller
+
+## Implementation Steps
+
+### Step 1: Add `language` to the User Mongoose schema (`src/app/models/User.ts`)
+
+Locate the schema definition and add:
+```typescript
+language: {
+  type: String,
+  enum: ['pt', 'en'],
+  default: 'pt',
+},
+```
+
+Place it alongside other user attribute fields (near `role`). Follow the existing field ordering pattern in the file.
+
+### Step 2: Find and update the use case
+
+Read `OnboardingController.ts` to identify the use case class. Open that use case file and:
+1. Add `language?: 'pt' | 'en'` to the input type/interface
+2. Pass `language: input.language ?? 'pt'` when constructing the User object
+
+### Step 3: Update `OnboardingController.ts` validation
+
+Add language to the validator chain. Follow the existing `body(...)` pattern:
+```typescript
+body('language')
+  .optional()
+  .isIn(['pt', 'en'])
+  .withMessage('language must be pt or en'),
+```
+
+Extract it from `matchedData` and pass to the use case execute call.
+
+### Step 4: Update route validation if applicable
+
+Check `login-route.ts` — if it has its own `check()` array, add the language validator there too.
+
+### Step 5: Create the MongoDB migration script (`scripts/migrate-user-language.js`)
+
+This is a script for the **MongoDB shell** (not Node.js). Add a clear header comment:
+
+```javascript
+// MongoDB shell migration: backfill language field on existing users
+// Run in MongoDB shell: load('scripts/migrate-user-language.js')
+// Or via mongosh: mongosh <connection-string> --file scripts/migrate-user-language.js
+
+const result = db.users.updateMany(
+  { language: { $exists: false } },
+  { $set: { language: 'pt' } }
+)
+
+print('Matched:', result.matchedCount)
+print('Modified:', result.modifiedCount)
+```
+
+## Testing
+
+- [ ] Run the existing backend test suite: `npx jest --testPathPattern="OnboardingController|User"` — all must pass
+- [ ] If a spec exists for the use case (e.g., `CreateLicenseeAndUser.spec.ts`), run it and ensure it passes with the `language` field threaded through
+- [ ] Add a test case to the OnboardingController spec:
+  - Submitting `language: 'en'` creates a user with `language: 'en'`
+  - Omitting `language` creates a user with `language: 'pt'` (default)
+  - Submitting `language: 'es'` returns a 422 validation error
+- [ ] Run `npx jest` — full backend suite must pass
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] No KB/doc updates required for this task — the migration script is self-documenting
+
+## Completion Criteria
+
+- [ ] `User.ts` schema has `language: { type: String, enum: ['pt', 'en'], default: 'pt' }`
+- [ ] OnboardingController validates and threads `language` to user creation
+- [ ] `scripts/migrate-user-language.js` exists with correct `updateMany` and print output
+- [ ] All backend tests pass including new language validation test cases
+- [ ] Changes committed to `plan/app-i18n/phase-1/task-02-user-model-backend`
+- [ ] `status.md` updated to `complete`
+
+## Conflict Avoidance Notes
+
+- Runs in parallel with phase-1/task-01-i18n-setup. That task modifies `client/src/` only; this task modifies `src/` (backend) only. No overlap.

--- a/.plans/app-i18n/phase-2/task-03-login-i18n/status.md
+++ b/.plans/app-i18n/phase-2/task-03-login-i18n/status.md
@@ -1,0 +1,25 @@
+# Status: Login Page i18n + Language Switcher + Post-Login Hydration
+
+**Current Status**: not-started
+**Last Updated**: 2026-06-24
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-06-24 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/app-i18n/phase-2/task-03-login-i18n/task.md
+++ b/.plans/app-i18n/phase-2/task-03-login-i18n/task.md
@@ -1,0 +1,152 @@
+# Task: Login Page i18n + Language Switcher + Post-Login Hydration
+
+**Plan**: App Internationalization (PT/EN)
+**Phase**: 2
+**Task ID (phase-local)**: task-03
+**Task Path**: phase-2/task-03-login-i18n
+**Depends On**: phase-1/task-01-i18n-setup, phase-1/task-02-user-model-backend
+**JIRA**: N/A
+
+## Objective
+
+Extract all hardcoded strings from the login page (`SignIn/index.tsx`) into `pt.json`/`en.json`, add the `LanguageSwitcher` component to the login page UI, and wire post-login language hydration in both `SignIn/index.tsx` and `routes.tsx` so the app switches to `user.language` after every login or session restore.
+
+## Context
+
+This task is the first to write actual translation keys into the locale files. All subsequent tasks in phases 2–3 will append more keys — never overwrite existing ones.
+
+**Login page** (`client/src/pages/SignIn/index.tsx`):
+- Uses `fetchLoggedUser()` to retrieve the user object after login (line ~39)
+- Uses `setCurrentUser()` from `useApp()` to store the logged-in user
+- After `fetchLoggedUser()` resolves, we must call `i18n.changeLanguage(user.language)` to apply the saved preference
+
+**Session restore** (`client/src/pages/routes.tsx`):
+- On mount, if `isAuthenticated() && !currentUser`, calls `fetchLoggedUser()` and `setCurrentUser()` (lines 22–28)
+- Same hydration hook needed here for page-refresh cases
+
+**Hardcoded strings found in `SignIn/index.tsx`** (audit the file directly — the list below is a starting point):
+- Form labels: "email", "senha"
+- Button: "Entrar"
+- Error messages: "Preencha e-mail e senha para continuar!", "Erro ao fazer login"
+- Links/prompts: "Não tem uma conta?", "Criar conta"
+- Success: "Conta criada com sucesso! Faça login para continuar."
+
+Read the file before writing any translation keys to capture ALL strings, including any added since the survey.
+
+**i18n instance**: import from `../../i18n` (or the relative path from the file location). Use `useTranslation()` hook to get `t` and `i18n`.
+
+## Before You Start
+
+- [ ] Switch to the task branch: `git switch main && git pull --rebase origin main && git switch -c plan/app-i18n/phase-2/task-03-login-i18n`
+- [ ] Verify phase-1/task-01-i18n-setup `status.md` shows `complete` (merge its branch first if needed)
+- [ ] Verify phase-1/task-02-user-model-backend `status.md` shows `complete`
+- [ ] Check this task's `status.md` — must be `not-started`
+- [ ] Read `client/src/pages/SignIn/index.tsx` in full — capture every hardcoded string
+- [ ] Read `client/src/pages/routes.tsx` — understand the `fetchLoggedUser` effect
+- [ ] Mark this task `in-progress` in `status.md` before proceeding
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `client/src/pages/SignIn/index.tsx` | modify | Replace hardcoded strings with `t()` calls + add LanguageSwitcher |
+| `client/src/pages/SignIn/index.spec.tsx` (if it exists) | modify | Update tests to mock i18n |
+| `client/src/pages/routes.tsx` | modify | Add `i18n.changeLanguage(user.language)` in session-restore effect |
+| `client/src/i18n/locales/pt.json` | modify | Append `login.*` keys |
+| `client/src/i18n/locales/en.json` | modify | Append `login.*` keys (English translations) |
+
+### Do NOT Modify
+
+- `client/src/pages/SignIn/OnboardingModal.tsx` — owned by phase-2/task-04-onboarding-i18n
+- `client/src/components/LanguageSwitcher/index.tsx` — owned by phase-1/task-01-i18n-setup (read-only here)
+- `client/src/i18n/index.ts` — owned by phase-1/task-01-i18n-setup (read-only here)
+
+## Implementation Steps
+
+### Step 1: Audit SignIn/index.tsx for all strings
+
+Read the file. List every hardcoded string. Plan the translation key namespace: `login.*`. Examples:
+```json
+{
+  "login": {
+    "emailLabel": "E-mail",
+    "passwordLabel": "Senha",
+    "submitButton": "Entrar",
+    "noAccount": "Não tem uma conta?",
+    "createAccount": "Criar conta",
+    "emptyFieldsError": "Preencha e-mail e senha para continuar!",
+    "loginError": "Erro ao fazer login",
+    "accountCreated": "Conta criada com sucesso! Faça login para continuar."
+  }
+}
+```
+
+Add corresponding English translations to `en.json`:
+```json
+{
+  "login": {
+    "emailLabel": "E-mail",
+    "passwordLabel": "Password",
+    "submitButton": "Sign in",
+    "noAccount": "Don't have an account?",
+    "createAccount": "Create account",
+    "emptyFieldsError": "Please enter your email and password to continue.",
+    "loginError": "Login error",
+    "accountCreated": "Account created successfully! Sign in to continue."
+  }
+}
+```
+
+### Step 2: Update SignIn/index.tsx
+
+1. Add `import { useTranslation } from 'react-i18next'`
+2. Add `import { LanguageSwitcher } from '../../components/LanguageSwitcher'`
+3. Inside component: `const { t, i18n } = useTranslation()`
+4. Replace every hardcoded string with `t('login.keyName')`
+5. After `fetchLoggedUser()` resolves and `user` is available, call `i18n.changeLanguage(user.language)` before or after `setCurrentUser(user ?? undefined)`
+6. Add `<LanguageSwitcher className="mb-3" />` to the login form UI (above or below the form title — choose the position that fits the existing layout)
+
+### Step 3: Update routes.tsx for session restore
+
+In the `useEffect` that calls `fetchLoggedUser()`:
+```typescript
+import i18n from '../i18n'
+
+fetchLoggedUser().then(user => {
+  setCurrentUser(user ?? undefined)
+  if (user?.language) {
+    i18n.changeLanguage(user.language)
+  }
+})
+```
+
+### Step 4: Update `common` section in locale files
+
+Add any shared strings used across the app that appear in this file (e.g., generic error/success messages) under a `common.*` namespace rather than duplicating them in multiple sections.
+
+## Testing
+
+- [ ] Run `npx vitest run client/src/pages/SignIn` — existing tests must still pass
+- [ ] If tests exist for `SignIn/index.tsx`, ensure they mock `useTranslation` (use `vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (k: string) => k, i18n: { changeLanguage: vi.fn() } }) }))`)
+- [ ] Verify: switching language on login page updates the page text immediately (manual test or snapshot)
+- [ ] Verify: after login, `i18n.language` matches `user.language` from the API response
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] No KB/doc updates required for this task
+
+## Completion Criteria
+
+- [ ] `SignIn/index.tsx` has zero hardcoded Portuguese strings
+- [ ] `LanguageSwitcher` is visible on the login page
+- [ ] `routes.tsx` calls `i18n.changeLanguage(user.language)` in the session-restore effect
+- [ ] `pt.json` and `en.json` have complete `login.*` section with all strings
+- [ ] All client tests pass
+- [ ] Changes committed to `plan/app-i18n/phase-2/task-03-login-i18n`
+- [ ] `status.md` updated to `complete`
+
+## Conflict Avoidance Notes
+
+- Task-04 (onboarding) depends on this task completing first — specifically because task-04 also writes to `pt.json`/`en.json`. Do not leave locale files in a partial state when committing.
+- `routes.tsx` change in this task (language hydration) is additive — it does not modify existing logic, only appends to the `fetchLoggedUser().then()` callback.

--- a/.plans/app-i18n/phase-2/task-04-onboarding-i18n/status.md
+++ b/.plans/app-i18n/phase-2/task-04-onboarding-i18n/status.md
@@ -1,0 +1,25 @@
+# Status: Onboarding Wizard i18n + Language Switcher
+
+**Current Status**: not-started
+**Last Updated**: 2026-06-24
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-06-24 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/app-i18n/phase-2/task-04-onboarding-i18n/task.md
+++ b/.plans/app-i18n/phase-2/task-04-onboarding-i18n/task.md
@@ -1,0 +1,188 @@
+# Task: Onboarding Wizard i18n + Language Switcher
+
+**Plan**: App Internationalization (PT/EN)
+**Phase**: 2
+**Task ID (phase-local)**: task-04
+**Task Path**: phase-2/task-04-onboarding-i18n
+**Depends On**: phase-2/task-03-login-i18n
+**JIRA**: N/A
+
+## Objective
+
+Extract all hardcoded strings from `OnboardingModal.tsx` (JSX labels, Yup validation messages, step title maps, button text) into `pt.json`/`en.json`, add the `LanguageSwitcher` to the modal header, and send the selected language in the POST /login/onboarding payload so the backend persists it on the created User.
+
+## Context
+
+`OnboardingModal.tsx` is a 5-step wizard with significant string density:
+
+- **Step title map**: `stepTitles: Record<StepId, string>` — currently a static TypeScript object with Portuguese strings
+- **JSX labels**: form labels, placeholders, option labels on every step
+- **Yup schemas**: validation error messages embedded directly in `Yup.string().required('...')` calls
+- **Button text**: "Próximo →", "Voltar", "Cancelar", "Criar conta"
+- **Inline error/info messages**: conditional strings rendered in JSX
+
+**Critical challenge — Yup schemas are static**: Yup validation schemas are typically defined at module level. Their error messages are evaluated once. To make them react to language changes:
+
+1. Move the schema definition **inside the component** (or into a factory function)
+2. Wrap with `useMemo(() => buildSchemaForStep(currentStep, t), [currentStep, t])` — this re-creates the schema whenever the translation function or step changes
+3. This is the standard pattern for react-i18next + Yup
+
+**POST /login/onboarding payload**: The wizard's final submit function sends a POST request. Add `language: i18n.language as 'pt' | 'en'` to the payload body. The backend (task-02) already accepts this field.
+
+**Language persistence**: When the user switches language inside the onboarding modal, `i18n.changeLanguage()` updates the UI immediately AND persists to localStorage (wired in `i18n/index.ts` by task-01). No additional persistence logic needed here — just calling `i18n.changeLanguage()` is sufficient.
+
+Read `OnboardingModal.tsx` fully before writing any translation keys. The audit from the codebase survey is a starting point; the file may have more strings.
+
+## Before You Start
+
+- [ ] Switch to the task branch: `git switch main && git pull --rebase origin main && git switch -c plan/app-i18n/phase-2/task-04-onboarding-i18n`
+- [ ] Verify phase-2/task-03-login-i18n `status.md` shows `complete`
+- [ ] Check this task's `status.md` — must be `not-started`
+- [ ] Read `client/src/pages/SignIn/OnboardingModal.tsx` in full — capture ALL strings and schema error messages
+- [ ] Read `client/src/pages/SignIn/OnboardingModal.spec.tsx` — understand what is currently tested
+- [ ] Mark this task `in-progress` in `status.md` before proceeding
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `client/src/pages/SignIn/OnboardingModal.tsx` | modify | Replace strings with `t()`, dynamic Yup, LanguageSwitcher, language in payload |
+| `client/src/pages/SignIn/OnboardingModal.spec.tsx` | modify | Add i18n mock, update/add tests for language behavior |
+| `client/src/i18n/locales/pt.json` | modify | Append `onboarding.*` keys |
+| `client/src/i18n/locales/en.json` | modify | Append `onboarding.*` keys (English) |
+
+### Do NOT Modify
+
+- `client/src/pages/SignIn/index.tsx` — owned by phase-2/task-03-login-i18n (already complete)
+- `client/src/components/LanguageSwitcher/index.tsx` — read-only (owned by phase-1/task-01)
+- `client/src/i18n/index.ts` — read-only (owned by phase-1/task-01)
+
+## Implementation Steps
+
+### Step 1: Audit OnboardingModal.tsx for all strings
+
+Read the file. Build a complete list. Group by step. Key namespace: `onboarding.*`. Example structure:
+
+```json
+{
+  "onboarding": {
+    "steps": {
+      "identity": "Dados da Empresa",
+      "integrations": "Integrações",
+      "chat": "Chat",
+      "whatsapp": "WhatsApp",
+      "credentials": "Credenciais do Usuário"
+    },
+    "buttons": {
+      "next": "Próximo →",
+      "back": "Voltar",
+      "cancel": "Cancelar",
+      "submit": "Criar conta"
+    },
+    "identity": {
+      "companyNameLabel": "Nome da empresa",
+      "companyNameRequired": "Nome da empresa é obrigatório",
+      ...
+    },
+    "integrations": { ... },
+    "chat": { ... },
+    "whatsapp": { ... },
+    "credentials": { ... }
+  }
+}
+```
+
+Mirror the same keys in `en.json` with English values.
+
+### Step 2: Update OnboardingModal.tsx — hook and step titles
+
+1. Add `import { useTranslation } from 'react-i18next'`
+2. Add `import { LanguageSwitcher } from '../../components/LanguageSwitcher'`
+3. Inside the component: `const { t, i18n } = useTranslation()`
+4. Convert `stepTitles` from a static object to a derived value:
+   ```typescript
+   const stepTitles: Record<StepId, string> = {
+     identity: t('onboarding.steps.identity'),
+     integrations: t('onboarding.steps.integrations'),
+     chat: t('onboarding.steps.chat'),
+     whatsapp: t('onboarding.steps.whatsapp'),
+     credentials: t('onboarding.steps.credentials'),
+   }
+   ```
+   This must be inside the component body (re-evaluated on language change).
+
+### Step 3: Make Yup schemas dynamic
+
+Move schema definitions inside the component and wrap with `useMemo`:
+
+```typescript
+const identitySchema = useMemo(
+  () =>
+    Yup.object({
+      licenseeName: Yup.string().required(t('onboarding.identity.companyNameRequired')),
+      // ... other fields
+    }),
+  [t]
+)
+```
+
+Repeat for each step's schema. The `t` function reference changes when language changes, causing `useMemo` to re-compute with updated error strings.
+
+### Step 4: Replace JSX strings with `t()` calls
+
+Replace every hardcoded string in JSX with the corresponding `t('onboarding.section.key')` call.
+
+### Step 5: Add LanguageSwitcher to modal header
+
+Place `<LanguageSwitcher className="ms-auto" />` in the modal header area (Bootstrap modal-header), aligned to the right alongside or near the close button. The exact placement depends on the current modal layout — read the JSX to find the appropriate position.
+
+### Step 6: Add `language` to submit payload
+
+In the final submit function, include:
+```typescript
+language: i18n.language as 'pt' | 'en',
+```
+
+in the payload sent to `POST /login/onboarding`.
+
+### Step 7: Update spec file
+
+In `OnboardingModal.spec.tsx`:
+1. Add standard `react-i18next` mock at the top:
+   ```typescript
+   vi.mock('react-i18next', () => ({
+     useTranslation: () => ({
+       t: (k: string) => k,
+       i18n: { language: 'pt', changeLanguage: vi.fn() },
+     }),
+   }))
+   ```
+2. Add a test: switching the LanguageSwitcher calls `i18n.changeLanguage`
+3. Add a test: submit payload includes `language`
+4. Ensure all existing tests still pass (they may need adjustment if they assert on exact Portuguese strings — update them to assert on translation keys instead)
+
+## Testing
+
+- [ ] Run `npx vitest run client/src/pages/SignIn` — all tests must pass
+- [ ] Manual check: open the modal and verify language switch updates step titles, labels, and validation errors live
+- [ ] Verify: `language` field appears in the network request to POST /login/onboarding
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] No KB/doc updates required for this task alone — the overall i18n pattern will be documented after the plan completes via `document-solution`
+
+## Completion Criteria
+
+- [ ] `OnboardingModal.tsx` has zero hardcoded Portuguese strings
+- [ ] `LanguageSwitcher` visible in modal header
+- [ ] Step titles, labels, Yup error messages all update on language switch
+- [ ] `language` field included in POST /login/onboarding payload
+- [ ] `pt.json` and `en.json` have complete `onboarding.*` section
+- [ ] All spec tests pass including new language-related tests
+- [ ] Changes committed to `plan/app-i18n/phase-2/task-04-onboarding-i18n`
+- [ ] `status.md` updated to `complete`
+
+## Conflict Avoidance Notes
+
+- Task-05 (navbar) depends on this task completing first due to shared locale files. Commit locale file changes in a complete, parseable JSON state.

--- a/.plans/app-i18n/phase-3/task-05-navbar-layout/status.md
+++ b/.plans/app-i18n/phase-3/task-05-navbar-layout/status.md
@@ -1,0 +1,25 @@
+# Status: Navbar + BaseLayout + Shared Components i18n
+
+**Current Status**: not-started
+**Last Updated**: 2026-06-24
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-06-24 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/app-i18n/phase-3/task-05-navbar-layout/task.md
+++ b/.plans/app-i18n/phase-3/task-05-navbar-layout/task.md
@@ -1,0 +1,118 @@
+# Task: Navbar + BaseLayout + Shared Components i18n
+
+**Plan**: App Internationalization (PT/EN)
+**Phase**: 3
+**Task ID (phase-local)**: task-05
+**Task Path**: phase-3/task-05-navbar-layout
+**Depends On**: phase-2/task-04-onboarding-i18n
+**JIRA**: N/A
+
+## Objective
+
+Extract all hardcoded strings from the Navbar, BaseLayout, and any shared components (PrivateRoute, SimpleCrud, etc.) into `pt.json`/`en.json`. This task covers the persistent chrome of the app that every authenticated page displays.
+
+## Context
+
+The Navbar (`client/src/pages/Navbar/index.tsx`) contains navigation labels seen by all authenticated users. BaseLayout wraps every page. These are high-visibility strings that affect the entire authenticated experience.
+
+Known strings in Navbar (verify by reading the file):
+- Navigation items: "Dashboard", "Admin", "Licenciados", "Usuários", "Cadastros", "Contatos", "Setores", "Gatilhos", "Templates", "Mensagens", "Chat", "Relatórios"
+- User menu items: logout text, user name area, role labels
+
+Known strings in `routes.tsx` (already modified in task-03 for hydration — this task handles remaining strings):
+- `<h1>Essa página não existe.</h1>` on the 404 catch-all route
+
+Additionally, scan `client/src/components/` for any shared components with user-facing strings (e.g., a `Required` component that renders "obrigatório" or similar).
+
+Read every file before writing keys — the survey list is a starting point.
+
+## Before You Start
+
+- [ ] Switch to the task branch: `git switch main && git pull --rebase origin main && git switch -c plan/app-i18n/phase-3/task-05-navbar-layout`
+- [ ] Verify phase-2/task-04-onboarding-i18n `status.md` shows `complete`
+- [ ] Check this task's `status.md` — must be `not-started`
+- [ ] Read `client/src/pages/Navbar/index.tsx` in full
+- [ ] Read `client/src/pages/BaseLayout/` files
+- [ ] Scan `client/src/components/` for user-facing strings
+- [ ] Read `client/src/pages/PrivateRoute/index.tsx`
+- [ ] Mark this task `in-progress` in `status.md` before proceeding
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `client/src/pages/Navbar/index.tsx` | modify | Replace strings with `t()` calls |
+| `client/src/pages/BaseLayout/index.tsx` (or files inside) | modify | Replace strings with `t()` calls |
+| `client/src/pages/routes.tsx` | modify | Replace the 404 `<h1>Essa página não existe.</h1>` |
+| `client/src/components/` (any files with user strings) | modify | Replace strings with `t()` calls |
+| `client/src/pages/PrivateRoute/index.tsx` | modify | Replace any hardcoded strings |
+| `client/src/i18n/locales/pt.json` | modify | Append `navbar.*` and `common.*` keys |
+| `client/src/i18n/locales/en.json` | modify | Append same keys with English values |
+
+### Do NOT Modify
+
+- Any file in `client/src/pages/Licensees/` — owned by phase-3/task-06-licensees
+- Any file in `client/src/pages/Users/`, `Sectors/`, `Dashboard/` — owned by phase-3/task-07
+- Any file in `client/src/pages/Contacts/`, `Templates/`, `Triggers/`, `Messages/`, `Chat/`, `Reports/` — owned by phase-3/task-08
+
+## Implementation Steps
+
+### Step 1: Audit all files in scope
+
+Read each file and compile the full string list. Group under `navbar.*` and `common.*` namespaces.
+
+Example `navbar` keys:
+```json
+{
+  "navbar": {
+    "dashboard": "Dashboard",
+    "admin": "Admin",
+    "licensees": "Licenciados",
+    "users": "Usuários",
+    "registrations": "Cadastros",
+    "contacts": "Contatos",
+    "sectors": "Setores",
+    "triggers": "Gatilhos",
+    "templates": "Templates",
+    "messages": "Mensagens",
+    "chat": "Chat",
+    "reports": "Relatórios",
+    "logout": "Sair",
+    "notFound": "Essa página não existe."
+  }
+}
+```
+
+Add `common.*` keys for any cross-cutting strings (e.g., "Salvar", "Cancelar", "Confirmar", "Erro", "Sucesso") that will be reused across pages in tasks 06–08.
+
+### Step 2: Update each file
+
+For each file: `import { useTranslation } from 'react-i18next'`, add `const { t } = useTranslation()` inside the component, replace hardcoded strings with `t('namespace.key')`.
+
+### Step 3: Update locale files
+
+Append the new sections to `pt.json` and `en.json`. Confirm the files remain valid JSON after editing.
+
+## Testing
+
+- [ ] Run `npx vitest run client/src/pages/Navbar` — existing tests must pass
+- [ ] Run `npx vitest run client/src` — full client suite must pass
+- [ ] Manual: navigate the app authenticated and verify nav labels render in both PT and EN
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] No KB/doc updates required for this task
+
+## Completion Criteria
+
+- [ ] Navbar, BaseLayout, PrivateRoute, and shared components have zero hardcoded strings
+- [ ] `pt.json`/`en.json` have complete `navbar.*` and `common.*` sections
+- [ ] All client tests pass
+- [ ] Changes committed to `plan/app-i18n/phase-3/task-05-navbar-layout`
+- [ ] `status.md` updated to `complete`
+
+## Conflict Avoidance Notes
+
+- Task-06 (licensees) depends on this task completing first. Locale files must be in a valid JSON state when committed.
+- The `common.*` namespace defined here is shared across tasks 06–08. Define only genuinely cross-cutting keys here; page-specific keys belong in their own namespace.

--- a/.plans/app-i18n/phase-3/task-06-licensees/status.md
+++ b/.plans/app-i18n/phase-3/task-06-licensees/status.md
@@ -1,0 +1,25 @@
+# Status: Licensees Pages i18n
+
+**Current Status**: not-started
+**Last Updated**: 2026-06-24
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-06-24 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/app-i18n/phase-3/task-06-licensees/task.md
+++ b/.plans/app-i18n/phase-3/task-06-licensees/task.md
@@ -1,0 +1,98 @@
+# Task: Licensees Pages i18n
+
+**Plan**: App Internationalization (PT/EN)
+**Phase**: 3
+**Task ID (phase-local)**: task-06
+**Task Path**: phase-3/task-06-licensees
+**Depends On**: phase-3/task-05-navbar-layout
+**JIRA**: N/A
+
+## Objective
+
+Extract all hardcoded strings from the Licensees feature pages (index, form panels, scenes) into `pt.json`/`en.json` under the `licensees.*` namespace.
+
+## Context
+
+Licensees is the most complex page area in the app. It has multiple scenes and panels:
+
+```
+client/src/pages/Licensees/
+├── routes.tsx
+└── scenes/
+    ├── Form/        — Edit licensee form (4 tabs: Principal, Chat, ChatBot, WhatsApp)
+    │   └── panels/  — ChatPanel, ChatBotPanel, WhatsAppPanel, PrincipalPanel (or similar)
+    ├── Index/       — List page
+    ├── New/         — Create wizard (LicenseeWizard — 4 steps)
+    └── Edit/        — Edit page
+```
+
+Read the directory structure and each file before writing keys. The survey shows panel files with hardcoded option labels and form field labels. There may also be Yup schemas — apply the same `useMemo` pattern from task-04 if needed.
+
+**common.* reuse**: Many button labels ("Salvar", "Cancelar", "Próximo", "Voltar") were added to `common.*` in task-05. Use `t('common.save')` etc. rather than duplicating keys.
+
+## Before You Start
+
+- [ ] Switch to the task branch: `git switch main && git pull --rebase origin main && git switch -c plan/app-i18n/phase-3/task-06-licensees`
+- [ ] Verify phase-3/task-05-navbar-layout `status.md` shows `complete`
+- [ ] Check this task's `status.md` — must be `not-started`
+- [ ] Run `find client/src/pages/Licensees -name "*.tsx" | sort` to enumerate all files
+- [ ] Read each file for hardcoded strings before writing any translation keys
+- [ ] Mark this task `in-progress` in `status.md` before proceeding
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `client/src/pages/Licensees/**/*.tsx` | modify | Replace strings with `t()` calls |
+| `client/src/i18n/locales/pt.json` | modify | Append `licensees.*` keys |
+| `client/src/i18n/locales/en.json` | modify | Append `licensees.*` keys (English) |
+
+### Do NOT Modify
+
+- Any file outside `client/src/pages/Licensees/`
+- Files in `client/src/pages/Users/`, `Sectors/`, `Dashboard/` — owned by task-07
+- Files in `client/src/pages/Contacts/`, `Templates/`, `Triggers/`, `Messages/`, `Chat/`, `Reports/` — owned by task-08
+
+## Implementation Steps
+
+### Step 1: Enumerate and audit
+
+```bash
+find client/src/pages/Licensees -name "*.tsx" | sort
+```
+
+Read each file. Build the full key list under `licensees.*`. Group logically: `licensees.index.*`, `licensees.form.*`, `licensees.form.chat.*`, `licensees.form.chatbot.*`, `licensees.form.whatsapp.*`, `licensees.wizard.*`, etc.
+
+### Step 2: Apply translations
+
+For each component file:
+1. Add `import { useTranslation } from 'react-i18next'`
+2. Add `const { t } = useTranslation()` inside the component
+3. Replace hardcoded strings with `t('licensees.section.key')` or `t('common.key')` for shared terms
+4. If Yup schemas are present, wrap with `useMemo(() => schema(t), [t])` (same pattern as task-04)
+
+### Step 3: Update locale files
+
+Append `licensees.*` section to both `pt.json` and `en.json`. Verify JSON validity.
+
+## Testing
+
+- [ ] Run `npx vitest run client/src/pages/Licensees` — all tests must pass
+- [ ] Run `npx vitest run client/src` — full suite must pass
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] No KB/doc updates required for this task
+
+## Completion Criteria
+
+- [ ] All files in `client/src/pages/Licensees/` have zero hardcoded Portuguese strings
+- [ ] `pt.json`/`en.json` have complete `licensees.*` section
+- [ ] All client tests pass
+- [ ] Changes committed to `plan/app-i18n/phase-3/task-06-licensees`
+- [ ] `status.md` updated to `complete`
+
+## Conflict Avoidance Notes
+
+- Task-07 depends on this task. Commit locale files in valid JSON state.

--- a/.plans/app-i18n/phase-3/task-07-users-sectors-dashboard/status.md
+++ b/.plans/app-i18n/phase-3/task-07-users-sectors-dashboard/status.md
@@ -1,0 +1,25 @@
+# Status: Users + Sectors + Dashboard i18n
+
+**Current Status**: not-started
+**Last Updated**: 2026-06-24
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-06-24 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/app-i18n/phase-3/task-07-users-sectors-dashboard/task.md
+++ b/.plans/app-i18n/phase-3/task-07-users-sectors-dashboard/task.md
@@ -1,0 +1,97 @@
+# Task: Users + Sectors + Dashboard i18n
+
+**Plan**: App Internationalization (PT/EN)
+**Phase**: 3
+**Task ID (phase-local)**: task-07
+**Task Path**: phase-3/task-07-users-sectors-dashboard
+**Depends On**: phase-3/task-06-licensees
+**JIRA**: N/A
+
+## Objective
+
+Extract all hardcoded strings from the Users, Sectors, and Dashboard pages into `pt.json`/`en.json` under their respective namespaces.
+
+## Context
+
+Three distinct page areas:
+
+**Users** (`client/src/pages/Users/`):
+- Likely has Index (list), New (create form), Edit forms
+- Form fields: name, email, password, role (enum labels), active toggle
+- Role enum labels ("Agente", "Supervisor", "Admin", "Super") need translations
+
+**Sectors** (`client/src/pages/Sectors/`):
+- Similar CRUD structure: Index, Form scenes
+- Fields specific to sectors (e.g., name, whatsapp number assignments)
+
+**Dashboard** (`client/src/pages/Dashboard/index.tsx`):
+- Summary cards with counts and labels
+- Role-aware — may show different labels based on user role
+
+Run `find client/src/pages/Users client/src/pages/Sectors client/src/pages/Dashboard -name "*.tsx" | sort` to enumerate all files before starting.
+
+**common.* reuse**: Use `t('common.save')`, `t('common.cancel')`, `t('common.active')`, `t('common.name')`, `t('common.email')` etc. for strings already in the common namespace from task-05. Only add page-specific keys to the page namespace.
+
+## Before You Start
+
+- [ ] Switch to the task branch: `git switch main && git pull --rebase origin main && git switch -c plan/app-i18n/phase-3/task-07-users-sectors-dashboard`
+- [ ] Verify phase-3/task-06-licensees `status.md` shows `complete`
+- [ ] Check this task's `status.md` — must be `not-started`
+- [ ] Enumerate and read all files in Users, Sectors, and Dashboard before writing keys
+- [ ] Check `common.*` in `pt.json` to avoid duplicating already-defined keys
+- [ ] Mark this task `in-progress` in `status.md` before proceeding
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `client/src/pages/Users/**/*.tsx` | modify | Replace strings with `t()` calls |
+| `client/src/pages/Sectors/**/*.tsx` | modify | Replace strings with `t()` calls |
+| `client/src/pages/Dashboard/**/*.tsx` | modify | Replace strings with `t()` calls |
+| `client/src/i18n/locales/pt.json` | modify | Append `users.*`, `sectors.*`, `dashboard.*` keys |
+| `client/src/i18n/locales/en.json` | modify | Append same keys with English values |
+
+### Do NOT Modify
+
+- `client/src/pages/Licensees/` — owned by phase-3/task-06 (complete)
+- `client/src/pages/Contacts/`, `Templates/`, `Triggers/`, `Messages/`, `Chat/`, `Reports/` — owned by task-08
+
+## Implementation Steps
+
+### Step 1: Enumerate and audit
+
+```bash
+find client/src/pages/Users client/src/pages/Sectors client/src/pages/Dashboard -name "*.tsx" | sort
+```
+
+Read each file. Build key lists. Group under `users.*`, `sectors.*`, `dashboard.*`.
+
+### Step 2: Apply translations
+
+For each component file: add `useTranslation()`, replace strings with `t()` calls, reuse `common.*` keys where applicable.
+
+### Step 3: Update locale files
+
+Append the three new sections to `pt.json` and `en.json`. Verify JSON validity after editing.
+
+## Testing
+
+- [ ] Run `npx vitest run client/src/pages/Users client/src/pages/Sectors client/src/pages/Dashboard` — all tests must pass
+- [ ] Run `npx vitest run client/src` — full suite must pass
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] No KB/doc updates required for this task
+
+## Completion Criteria
+
+- [ ] All files in Users, Sectors, and Dashboard have zero hardcoded Portuguese strings
+- [ ] `pt.json`/`en.json` have `users.*`, `sectors.*`, `dashboard.*` sections
+- [ ] All client tests pass
+- [ ] Changes committed to `plan/app-i18n/phase-3/task-07-users-sectors-dashboard`
+- [ ] `status.md` updated to `complete`
+
+## Conflict Avoidance Notes
+
+- Task-08 depends on this task. Commit locale files in valid JSON state.

--- a/.plans/app-i18n/phase-3/task-08-remaining-pages/status.md
+++ b/.plans/app-i18n/phase-3/task-08-remaining-pages/status.md
@@ -1,0 +1,25 @@
+# Status: Contacts + Templates + Triggers + Messages + Chat + Reports i18n
+
+**Current Status**: not-started
+**Last Updated**: 2026-06-24
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-06-24 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/app-i18n/phase-3/task-08-remaining-pages/task.md
+++ b/.plans/app-i18n/phase-3/task-08-remaining-pages/task.md
@@ -1,0 +1,118 @@
+# Task: Contacts + Templates + Triggers + Messages + Chat + Reports i18n
+
+**Plan**: App Internationalization (PT/EN)
+**Phase**: 3
+**Task ID (phase-local)**: task-08
+**Task Path**: phase-3/task-08-remaining-pages
+**Depends On**: phase-3/task-07-users-sectors-dashboard
+**JIRA**: N/A
+
+## Objective
+
+Extract all hardcoded strings from the remaining authenticated pages — Contacts, Templates, Triggers, Messages, Chat, and Reports — completing full app coverage. After this task, no hardcoded Portuguese strings should remain in `client/src/`.
+
+## Context
+
+This is the final translation sweep. Six page areas:
+
+- **Contacts** (`client/src/pages/Contacts/`) — contact list, form, detail view
+- **Templates** (`client/src/pages/Templates/`) — template list and form
+- **Triggers** (`client/src/pages/Triggers/`) — trigger list and form
+- **Messages** (`client/src/pages/Messages/`) — message list/viewer
+- **Chat** (`client/src/pages/Chat/`) — full-screen agent chat UI (note: Chat is a `noLayout` route — may have distinct UI patterns)
+- **Reports** (`client/src/pages/Reports/`) — report views
+
+Run `find` on each directory before reading files. Use `common.*` for shared labels already defined in task-05.
+
+After completing translations, run a final grep to verify no hardcoded Portuguese strings remain anywhere in `client/src/`:
+```bash
+# Check for common Portuguese patterns
+grep -r "ção\|ões\|ão\|ões\|Salvar\|Cancelar\|Próximo\|Voltar" client/src --include="*.tsx" --include="*.ts" -l
+```
+The result should only match `*.json` locale files — not component or service files.
+
+## Before You Start
+
+- [ ] Switch to the task branch: `git switch main && git pull --rebase origin main && git switch -c plan/app-i18n/phase-3/task-08-remaining-pages`
+- [ ] Verify phase-3/task-07-users-sectors-dashboard `status.md` shows `complete`
+- [ ] Check this task's `status.md` — must be `not-started`
+- [ ] Enumerate all files in the six page directories before writing keys
+- [ ] Review `common.*` in `pt.json` — reuse existing keys rather than duplicating
+- [ ] Mark this task `in-progress` in `status.md` before proceeding
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `client/src/pages/Contacts/**/*.tsx` | modify | Replace strings with `t()` calls |
+| `client/src/pages/Templates/**/*.tsx` | modify | Replace strings with `t()` calls |
+| `client/src/pages/Triggers/**/*.tsx` | modify | Replace strings with `t()` calls |
+| `client/src/pages/Messages/**/*.tsx` | modify | Replace strings with `t()` calls |
+| `client/src/pages/Chat/**/*.tsx` | modify | Replace strings with `t()` calls |
+| `client/src/pages/Reports/**/*.tsx` | modify | Replace strings with `t()` calls |
+| `client/src/i18n/locales/pt.json` | modify | Append `contacts.*`, `templates.*`, `triggers.*`, `messages.*`, `chat.*`, `reports.*` |
+| `client/src/i18n/locales/en.json` | modify | Append same sections with English values |
+
+### Do NOT Modify
+
+- Any file in previously completed tasks — all owned files are in the six page directories above
+
+## Implementation Steps
+
+### Step 1: Enumerate all files
+
+```bash
+find client/src/pages/Contacts client/src/pages/Templates client/src/pages/Triggers \
+     client/src/pages/Messages client/src/pages/Chat client/src/pages/Reports \
+     -name "*.tsx" | sort
+```
+
+Read each file. Build key lists per page namespace.
+
+### Step 2: Apply translations (page by page)
+
+Work through one page area at a time. For each component:
+1. `import { useTranslation } from 'react-i18next'`
+2. `const { t } = useTranslation()`
+3. Replace hardcoded strings — use `common.*` for shared terms, page-specific keys for the rest
+
+### Step 3: Update locale files
+
+Append all six new sections to `pt.json` and `en.json`. Verify JSON validity.
+
+### Step 4: Final audit — no hardcoded strings remain
+
+```bash
+grep -r "ção\|ões\|Salvar\|Cancelar\|Próximo\|Voltar\|Editar\|Excluir\|Novo\|Nova\|Buscar" \
+  client/src --include="*.tsx" --include="*.ts" -l
+```
+
+Review every hit. Only locale JSON files should contain Portuguese text. Fix any remaining stragglers.
+
+## Testing
+
+- [ ] Run `npx vitest run client/src` — full client suite must pass
+- [ ] Run the final audit grep — zero hits in `.tsx`/`.ts` files
+- [ ] Manual: switch language to EN and browse all pages — verify every label is translated
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] After this task completes the full plan: run `document-solution` to capture the i18n setup pattern, LanguageSwitcher usage, Yup dynamic schema pattern, and language hydration flow for future reference
+- [ ] Run `check-kb-index` after the KB doc is created
+
+## Completion Criteria
+
+- [ ] All six remaining page areas have zero hardcoded Portuguese strings
+- [ ] `pt.json` and `en.json` have complete sections for all pages
+- [ ] Final audit grep shows zero hits in `.tsx`/`.ts` files
+- [ ] All client tests pass
+- [ ] `document-solution` run and KB doc created for i18n pattern
+- [ ] Changes committed to `plan/app-i18n/phase-3/task-08-remaining-pages`
+- [ ] `status.md` updated to `complete`
+- [ ] Plan `overview.md` status updated to `complete`
+
+## Conflict Avoidance Notes
+
+- This is the last task in the plan. After this task, open the single PR for the entire plan.
+- Before opening the PR: rebase on `main` to pull any changes from the last few weeks of parallel development.

--- a/.plans/app-i18n/phase-3/task-09-widget-i18n/status.md
+++ b/.plans/app-i18n/phase-3/task-09-widget-i18n/status.md
@@ -1,0 +1,25 @@
+# Status: Chat Widget i18n
+
+**Current Status**: not-started
+**Last Updated**: 2026-06-24
+**Agent**: —
+**Branch**: —
+**PR**: —
+
+## Status History
+
+| Timestamp | Status | Agent | Notes |
+|-----------|--------|-------|-------|
+| 2026-06-24 | not-started | — | Task created |
+
+## Blockers
+
+None
+
+## Artifacts
+
+None
+
+## Adaptations
+
+None

--- a/.plans/app-i18n/phase-3/task-09-widget-i18n/task.md
+++ b/.plans/app-i18n/phase-3/task-09-widget-i18n/task.md
@@ -1,0 +1,268 @@
+# Task: Chat Widget i18n
+
+**Plan**: App Internationalization (PT/EN)
+**Phase**: 3
+**Task ID (phase-local)**: task-09
+**Task Path**: phase-3/task-09-widget-i18n
+**Depends On**: phase-1/task-01-i18n-setup
+**JIRA**: N/A
+
+## Objective
+
+Add Portuguese/English support to the embeddable chat widget (`widget/src/`). The widget is a separate IIFE bundle isolated in Shadow DOM — it cannot share the main app's i18next instance. Use a lightweight translations map instead. Expose `language` via (1) `data-language` attribute on the `<script>` tag, (2) `EcomandaWidget.init({ language? })` for Mode 2, defaulting to `'pt'`.
+
+## Context
+
+The widget lives in `widget/src/` — a completely separate Vite project (its own `package.json`, `tsconfig.json`, `vite.config.ts`). It is compiled as a single IIFE (`widget.js`) and mounted into a Shadow DOM root, so it is fully isolated from the main React app's providers and context.
+
+**Do NOT add `react-i18next` or `i18next` to the widget.** Those libraries would bloat the bundle unnecessarily. A simple translations object is sufficient for ~12 strings.
+
+**String inventory** (all files with user-facing text):
+
+`widget/src/components/SessionForm.tsx`:
+- `"Iniciar conversa"` — heading + submit button
+- `"Preencha seus dados para começar o atendimento."` — subheading
+- `"Nome"` — label
+- `"Seu nome"` — placeholder
+- `"E-mail"` — label
+- `"Informe um e-mail válido."` — validation error
+- `"Telefone (opcional)"` — label
+- `"(00) 00000-0000"` — phone placeholder
+- `"Aguarde..."` — loading button state
+
+`widget/src/components/MessageInput.tsx`:
+- `placeholder="Digite uma mensagem..."` 
+- `aria-label="Mensagem"`
+- `aria-label="Enviar mensagem"`
+
+No other widget files contain user-facing strings.
+
+**Language resolution order** (highest priority first):
+1. `EcomandaWidget.init({ language: 'en' })` — Mode 2 authenticated, set at runtime
+2. `<script data-licensee="TOKEN" data-language="en">` — declarative, set at install time
+3. Default: `'pt'`
+
+**How Mode 2 connects to the main app**: When the main app (authenticated) calls `EcomandaWidget.init({ name, email, language: i18n.language })`, the widget switches to that language. This is the primary integration path for app-i18n.
+
+## Before You Start
+
+- [ ] Switch to the task branch: `git switch main && git pull --rebase origin main && git switch -c plan/app-i18n/phase-3/task-09-widget-i18n`
+- [ ] Verify phase-1/task-01-i18n-setup `status.md` shows `complete` (so the main app has `i18n.language` available for Mode 2 callers)
+- [ ] Check this task's `status.md` — must be `not-started`
+- [ ] Re-read `widget/src/main.tsx`, `SessionForm.tsx`, `MessageInput.tsx`, `App.tsx` to confirm the string inventory matches this task file (it may have changed)
+- [ ] Check `widget/package.json` — do NOT add any i18n package
+- [ ] Mark this task `in-progress` in `status.md` before proceeding
+
+## File Ownership
+
+| File | Action | Notes |
+|------|--------|-------|
+| `widget/src/translations.ts` | create | `{ pt: {...}, en: {...} }` string map + `Language` type |
+| `widget/src/main.tsx` | modify | Read `data-language`; add `language` to `InitData`; thread to `App` |
+| `widget/src/App.tsx` | modify | Accept + forward `language` prop to `SessionForm` + `MessageInput` |
+| `widget/src/components/SessionForm.tsx` | modify | Accept `language` prop; replace hardcoded strings |
+| `widget/src/components/MessageInput.tsx` | modify | Accept `language` prop; replace hardcoded strings |
+| `widget/src/types.ts` | modify | Export `Language = 'pt' \| 'en'` type alias |
+
+### Do NOT Modify
+
+- Anything in `client/src/` — owned by tasks 03–08
+- `widget/package.json` — no new dependencies
+- `widget/src/components/ChatPopup.tsx`, `FloatingButton.tsx`, `MessageList.tsx` — no user-facing strings
+
+## Implementation Steps
+
+### Step 1: Add `Language` type to `widget/src/types.ts`
+
+```typescript
+export type Language = 'pt' | 'en'
+```
+
+### Step 2: Create `widget/src/translations.ts`
+
+```typescript
+import type { Language } from './types'
+
+interface WidgetStrings {
+  sessionForm: {
+    heading: string
+    subheading: string
+    namePlaceholder: string
+    emailLabel: string
+    emailPlaceholder: string
+    emailError: string
+    phoneLabel: string
+    phonePlaceholder: string
+    loadingButton: string
+    submitButton: string
+  }
+  messageInput: {
+    placeholder: string
+    ariaLabel: string
+    sendAriaLabel: string
+  }
+}
+
+const translations: Record<Language, WidgetStrings> = {
+  pt: {
+    sessionForm: {
+      heading: 'Iniciar conversa',
+      subheading: 'Preencha seus dados para começar o atendimento.',
+      namePlaceholder: 'Seu nome',
+      emailLabel: 'E-mail',
+      emailPlaceholder: 'seu@email.com',
+      emailError: 'Informe um e-mail válido.',
+      phoneLabel: 'Telefone (opcional)',
+      phonePlaceholder: '(00) 00000-0000',
+      loadingButton: 'Aguarde...',
+      submitButton: 'Iniciar conversa',
+    },
+    messageInput: {
+      placeholder: 'Digite uma mensagem...',
+      ariaLabel: 'Mensagem',
+      sendAriaLabel: 'Enviar mensagem',
+    },
+  },
+  en: {
+    sessionForm: {
+      heading: 'Start a conversation',
+      subheading: 'Fill in your details to begin.',
+      namePlaceholder: 'Your name',
+      emailLabel: 'E-mail',
+      emailPlaceholder: 'you@email.com',
+      emailError: 'Please enter a valid email address.',
+      phoneLabel: 'Phone (optional)',
+      phonePlaceholder: '+1 (000) 000-0000',
+      loadingButton: 'Please wait...',
+      submitButton: 'Start conversation',
+    },
+    messageInput: {
+      placeholder: 'Type a message...',
+      ariaLabel: 'Message',
+      sendAriaLabel: 'Send message',
+    },
+  },
+}
+
+export function useWidgetStrings(language: Language): WidgetStrings {
+  return translations[language] ?? translations.pt
+}
+```
+
+### Step 3: Update `widget/src/types.ts` — extend `InitData` signature
+
+Add `Language` export (done in step 1). `InitData` is defined in `main.tsx`, not `types.ts` — update it there.
+
+### Step 4: Update `widget/src/main.tsx`
+
+1. Read `data-language` from the script element:
+   ```typescript
+   const rawLang = scriptEl?.dataset.language
+   const defaultLanguage: Language = rawLang === 'en' ? 'en' : 'pt'
+   ```
+
+2. Add `language?` to `InitData`:
+   ```typescript
+   type InitData = { name: string; email: string; phone?: string; language?: Language }
+   ```
+
+3. Add `language` state to `WidgetRoot`, initialized from `defaultLanguage`:
+   ```typescript
+   const [language, setLanguage] = useState<Language>(defaultLanguage)
+   ```
+
+4. In the `_handler` assignment (inside `useEffect`), extract and apply `language`:
+   ```typescript
+   api._handler = (data) => {
+     if (data.language) setLanguage(data.language)
+     createSessionRef.current(data.name, data.email, data.phone)
+   }
+   ```
+   And in the `_pending` flush:
+   ```typescript
+   if (api._pending) {
+     const { name, email, phone, language: pendingLang } = api._pending
+     api._pending = null
+     if (pendingLang) setLanguage(pendingLang)
+     createSessionRef.current(name, email, phone)
+   }
+   ```
+
+5. Pass `language` to `<App>`:
+   ```tsx
+   <App ... language={language} />
+   ```
+
+### Step 5: Update `widget/src/App.tsx`
+
+Add `language: Language` to `AppProps` and forward it:
+```tsx
+interface AppProps {
+  // ...existing props...
+  language: Language
+}
+
+// In JSX:
+<SessionForm onSubmit={onSessionCreate} loading={sessionLoading} language={language} />
+<MessageInput onSend={onSend} disabled={sendDisabled} language={language} />
+```
+
+### Step 6: Update `widget/src/components/SessionForm.tsx`
+
+1. Add `language: Language` to `SessionFormProps`
+2. Import `useWidgetStrings` from `'../translations'`
+3. Inside component: `const strings = useWidgetStrings(language)`
+4. Replace every hardcoded string — e.g.:
+   - `<p style={headingStyle}>{strings.sessionForm.heading}</p>`
+   - `placeholder={strings.sessionForm.namePlaceholder}`
+   - `setEmailError(strings.sessionForm.emailError)`
+   - `{loading ? strings.sessionForm.loadingButton : strings.sessionForm.submitButton}`
+   - Remove the hardcoded `"Nome"` label — replace with `strings.sessionForm.namePlaceholder` as label text (or add a `nameLabel` key if needed)
+
+> Note: `SessionForm` currently has no separate `nameLabel` key — it renders `"Nome"` as label text. Add `nameLabel: 'Nome'` / `'Name'` to the translations if the label is rendered separately from the placeholder.
+
+### Step 7: Update `widget/src/components/MessageInput.tsx`
+
+1. Add `language: Language` to `MessageInputProps`
+2. Import `useWidgetStrings`
+3. Replace the three hardcoded strings:
+   ```tsx
+   const strings = useWidgetStrings(language)
+   // ...
+   placeholder={strings.messageInput.placeholder}
+   aria-label={strings.messageInput.ariaLabel}
+   // send button:
+   aria-label={strings.messageInput.sendAriaLabel}
+   ```
+
+## Testing
+
+- [ ] Run the widget build to verify it compiles: `cd widget && yarn build` (or check the build command in `widget/package.json`)
+- [ ] If widget tests exist (`widget/src/**/*.spec.*`): run them and verify they pass
+- [ ] Manual test — build widget and load it on a test page:
+  - Default (no `data-language`): renders in Portuguese
+  - `<script data-language="en">`: renders in English
+  - `EcomandaWidget.init({ name: 'Test', email: 'a@b.com', language: 'en' })`: widget renders in English, session form skipped
+  - Switching language via `init` after mount updates labels
+- [ ] `pre-commit-check` passes
+
+## Documentation / KB Updates
+
+- [ ] This task is part of the same i18n `document-solution` entry to be written after task-08 completes — note the widget's lightweight translations-map approach as an alternative to react-i18next for isolated IIFE bundles
+
+## Completion Criteria
+
+- [ ] `widget/src/translations.ts` created with complete PT and EN string maps
+- [ ] `Language` type exported from `widget/src/types.ts`
+- [ ] `EcomandaWidget.init({ language? })` accepts and applies language at runtime
+- [ ] `data-language` attribute on script tag sets the default language
+- [ ] `SessionForm` and `MessageInput` render in the active language
+- [ ] Widget build succeeds (`yarn build` in `widget/`)
+- [ ] No i18n packages added to `widget/package.json`
+- [ ] Changes committed to `plan/app-i18n/phase-3/task-09-widget-i18n`
+- [ ] `status.md` updated to `complete`
+
+## Conflict Avoidance Notes
+
+- This task owns only `widget/src/` files — zero overlap with tasks 05–08 which own `client/src/`. It can run in parallel with any phase-3 task from a file ownership standpoint.
+- It is listed last (task-09) purely for ordering clarity, not because it must wait for tasks 05–08 to complete.


### PR DESCRIPTION
## Plan: App Internationalization (PT/EN)

Add Portuguese/English language selection throughout the app. Users choose their language on the login page (persisted in localStorage) and during onboarding (persisted in the User document). After login the app renders in the user's saved language. Every hardcoded string in the frontend is externalized to translation files.

**Type**: Type 1 — Product
**Phases**: 3  **Tasks**: 8
**PR Strategy**: single
**Assigned Dev**: Alan Costa Facchini

### Dependency Graph

```
Phase 1 (parallel):
  task-01-i18n-setup       ─┐
  task-02-user-model-backend─┤
                             ↓
Phase 2 (sequential):
  task-03-login-i18n ──→ task-04-onboarding-i18n
                             ↓
Phase 3 (sequential chain):
  task-05 ──→ task-06 ──→ task-07 ──→ task-08
```

> Merge this PR before running `/execute-plan app-i18n` or any `/execute-task`.